### PR TITLE
fix: correct artifact path for v0.9.3 release

- Changed artifact upload path from electron/out/make/ to out/make/
- This matches the actual output directory used by electron-forge
- Updated version to 0.9.3 for the upcoming release
- Added debug output to verify artifact location in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,22 @@ jobs:
       - name: Package application (Electron)
         run: npm run make
 
+      - name: Debug artifact structure
+        run: |
+          echo "=== Project root contents ==="
+          ls -la
+          echo "=== Looking for out directory ==="
+          find . -name "out" -type d
+          echo "=== Looking for make directory ==="
+          find . -name "make" -type d
+          echo "=== All files with 'romper' or app name ==="
+          find . -name "*romper*" -o -name "*Romper*" | head -20
+
       - name: Upload platform artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: electron/out/make/
+          path: out/make/
           retention-days: 7
 
   release:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/electron/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Implement fix: correct artifact path for v0.9.3 release

- changed artifact upload path from electron/out/make/ to out/make/
- this matches the actual output directory used by electron-forge
- updated version to 0.9.3 for the upcoming release
- added debug output to verify artifact location in ci

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed