### PR TITLE
fix: ensure PR titles are concise and under 60 chars

- Add

### DIFF
--- a/.agent/task-execution.md
+++ b/.agent/task-execution.md
@@ -225,6 +225,37 @@ lsof romper.db
   4. Wait for explicit user approval before using `--no-verify`
 - **Test failures are blocking** - commits must not proceed with any failing tests
 
+### PR Review Response Protocol (CRITICAL)
+
+When addressing PR review comments, follow this systematic approach to prevent common mistakes:
+
+#### Systematic Review Comment Processing
+
+1. **Read ALL review comments first** - Never implement fixes piecemeal
+2. **Create TodoWrite items** for each specific comment/fix needed  
+3. **Follow exact suggestions when provided** - Don't try to "improve" on reviewer feedback
+4. **Use `npm run commit` for validation** - Let pre-commit hooks catch issues immediately
+5. **Address each todo systematically** - Mark complete only when verified working
+
+#### Critical Mistake Prevention
+
+- **Syntax errors**: `npm run commit` will catch these via pre-commit hooks - no need for separate linting
+- **Incomplete implementation**: Address all comments in comprehensive fix, not one-by-one
+- **Process shortcuts**: Use TodoWrite to track progress systematically  
+- **Quality bypassing**: NEVER use `--no-verify` - fix issues properly instead
+
+#### Implementation Pattern
+
+```bash
+# 1. Plan systematically using TodoWrite for each review comment
+# 2. Fix each issue with immediate validation via npm run commit  
+# 3. Let pre-commit hooks provide quality feedback automatically
+# 4. Fix any hook failures properly (never bypass with --no-verify)
+# 5. Final commit when all issues resolved and hooks pass
+```
+
+This systematic approach prevents rushing through fixes and missing issues that create additional review cycles.
+
 ### Commit Message Standards
 
 - Use conventional commit format: `type: description`

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -137,33 +137,11 @@ async function main() {
         const maxDescLength = 60 - type.length;
 
         if (maxDescLength > 0) {
-          const truncatedDesc = description.slice(0, maxDescLength);
-          const finalDesc = (
-            /\s+\S*$/.test(truncatedDesc)
-              ? truncatedDesc.replace(/\s+\S*$/, "")
-              : truncatedDesc
-          ).trim();
-
-          // Check if we have a meaningful description after truncation (minimum 3 chars)
-          if (finalDesc.length >= 3) {
-            prTitle = type + finalDesc;
-          } else {
-            // Fallback: just truncate the commit message as in the "no type prefix" branch
-            const truncated = commitMessage.slice(0, 60);
-            prTitle = (
-              /\s+\S*$/.test(truncated)
-                ? truncated.replace(/\s+\S*$/, "")
-                : truncated
-            ).trim();
-          }
+          const descTrunc = description.slice(0, maxDescLength).replace(/\s+\S*$/, '').trim();
+          prTitle = type + descTrunc;
         } else {
           // Fallback: just truncate the commit message as in the "no type prefix" branch
-          const truncated = commitMessage.slice(0, 60);
-          prTitle = (
-            /\s+\S*$/.test(truncated)
-              ? truncated.replace(/\s+\S*$/, "")
-              : truncated
-          ).trim();
+          prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, '').trim();
         }
       }
     } else {

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -133,26 +133,19 @@ async function main() {
       // Has a type prefix, ensure the whole title is under 60 chars
       if (commitMessage.length > 60) {
         const type = typeMatch[0];
-        const description = commitMessage.slice(type.length);
-        // Truncate description to fit within 60 chars total
+        const description = commitMessage.slice(type.length).trim();
         const maxDescLength = 60 - type.length;
         
-        // Ensure we have a minimum description length to avoid empty or too short descriptions
-        if (maxDescLength < 10) {
-          // If type prefix is too long, fall back to simple truncation
+        // Address Copilot comment: Prevent empty descriptions when type prefix is too long
+        if (maxDescLength < 5 || description.length === 0) {
+          // If type prefix leaves insufficient space or no description, use simple truncation
           prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, "").trim();
         } else {
           const truncatedDesc = description
             .slice(0, maxDescLength)
             .replace(/\s+\S*$/, "")
             .trim();
-          
-          // Ensure description isn't empty after truncation
-          if (truncatedDesc.length === 0) {
-            prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, "").trim();
-          } else {
-            prTitle = type + truncatedDesc;
-          }
+          prTitle = type + truncatedDesc;
         }
       }
     } else {

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -139,7 +139,14 @@ async function main() {
     } else {
       // No type prefix, just truncate to 50 chars
       if (commitMessage.length > 50) {
-        prTitle = commitMessage.slice(0, 50).replace(/\s+\S*$/, '').trim();
+        const truncatedDesc = description.slice(0, maxDescLength);
+        prTitle = type + (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
+      }
+    } else {
+      // No type prefix, just truncate to 50 chars
+      if (commitMessage.length > 50) {
+        const truncated = commitMessage.slice(0, 50);
+        prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
       }
     }
     

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -136,12 +136,24 @@ async function main() {
         const description = commitMessage.slice(type.length);
         // Truncate description to fit within 60 chars total
         const maxDescLength = 60 - type.length;
-        prTitle =
-          type +
-          description
+        
+        // Ensure we have a minimum description length to avoid empty or too short descriptions
+        if (maxDescLength < 10) {
+          // If type prefix is too long, fall back to simple truncation
+          prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, "").trim();
+        } else {
+          const truncatedDesc = description
             .slice(0, maxDescLength)
             .replace(/\s+\S*$/, "")
             .trim();
+          
+          // Ensure description isn't empty after truncation
+          if (truncatedDesc.length === 0) {
+            prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, "").trim();
+          } else {
+            prTitle = type + truncatedDesc;
+          }
+        }
       }
     } else {
       // No type prefix, just truncate to 50 chars

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -136,9 +136,18 @@ async function main() {
         const description = commitMessage.slice(type.length).trim();
         const maxDescLength = 60 - type.length;
         
-        if (maxDescLength > 0 && description.length > 0) {
+        if (maxDescLength > 0) {
           const truncatedDesc = description.slice(0, maxDescLength);
-          prTitle = type + (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
+          const finalDesc = (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
+          
+          // Check if we have a meaningful description after truncation (minimum 3 chars)
+          if (finalDesc.length >= 3) {
+            prTitle = type + finalDesc;
+          } else {
+            // Fallback: just truncate the commit message as in the "no type prefix" branch
+            const truncated = commitMessage.slice(0, 60);
+            prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
+          }
         } else {
           // Fallback: just truncate the commit message as in the "no type prefix" branch
           const truncated = commitMessage.slice(0, 60);

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -124,9 +124,11 @@ async function main() {
   try {
     // Extract a short PR title from commit message (max 50-60 chars)
     // Try to detect type prefix (feat:, fix:, etc.) and preserve it
-    const typeMatch = commitMessage.match(/^(feat|fix|docs|style|refactor|test|chore|perf|build|ci):\s*/i);
+    const typeMatch = commitMessage.match(
+      /^(feat|fix|docs|style|refactor|test|chore|perf|build|ci):\s*/i,
+    );
     let prTitle = commitMessage;
-    
+
     if (typeMatch) {
       // Has a type prefix, ensure the whole title is under 60 chars
       if (commitMessage.length > 60) {
@@ -134,13 +136,12 @@ async function main() {
         const description = commitMessage.slice(type.length);
         // Truncate description to fit within 60 chars total
         const maxDescLength = 60 - type.length;
-        prTitle = type + description.slice(0, maxDescLength).replace(/\s+\S*$/, '').trim();
-      }
-    } else {
-      // No type prefix, just truncate to 50 chars
-      if (commitMessage.length > 50) {
-        const truncatedDesc = description.slice(0, maxDescLength);
-        prTitle = type + (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
+        prTitle =
+          type +
+          description
+            .slice(0, maxDescLength)
+            .replace(/\s+\S*$/, "")
+            .trim();
       }
     } else {
       // No type prefix, just truncate to 50 chars
@@ -149,7 +150,6 @@ async function main() {
         prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
       }
     }
-    
     const prBody = `## Summary
 - ${commitMessage}
 

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -136,16 +136,13 @@ async function main() {
         const description = commitMessage.slice(type.length).trim();
         const maxDescLength = 60 - type.length;
         
-        // Address Copilot comment: Prevent empty descriptions when type prefix is too long
-        if (maxDescLength < 5 || description.length === 0) {
-          // If type prefix leaves insufficient space or no description, use simple truncation
-          prTitle = commitMessage.slice(0, 60).replace(/\s+\S*$/, "").trim();
+        if (maxDescLength > 0 && description.length > 0) {
+          const truncatedDesc = description.slice(0, maxDescLength);
+          prTitle = type + (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
         } else {
-          const truncatedDesc = description
-            .slice(0, maxDescLength)
-            .replace(/\s+\S*$/, "")
-            .trim();
-          prTitle = type + truncatedDesc;
+          // Fallback: just truncate the commit message as in the "no type prefix" branch
+          const truncated = commitMessage.slice(0, 60);
+          prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
         }
       }
     } else {
@@ -156,7 +153,7 @@ async function main() {
       }
     }
     const prBody = `## Summary
-- ${commitMessage}
+${commitMessage}
 
 ## Test plan
 - [x] All pre-commit checks pass

--- a/scripts/enhanced-commit.js
+++ b/scripts/enhanced-commit.js
@@ -135,30 +135,46 @@ async function main() {
         const type = typeMatch[0];
         const description = commitMessage.slice(type.length).trim();
         const maxDescLength = 60 - type.length;
-        
+
         if (maxDescLength > 0) {
           const truncatedDesc = description.slice(0, maxDescLength);
-          const finalDesc = (/\s+\S*$/.test(truncatedDesc) ? truncatedDesc.replace(/\s+\S*$/, '') : truncatedDesc).trim();
-          
+          const finalDesc = (
+            /\s+\S*$/.test(truncatedDesc)
+              ? truncatedDesc.replace(/\s+\S*$/, "")
+              : truncatedDesc
+          ).trim();
+
           // Check if we have a meaningful description after truncation (minimum 3 chars)
           if (finalDesc.length >= 3) {
             prTitle = type + finalDesc;
           } else {
             // Fallback: just truncate the commit message as in the "no type prefix" branch
             const truncated = commitMessage.slice(0, 60);
-            prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
+            prTitle = (
+              /\s+\S*$/.test(truncated)
+                ? truncated.replace(/\s+\S*$/, "")
+                : truncated
+            ).trim();
           }
         } else {
           // Fallback: just truncate the commit message as in the "no type prefix" branch
           const truncated = commitMessage.slice(0, 60);
-          prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
+          prTitle = (
+            /\s+\S*$/.test(truncated)
+              ? truncated.replace(/\s+\S*$/, "")
+              : truncated
+          ).trim();
         }
       }
     } else {
       // No type prefix, just truncate to 50 chars
       if (commitMessage.length > 50) {
         const truncated = commitMessage.slice(0, 50);
-        prTitle = (/\s+\S*$/.test(truncated) ? truncated.replace(/\s+\S*$/, '') : truncated).trim();
+        prTitle = (
+          /\s+\S*$/.test(truncated)
+            ? truncated.replace(/\s+\S*$/, "")
+            : truncated
+        ).trim();
       }
     }
     const prBody = `## Summary

--- a/scripts/worktree-current.js
+++ b/scripts/worktree-current.js
@@ -36,7 +36,7 @@ function main() {
 
     // Check if we're in a worktree
     try {
-      const worktreeInfo = runCommand("git rev-parse --show-toplevel", {
+      const _worktreeInfo = runCommand("git rev-parse --show-toplevel", {
         silent: true,
       }).trim();
       const gitCommonDir = runCommand("git rev-parse --git-common-dir", {
@@ -52,7 +52,7 @@ function main() {
       } else {
         console.log("📦 Status: Main repository");
       }
-    } catch (error) {
+    } catch (_error) {
       console.log("📦 Status: Unknown");
     }
 
@@ -62,7 +62,7 @@ function main() {
     console.log("-----------");
     try {
       runCommand("git status --porcelain", { silent: false });
-    } catch (error) {
+    } catch (_error) {
       console.log("No git status available");
     }
 
@@ -72,10 +72,10 @@ function main() {
     console.log("--------------");
     try {
       runCommand("git worktree list");
-    } catch (error) {
+    } catch (_error) {
       console.log("No worktrees found");
     }
-  } catch (error) {
+  } catch (_error) {
     console.error("❌ Failed to get worktree information");
     process.exit(1);
   }

--- a/scripts/worktree-remove.js
+++ b/scripts/worktree-remove.js
@@ -43,7 +43,7 @@ function main() {
     console.error("Available worktrees:");
     try {
       runCommand("npm run worktree:list");
-    } catch (error) {
+    } catch (_error) {
       console.error("No worktrees found");
     }
     process.exit(1);
@@ -55,7 +55,7 @@ function main() {
   if (!force) {
     try {
       // Check if branch has unmerged changes
-      const result = runCommand(
+      const _result = runCommand(
         `git branch --no-merged main | grep -q ${branchName}`,
         { silent: true },
       );
@@ -65,7 +65,7 @@ function main() {
       console.log("");
       console.log("Or merge/PR the branch first, then remove the worktree.");
       process.exit(1);
-    } catch (error) {
+    } catch (_error) {
       // Branch is merged or doesn't exist, safe to remove
     }
   }
@@ -78,7 +78,7 @@ function main() {
     try {
       console.log(`🌿 Deleting branch: ${branchName}`);
       runCommand(`git branch -D ${branchName}`, { silent: true });
-    } catch (error) {
+    } catch (_error) {
       // Branch might not exist or might be protected, that's okay
       console.log(
         `ℹ️  Branch ${branchName} not deleted (might not exist or be protected)`,
@@ -88,12 +88,12 @@ function main() {
     // Clean up any orphaned worktree references
     try {
       runCommand("git worktree prune", { silent: true });
-    } catch (error) {
+    } catch (_error) {
       // Ignore prune errors
     }
 
     console.log("✅ Worktree removed successfully!");
-  } catch (error) {
+  } catch (_error) {
     console.error("❌ Failed to remove worktree");
     console.error("You may need to force remove with:");
     console.error(`  git worktree remove --force ${worktreePath}`);


### PR DESCRIPTION
## Summary
- fix: ensure PR titles are concise and under 60 chars

- Add intelligent title truncation to enhanced-commit script
- Preserve type prefixes (feat:, fix:, etc.) when truncating
- Limit titles to 60 chars for type-prefixed commits, 50 chars otherwise
- Use word boundaries to avoid cutting words mid-way
- Keep full commit message in PR body for context

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed