### PR TITLE
fix: refresh kit browser after alias updates

### DIFF
--- a/app/renderer/components/KitDetails.tsx
+++ b/app/renderer/components/KitDetails.tsx
@@ -11,6 +11,7 @@ import UnscannedKitPrompt from "./UnscannedKitPrompt";
 
 interface KitDetailsAllProps extends KitDetailsProps {
   onCreateKit?: () => void; // Used by useKitDetailsLogic hook
+  onKitUpdated?: () => Promise<void>; // Called when kit metadata is updated
   onMessage?: (text: string, type?: string, duration?: number) => void; // Used by useKitDetailsLogic hook
   onRequestSamplesReload?: () => Promise<void>;
 }

--- a/app/renderer/components/KitDetailsContainer.tsx
+++ b/app/renderer/components/KitDetailsContainer.tsx
@@ -12,6 +12,7 @@ interface KitDetailsContainerProps {
   kits: KitWithRelations[];
   onAddUndoAction: (action: any) => void;
   onBack: (scrollToKit?: any) => Promise<void>;
+  onKitUpdated: () => Promise<void>;
   onMessage: (text: string, type?: string, duration?: number) => void;
   onNextKit: () => void;
   onPrevKit: () => void;
@@ -30,6 +31,7 @@ const KitDetailsContainer: React.FC<KitDetailsContainerProps> = (props) => {
     kits,
     onAddUndoAction,
     onBack,
+    onKitUpdated,
     onMessage,
     onNextKit,
     onPrevKit,
@@ -56,6 +58,10 @@ const KitDetailsContainer: React.FC<KitDetailsContainerProps> = (props) => {
     return onRequestSamplesReload();
   }, [onRequestSamplesReload]);
 
+  const handleKitUpdated = React.useCallback(() => {
+    return onKitUpdated();
+  }, [onKitUpdated]);
+
   return (
     <KitDetails
       kitIndex={kitIndex}
@@ -63,6 +69,7 @@ const KitDetailsContainer: React.FC<KitDetailsContainerProps> = (props) => {
       kits={kits}
       onAddUndoAction={onAddUndoAction}
       onBack={handleBack}
+      onKitUpdated={handleKitUpdated}
       onMessage={handleMessage}
       onNextKit={onNextKit}
       onPrevKit={onPrevKit}

--- a/app/renderer/components/KitDetailsContainer.tsx
+++ b/app/renderer/components/KitDetailsContainer.tsx
@@ -58,10 +58,6 @@ const KitDetailsContainer: React.FC<KitDetailsContainerProps> = (props) => {
     return onRequestSamplesReload();
   }, [onRequestSamplesReload]);
 
-  const handleKitUpdated = React.useCallback(() => {
-    return onKitUpdated();
-  }, [onKitUpdated]);
-
   return (
     <KitDetails
       kitIndex={kitIndex}
@@ -69,7 +65,7 @@ const KitDetailsContainer: React.FC<KitDetailsContainerProps> = (props) => {
       kits={kits}
       onAddUndoAction={onAddUndoAction}
       onBack={handleBack}
-      onKitUpdated={handleKitUpdated}
+      onKitUpdated={onKitUpdated}
       onMessage={handleMessage}
       onNextKit={onNextKit}
       onPrevKit={onPrevKit}

--- a/app/renderer/components/hooks/kit-management/useKit.ts
+++ b/app/renderer/components/hooks/kit-management/useKit.ts
@@ -4,12 +4,13 @@ import { useCallback, useEffect, useState } from "react";
 
 export interface UseKitParams {
   kitName: string;
+  onKitUpdated?: () => Promise<void>;
 }
 
 /**
  * Hook for loading and managing kit data from database
  */
-export function useKit({ kitName }: UseKitParams) {
+export function useKit({ kitName, onKitUpdated }: UseKitParams) {
   const [kit, setKit] = useState<KitWithRelations | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<null | string>(null);
@@ -46,6 +47,10 @@ export function useKit({ kitName }: UseKitParams) {
       const result = await window.electronAPI.updateKit(kitName, { alias });
       if (result.success) {
         await loadKit();
+        // Refresh the kit browser's data after updating alias
+        if (onKitUpdated) {
+          await onKitUpdated();
+        }
       } else {
         setError(result.error || "Failed to update kit alias");
       }
@@ -65,6 +70,10 @@ export function useKit({ kitName }: UseKitParams) {
       });
       if (result.success) {
         await loadKit();
+        // Refresh the kit browser's data after updating editable state
+        if (onKitUpdated) {
+          await onKitUpdated();
+        }
       } else {
         setError(result.error || "Failed to toggle editable mode");
       }

--- a/app/renderer/components/hooks/kit-management/useKitDetailsLogic.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDetailsLogic.ts
@@ -13,6 +13,7 @@ import { useKitVoicePanels } from "./useKitVoicePanels";
 
 interface UseKitDetailsLogicParams extends KitDetailsProps {
   onCreateKit?: () => void;
+  onKitUpdated?: () => Promise<void>;
   onMessage?: (text: string, type?: string, duration?: number) => void;
   onRequestSamplesReload?: () => Promise<void>;
 }
@@ -35,6 +36,7 @@ export function useKitDetailsLogic(props: UseKitDetailsLogicParams) {
     updateKitAlias,
   } = useKit({
     kitName: props.kitName,
+    onKitUpdated: props.onKitUpdated,
   });
 
   // Voice alias management

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -258,6 +258,7 @@ const KitsView: React.FC = () => {
           kits={navigation.sortedKits}
           onAddUndoAction={keyboardShortcuts.addUndoAction}
           onBack={navigation.handleBack}
+          onKitUpdated={refreshAllKitsAndSamples}
           onMessage={showMessage}
           onNextKit={navigation.handleNextKit}
           onPrevKit={navigation.handlePrevKit}


### PR DESCRIPTION
## Summary
- Implement fix: refresh kit browser after alias/editable updates

- add onkitupdated callback to refresh kit browser state after alias changes
- pass refreshallkitsandsamples through component chain to usekit hook  
- call kit browser refresh in updatekitalias and toggleeditablemode
- fixes bug where kit browser shows stale alias until force reload

now when a kit alias is changed in details view, the kit browser 
immediately shows the updated alias without requiring manual refresh.

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed