### PR TITLE
Add docs folder and pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prepare static site
+        run: |
+          mkdir -p site
+          cp -r docs/* site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'site'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Romper Sample Manager
+
+Welcome to the Romper documentation site. This project is a cross-platform desktop app for organizing sample kits for the Squarp Rample.
+
+For full details, see the [README](../README.md).
+
+## Features
+
+- Drag-and-drop sample assignment to kit voices
+- Browse and manage kits on your Rample SD card
+- Preview individual samples using the Web Audio API
+- Protect factory kits from accidental overwrite
+- Enforces Rample folder and file format rules
+


### PR DESCRIPTION
## Summary
- create `docs/index.md` as a simple documentation landing page
- add a GitHub Actions workflow to deploy the docs folder to GitHub Pages

## Testing
- `npm test` *(fails: Unable to find an element with the text: kick.wav, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4c4490883339744cedd3651e1c6