### PR TITLE
fix: prevent invalid store dialog during wizard

### DIFF
--- a/app/renderer/components/KitDetails.tsx
+++ b/app/renderer/components/KitDetails.tsx
@@ -37,7 +37,11 @@ const KitDetails: React.FC<KitDetailsAllProps> = (props) => {
   // Check if kit needs scanning - this is just a simple heuristic for now
   // A more robust implementation would check the database for scan status
   // Don't show scanning prompt for empty kits (no samples to scan yet)
-  const hasAnySamples = logic.samples && Object.values(logic.samples).some(voiceSamples => voiceSamples.length > 0);
+  const hasAnySamples =
+    logic.samples &&
+    Object.values(logic.samples).some(
+      (voiceSamples) => voiceSamples.length > 0,
+    );
   const needsScanning =
     logic.kit &&
     hasAnySamples && // Only show scanning prompt if there are actually samples to scan

--- a/app/renderer/components/LocalStoreWizardModal.tsx
+++ b/app/renderer/components/LocalStoreWizardModal.tsx
@@ -6,6 +6,7 @@ interface LocalStoreWizardModalProps {
   isOpen: boolean;
   onClose: () => void;
   onCloseApp?: () => void;
+  onInitializationChange?: (isInitializing: boolean) => void;
   onSuccess: () => void;
   setLocalStorePath: (path: string) => void;
 }
@@ -18,6 +19,7 @@ const LocalStoreWizardModal: React.FC<LocalStoreWizardModalProps> = ({
   isOpen,
   onClose,
   onCloseApp,
+  onInitializationChange,
   onSuccess,
   setLocalStorePath,
 }) => {
@@ -40,6 +42,7 @@ const LocalStoreWizardModal: React.FC<LocalStoreWizardModalProps> = ({
         </div>
         <LocalStoreWizardUI
           onClose={handleClose}
+          onInitializationChange={onInitializationChange}
           onSuccess={onSuccess}
           setLocalStorePath={setLocalStorePath}
         />

--- a/app/renderer/components/LocalStoreWizardUI.tsx
+++ b/app/renderer/components/LocalStoreWizardUI.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { FaArchive, FaFolderOpen, FaSdCard, FaSearch } from "react-icons/fa";
 
 import { config } from "../config";
@@ -20,12 +20,13 @@ enum WizardStep {
 
 interface LocalStoreWizardUIProps {
   onClose: () => void;
+  onInitializationChange?: (isInitializing: boolean) => void;
   onSuccess?: () => void;
   setLocalStorePath: (path: string) => void;
 }
 
 const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
-  ({ onClose, onSuccess, setLocalStorePath }) => {
+  ({ onClose, onInitializationChange, onSuccess, setLocalStorePath }) => {
     // Only log on development or if there's an issue
     const isDev = process.env.NODE_ENV === "development";
     isDev &&
@@ -52,6 +53,11 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
       setTargetPath,
       state,
     } = useLocalStoreWizard(undefined, setLocalStorePath);
+
+    // Notify parent when initialization state changes
+    useEffect(() => {
+      onInitializationChange?.(state.isInitializing);
+    }, [state.isInitializing, onInitializationChange]);
 
     const safeSelectLocalStorePath = useCallback(async () => {
       if (window.electronAPI?.selectLocalStorePath) {

--- a/app/renderer/components/__tests__/KitDetails.test.tsx
+++ b/app/renderer/components/__tests__/KitDetails.test.tsx
@@ -447,11 +447,11 @@ describe("KitDetails", () => {
             { id: 2, kit_name: "TestKit", voice_alias: null, voice_number: 2 },
           ],
         },
-        samples: { 1: ["sample1.wav"], 2: ["sample2.wav"], 3: [], 4: [] }, // Has samples
         playback: {
           ...createMockLogic().playback,
           samplePlaying: { "1:sample1.wav": false, "2:sample2.wav": false }, // Mock playback state
         },
+        samples: { 1: ["sample1.wav"], 2: ["sample2.wav"], 3: [], 4: [] }, // Has samples
       };
       (useKitDetailsLogic as Mock).mockReturnValue(mockLogic);
 
@@ -477,15 +477,25 @@ describe("KitDetails", () => {
         kit: {
           ...createMockLogic().kit,
           voices: [
-            { id: 1, kit_name: "TestKit", voice_alias: "Kick", voice_number: 1 },
-            { id: 2, kit_name: "TestKit", voice_alias: "Snare", voice_number: 2 },
+            {
+              id: 1,
+              kit_name: "TestKit",
+              voice_alias: "Kick",
+              voice_number: 1,
+            },
+            {
+              id: 2,
+              kit_name: "TestKit",
+              voice_alias: "Snare",
+              voice_number: 2,
+            },
           ],
         },
-        samples: { 1: ["sample1.wav"], 2: ["sample2.wav"], 3: [], 4: [] }, // Has samples
         playback: {
           ...createMockLogic().playback,
           samplePlaying: { "1:sample1.wav": false, "2:sample2.wav": false }, // Mock playback state
         },
+        samples: { 1: ["sample1.wav"], 2: ["sample2.wav"], 3: [], 4: [] }, // Has samples
       };
       (useKitDetailsLogic as Mock).mockReturnValue(mockLogic);
 

--- a/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
+++ b/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
@@ -159,9 +159,6 @@ export function useLocalStoreWizard(
       if (!state.source) throw new Error("No source selected");
       if (api.ensureDir) await api.ensureDir(state.targetPath);
 
-      // Set the local store path early in the process
-      await setLocalStorePathHelper();
-
       // Process source-specific operations
       await processSource();
 
@@ -179,6 +176,9 @@ export function useLocalStoreWizard(
       await scanningHook.runScanning(state.targetPath, dbDir, validKits);
       isDev &&
         console.debug("[Hook] initialize - scanning operations completed");
+
+      // Set the local store path only after everything is ready
+      await setLocalStorePathHelper();
 
       isDev && console.debug("[Hook] initialize completed successfully");
       return { success: true };

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -83,6 +83,9 @@ const KitsView: React.FC = () => {
   // Track if we just completed the wizard to prevent re-opening
   const [wizardJustCompleted, setWizardJustCompleted] = useState(false);
 
+  // Track wizard initialization state to suppress invalid store dialog
+  const [isWizardInitializing, setIsWizardInitializing] = useState(false);
+
   // Kit data management
   const {
     allKitSamples,
@@ -301,6 +304,7 @@ const KitsView: React.FC = () => {
             ? () => window.electronAPI?.closeApp?.()
             : undefined
         }
+        onInitializationChange={setIsWizardInitializing}
         onSuccess={handleWizardSuccess}
         setLocalStorePath={setLocalStorePath}
       />
@@ -310,7 +314,11 @@ const KitsView: React.FC = () => {
         errorMessage={
           localStoreStatus?.error || "Invalid local store configuration"
         }
-        isOpen={hasInvalidLocalStore && !hasCriticalEnvironmentError}
+        isOpen={
+          hasInvalidLocalStore &&
+          !hasCriticalEnvironmentError &&
+          !isWizardInitializing
+        }
         localStorePath={localStoreStatus?.localStorePath || null}
         onMessage={showMessage}
       />


### PR DESCRIPTION
## Summary
fix: prevent invalid store dialog during wizard initialization

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed