### PR TITLE
feat: add editable kit alias functionality

- Add kit alias display on kit list cards below kit names
- Enable inline editing of kit aliases in kit details header  
- Kit aliases appear in smaller italic text with tooltips
- Click alias in header to edit, Enter to save, Escape to cancel
- Proper state management for editing mode with auto-focus
- Integrates with existing updateKitAlias functionality

Addresses user request to show and edit kit aliases in both
kit browser and detail views for improved kit organization.

### DIFF
--- a/app/renderer/components/KitDetails.tsx
+++ b/app/renderer/components/KitDetails.tsx
@@ -20,6 +20,18 @@ const KitDetails: React.FC<KitDetailsAllProps> = (props) => {
   const [dismissedUnscannedPrompt, setDismissedUnscannedPrompt] =
     React.useState(false);
 
+  // Kit alias editing state
+  const [editingKitAlias, setEditingKitAlias] = React.useState(false);
+  const [kitAliasInput, setKitAliasInput] = React.useState(
+    logic.kit?.alias || "",
+  );
+  const kitAliasInputRef = React.useRef<HTMLInputElement>(null!);
+
+  // Update kitAliasInput when kit changes
+  React.useEffect(() => {
+    setKitAliasInput(logic.kit?.alias || "");
+  }, [logic.kit?.alias]);
+
   // Check if kit needs scanning - this is just a simple heuristic for now
   // A more robust implementation would check the database for scan status
   const needsScanning =
@@ -35,14 +47,12 @@ const KitDetails: React.FC<KitDetailsAllProps> = (props) => {
       data-testid="kit-details"
     >
       <KitHeader
-        editingKitAlias={false}
+        editingKitAlias={editingKitAlias}
         handleSaveKitAlias={logic.updateKitAlias}
         isEditable={logic.kit?.editable ?? false}
         kit={logic.kit}
-        kitAliasInput={logic.kit?.alias || logic.kit?.name || ""}
-        kitAliasInputRef={
-          React.createRef<HTMLInputElement>() as React.RefObject<HTMLInputElement>
-        }
+        kitAliasInput={kitAliasInput}
+        kitAliasInputRef={kitAliasInputRef}
         kitIndex={props.kitIndex}
         kitName={props.kitName}
         kits={props.kits}
@@ -51,8 +61,8 @@ const KitDetails: React.FC<KitDetailsAllProps> = (props) => {
         onPrevKit={props.onPrevKit}
         onScanKit={logic.handleScanKit}
         onToggleEditableMode={logic.toggleEditableMode}
-        setEditingKitAlias={() => {}}
-        setKitAliasInput={() => {}}
+        setEditingKitAlias={setEditingKitAlias}
+        setKitAliasInput={setKitAliasInput}
       />
 
       {needsScanning && (

--- a/app/renderer/components/KitGridItem.tsx
+++ b/app/renderer/components/KitGridItem.tsx
@@ -134,13 +134,25 @@ const KitGridItem = React.memo(
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-2 flex-1 min-w-0">
               <span title={iconLabel}>{icon}</span>
-              <span
-                className={`font-mono text-sm truncate ${
-                  isValid ? "text-gray-900 dark:text-gray-100" : "text-red-500"
-                }`}
-              >
-                {kit}
-              </span>
+              <div className="flex flex-col flex-1 min-w-0">
+                <span
+                  className={`font-mono text-sm truncate ${
+                    isValid
+                      ? "text-gray-900 dark:text-gray-100"
+                      : "text-red-500"
+                  }`}
+                >
+                  {kit}
+                </span>
+                {kitData?.alias && (
+                  <span
+                    className="text-xs text-gray-600 dark:text-gray-400 truncate italic"
+                    title={`Kit alias: ${kitData.alias}`}
+                  >
+                    {kitData.alias}
+                  </span>
+                )}
+              </div>
             </div>
 
             {/* Enhanced Status indicators */}


### PR DESCRIPTION
## Summary
- Implement feat: add editable kit alias functionality

- add kit alias display on kit list cards below kit names
- enable inline editing of kit aliases in kit details header  
- kit aliases appear in smaller italic text with tooltips
- click alias in header to edit, enter to save, escape to cancel
- proper state management for editing mode with auto-focus
- integrates with existing updatekitalias functionality

addresses user request to show and edit kit aliases in both
kit browser and detail views for improved kit organization.

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed