### PR TITLE
fix: wrap async handleBack in void function for keyboard shortcuts

### DIFF
--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -74,7 +74,9 @@ const KitsView: React.FC = () => {
     currentKitName: navigation.selectedKit ?? undefined,
     isEditMode: currentKit?.editable ?? false,
     onBackNavigation: navigation.selectedKit
-      ? navigation.handleBack
+      ? () => {
+          navigation.handleBack();
+        }
       : undefined,
   });
 


### PR DESCRIPTION
Resolves TypeScript error where promise-returning handleBack was provided to onBackNavigation property expecting void return type.