### PR TITLE
fix: make debug script cross-platform compatible

- Split debug script into Windows and Unix versions
- Use PowerShell commands for Windows (Get-ChildItem)
- Keep Unix commands for macOS and Linux (ls, find)
- Fixes Windows build failure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,20 @@ jobs:
       - name: Package application (Electron)
         run: npm run make
 
-      - name: Debug artifact structure
+      - name: Debug artifact structure (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "=== Project root contents ==="
+          Get-ChildItem -Force
+          echo "=== Looking for out directory ==="
+          Get-ChildItem -Recurse -Directory -Name "out" -ErrorAction SilentlyContinue
+          echo "=== Looking for make directory ==="
+          Get-ChildItem -Recurse -Directory -Name "make" -ErrorAction SilentlyContinue
+          echo "=== All files with 'romper' or app name ==="
+          Get-ChildItem -Recurse -Name "*romper*", "*Romper*" -ErrorAction SilentlyContinue | Select-Object -First 20
+
+      - name: Debug artifact structure (Unix)
+        if: matrix.os != 'windows-latest'
         run: |
           echo "=== Project root contents ==="
           ls -la


### PR DESCRIPTION
## Summary
- Implement fix: make debug script cross-platform compatible

- split debug script into windows and unix versions
- use powershell commands for windows (get-childitem)
- keep unix commands for macos and linux (ls, find)
- fixes windows build failure in release workflow

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed