### PR TITLE
fix: show slot numbers only once on left side of kit details page

### DIFF
--- a/app/renderer/components/KitVoicePanel.tsx
+++ b/app/renderer/components/KitVoicePanel.tsx
@@ -210,26 +210,19 @@ const KitVoicePanel: React.FC<
   return (
     <div aria-label={`Voice ${voice} panel`} className="flex flex-col">
       {rendering.renderVoiceName(dataTestIdVoiceName)}
-      <div className="flex flex-1">
-        {/* Slot numbers column */}
-        <div className="flex flex-col justify-start pt-3 pr-2">
-          {rendering.renderSlotNumbers()}
-        </div>
-
-        {/* Voice panel content */}
-        <div className="flex-1 p-3 rounded-lg shadow bg-gray-100 dark:bg-slate-800 text-gray-900 dark:text-gray-100 min-h-[80px]">
-          <ul
-            aria-label={`Sample slots for voice ${voice}`}
-            className="list-none ml-0 text-sm flex flex-col"
-            data-testid={`sample-list-voice-${voice}`}
-            onKeyDown={keyboardNav.handleKeyDown}
-            ref={listRef}
-            role="listbox"
-            tabIndex={isActive ? 0 : -1}
-          >
-            {rendering.renderSampleSlots()}
-          </ul>
-        </div>
+      {/* Voice panel content */}
+      <div className="flex-1 p-3 rounded-lg shadow bg-gray-100 dark:bg-slate-800 text-gray-900 dark:text-gray-100 min-h-[80px]">
+        <ul
+          aria-label={`Sample slots for voice ${voice}`}
+          className="list-none ml-0 text-sm flex flex-col"
+          data-testid={`sample-list-voice-${voice}`}
+          onKeyDown={keyboardNav.handleKeyDown}
+          ref={listRef}
+          role="listbox"
+          tabIndex={isActive ? 0 : -1}
+        >
+          {rendering.renderSampleSlots()}
+        </ul>
       </div>
     </div>
   );

--- a/app/renderer/components/KitVoicePanels.tsx
+++ b/app/renderer/components/KitVoicePanels.tsx
@@ -138,79 +138,98 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
   };
 
   return (
-    <div
-      className="grid grid-cols-4 gap-4 w-full relative"
-      data-testid="voice-panels-row"
-    >
-      {[1, 2, 3, 4].map((voice) => (
-        <React.Fragment key={`${hookProps.kitName}-voicepanel-${voice}`}>
-          <div className="relative" data-testid={`voice-panel-${voice}`}>
-            <KitVoicePanel
-              dataTestIdVoiceName={`voice-name-${voice}`}
-              isActive={voice === hookProps.selectedVoice}
-              isEditable={props.isEditable ?? false}
-              isStereoDragTarget={
-                stereoDragInfo?.targetVoice === voice ||
-                stereoDragInfo?.nextVoice === voice
-              }
-              kitName={hookProps.kitName}
-              onPlay={hookProps.onPlay}
-              onRescanVoiceName={() =>
-                hookProps.onRescanVoiceName(voice, hookProps.samples)
-              }
-              onSampleAdd={props.onSampleAdd}
-              onSampleDelete={props.onSampleDelete}
-              onSampleKeyNav={hookProps.onSampleKeyNav}
-              onSampleMove={props.onSampleMove}
-              onSampleReplace={props.onSampleReplace}
-              onSampleSelect={hookProps.onSampleSelect}
-              onSaveVoiceName={hookProps.onSaveVoiceName}
-              onStereoDragLeave={handleStereoDragLeave}
-              onStereoDragOver={handleStereoDragOver}
-              onStop={hookProps.onStop}
-              onWaveformPlayingChange={hookProps.onWaveformPlayingChange}
-              playTriggers={hookProps.playTriggers}
-              sampleMetadata={sampleMetadata}
-              samplePlaying={hookProps.samplePlaying}
-              samples={hookProps.samples[voice] || []}
-              selectedIdx={
-                voice === hookProps.selectedVoice
-                  ? hookProps.selectedSampleIdx
-                  : -1
-              }
-              setSharedDraggedSample={setInternalDraggedSample}
-              sharedDraggedSample={internalDraggedSample}
-              stereoDragSlotNumber={
-                stereoDragInfo?.targetVoice === voice ||
-                stereoDragInfo?.nextVoice === voice
-                  ? stereoDragInfo.slotNumber
-                  : undefined
-              }
-              stopTriggers={hookProps.stopTriggers}
-              voice={voice}
-              voiceName={
-                hookProps.kit?.voices?.find((v) => v.voice_number === voice)
-                  ?.voice_alias || null
-              }
-            />
-            {/* Task 7.1.3: Show link icon between voices for stereo drops */}
-            {stereoDragInfo?.targetVoice === voice && (
-              <div
-                className="absolute -right-6 top-1/2 transform -translate-y-1/2 z-10
+    <div className="flex w-full relative" data-testid="voice-panels-row">
+      {/* Global slot numbers column */}
+      <div className="flex flex-col justify-start pt-12 pr-3">
+        {[...Array(12)].map((_, i) => (
+          <div
+            className="min-h-[28px] flex items-center justify-end"
+            key={`global-slot-${i}`}
+            style={{ marginBottom: 4 }}
+          >
+            <span
+              className="text-xs font-mono text-gray-500 dark:text-gray-400 select-none bg-gray-200 dark:bg-gray-700 px-1.5 py-0.5 rounded text-center w-8 h-5 flex items-center justify-center inline-block"
+              data-testid={`global-slot-number-${i}`}
+              style={{ display: "inline-block", width: "32px" }}
+            >
+              {i + 1}.
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Voice panels grid */}
+      <div className="grid grid-cols-4 gap-4 flex-1">
+        {[1, 2, 3, 4].map((voice) => (
+          <React.Fragment key={`${hookProps.kitName}-voicepanel-${voice}`}>
+            <div className="relative" data-testid={`voice-panel-${voice}`}>
+              <KitVoicePanel
+                dataTestIdVoiceName={`voice-name-${voice}`}
+                isActive={voice === hookProps.selectedVoice}
+                isEditable={props.isEditable ?? false}
+                isStereoDragTarget={
+                  stereoDragInfo?.targetVoice === voice ||
+                  stereoDragInfo?.nextVoice === voice
+                }
+                kitName={hookProps.kitName}
+                onPlay={hookProps.onPlay}
+                onRescanVoiceName={() =>
+                  hookProps.onRescanVoiceName(voice, hookProps.samples)
+                }
+                onSampleAdd={props.onSampleAdd}
+                onSampleDelete={props.onSampleDelete}
+                onSampleKeyNav={hookProps.onSampleKeyNav}
+                onSampleMove={props.onSampleMove}
+                onSampleReplace={props.onSampleReplace}
+                onSampleSelect={hookProps.onSampleSelect}
+                onSaveVoiceName={hookProps.onSaveVoiceName}
+                onStereoDragLeave={handleStereoDragLeave}
+                onStereoDragOver={handleStereoDragOver}
+                onStop={hookProps.onStop}
+                onWaveformPlayingChange={hookProps.onWaveformPlayingChange}
+                playTriggers={hookProps.playTriggers}
+                sampleMetadata={sampleMetadata}
+                samplePlaying={hookProps.samplePlaying}
+                samples={hookProps.samples[voice] || []}
+                selectedIdx={
+                  voice === hookProps.selectedVoice
+                    ? hookProps.selectedSampleIdx
+                    : -1
+                }
+                setSharedDraggedSample={setInternalDraggedSample}
+                sharedDraggedSample={internalDraggedSample}
+                stereoDragSlotNumber={
+                  stereoDragInfo?.targetVoice === voice ||
+                  stereoDragInfo?.nextVoice === voice
+                    ? stereoDragInfo.slotNumber
+                    : undefined
+                }
+                stopTriggers={hookProps.stopTriggers}
+                voice={voice}
+                voiceName={
+                  hookProps.kit?.voices?.find((v) => v.voice_number === voice)
+                    ?.voice_alias || null
+                }
+              />
+              {/* Task 7.1.3: Show link icon between voices for stereo drops */}
+              {stereoDragInfo?.targetVoice === voice && (
+                <div
+                  className="absolute -right-6 top-1/2 transform -translate-y-1/2 z-10
                           bg-purple-500 text-white rounded-full p-2 shadow-lg
                           animate-pulse"
-                style={{
-                  // Position at the specific slot
-                  top: `calc(50px + ${stereoDragInfo.slotNumber * 32}px)`,
-                }}
-                title="Stereo link"
-              >
-                <FiLink className="w-4 h-4" />
-              </div>
-            )}
-          </div>
-        </React.Fragment>
-      ))}
+                  style={{
+                    // Position at the specific slot
+                    top: `calc(50px + ${stereoDragInfo.slotNumber * 32}px)`,
+                  }}
+                  title="Stereo link"
+                >
+                  <FiLink className="w-4 h-4" />
+                </div>
+              )}
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
     </div>
   );
 };

--- a/app/renderer/components/__tests__/KitVoicePanel.test.tsx
+++ b/app/renderer/components/__tests__/KitVoicePanel.test.tsx
@@ -101,10 +101,10 @@ describe("KitVoicePanel", () => {
     expect(screen.queryByTestId("drop-zone-voice-1")).not.toBeInTheDocument();
   });
 
-  it("renders slot numbers correctly", () => {
+  it("does not render slot numbers (now handled by parent)", () => {
     renderKitVoicePanel();
-    expect(screen.getByTestId("slot-number-1-0")).toHaveTextContent("1.");
-    expect(screen.getByTestId("slot-number-1-1")).toHaveTextContent("2.");
+    expect(screen.queryByTestId("slot-number-1-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("slot-number-1-1")).not.toBeInTheDocument();
   });
 
   it("renders samples with interaction elements when editable", () => {

--- a/app/renderer/components/__tests__/KitVoicePanels.test.tsx
+++ b/app/renderer/components/__tests__/KitVoicePanels.test.tsx
@@ -134,6 +134,20 @@ describe("KitVoicePanels", () => {
     expect(screen.getByText("clap.wav")).toBeInTheDocument();
   });
 
+  it("renders global slot numbers on the left side only", () => {
+    render(<MultiVoicePanelsTestWrapper />);
+    // Check that global slot numbers 1-12 are rendered
+    expect(screen.getByTestId("global-slot-number-0")).toHaveTextContent("1.");
+    expect(screen.getByTestId("global-slot-number-1")).toHaveTextContent("2.");
+    expect(screen.getByTestId("global-slot-number-11")).toHaveTextContent(
+      "12.",
+    );
+
+    // Verify individual voice panels do not render their own slot numbers
+    expect(screen.queryByTestId("slot-number-1-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("slot-number-2-0")).not.toBeInTheDocument();
+  });
+
   it("cross-voice keyboard navigation moves selection between voices", async () => {
     render(<MultiVoicePanelsTestWrapper />);
     // Down to snare.wav

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelRendering.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelRendering.tsx
@@ -153,7 +153,6 @@ export function useVoicePanelRendering({
     renderPlayButton: buttons.renderPlayButton,
     renderSampleSlot: slots.renderSampleSlot,
     renderSampleSlots: slots.renderSampleSlots,
-    renderSlotNumbers: ui.renderSlotNumbers,
     renderVoiceName: ui.renderVoiceName,
   };
 }


### PR DESCRIPTION
## Summary
- Implement fix: show slot numbers only once on left side of kit details page

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed