### PR TITLE
remove: unused ready status label from footer

### DIFF
--- a/app/renderer/components/StatusBar.tsx
+++ b/app/renderer/components/StatusBar.tsx
@@ -5,12 +5,10 @@ import { useSettings } from "../utils/SettingsContext";
 
 interface StatusBarProps {
   progress?: null | number; // 0-100, or null for none
-  status?: string;
 }
 
 const StatusBar: React.FC<StatusBarProps> = ({
   progress = null,
-  status = "Ready",
 }) => {
   const { isDarkMode, localStorePath, setThemeMode, themeMode } = useSettings();
 
@@ -40,9 +38,6 @@ const StatusBar: React.FC<StatusBarProps> = ({
           <span className="font-mono">
             {localStorePath || "Not configured"}
           </span>
-        </span>
-        <span className="ml-4 font-semibold" data-testid="status-text">
-          {status}
         </span>
         {progress !== null && (
           <div

--- a/app/renderer/components/__tests__/StatusBar.test.tsx
+++ b/app/renderer/components/__tests__/StatusBar.test.tsx
@@ -40,20 +40,9 @@ describe("StatusBar", () => {
   describe("rendering", () => {
     it("should render without crashing", () => {
       render(<StatusBar />);
-      expect(screen.getByText("Ready")).toBeInTheDocument();
+      expect(screen.getByText("/test/path")).toBeInTheDocument();
     });
 
-    it("should display default status when no status provided", () => {
-      render(<StatusBar />);
-      expect(screen.getByTestId("status-text")).toHaveTextContent("Ready");
-    });
-
-    it("should display custom status", () => {
-      render(<StatusBar status="Processing..." />);
-      expect(screen.getByTestId("status-text")).toHaveTextContent(
-        "Processing...",
-      );
-    });
 
     it("should display local store path", () => {
       render(<StatusBar />);
@@ -249,14 +238,5 @@ describe("StatusBar", () => {
       expect(screen.queryByTestId("progress-bar")).not.toBeInTheDocument();
     });
 
-    it("should handle empty status string", () => {
-      render(<StatusBar status="" />);
-      expect(screen.getByTestId("status-text")).toHaveTextContent("");
-    });
-
-    it("should handle null status", () => {
-      render(<StatusBar status={null as any} />);
-      expect(screen.getByTestId("status-text")).toHaveTextContent("");
-    });
   });
 });


### PR DESCRIPTION
## Summary
- Implement remove: unused ready status label from footer

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed