### PR TITLE
fix: reduce duplicate CI workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,6 @@
 name: End-to-End Tests
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
## Summary
- Optimized GitHub Actions triggers to eliminate redundant CI executions
- Build, Lint, and E2E workflows now only run on pull_request events
- Test workflow runs on pull_request + main branch pushes only

## Test plan
- [ ] Verify workflows only trigger once per PR push
- [ ] Confirm test workflow still runs on main branch for coverage analysis
- [ ] Check that all required checks still pass for PR validation