### PR TITLE
fix: sequencer BPM updates speed reliably on change

### DIFF
--- a/app/renderer/components/KitStepSequencer.tsx
+++ b/app/renderer/components/KitStepSequencer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { useKitStepSequencerLogic } from "./hooks/kit-management/useKitStepSequencerLogic";
+import { useBpm } from "./hooks/shared/useBpm";
 import StepSequencerControls from "./StepSequencerControls";
 import StepSequencerDrawer from "./StepSequencerDrawer";
 import StepSequencerGrid from "./StepSequencerGrid";
@@ -18,7 +19,14 @@ interface KitStepSequencerProps {
 }
 
 const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
-  const logic = useKitStepSequencerLogic(props);
+  // Manage BPM state at this level to ensure sequencer logic gets live updates
+  const bpmLogic = useBpm({ initialBpm: props.bpm, kitName: props.kitName });
+
+  // Pass the current BPM from bpmLogic to sequencer logic for live updates
+  const logic = useKitStepSequencerLogic({
+    ...props,
+    bpm: bpmLogic.bpm, // Use live BPM value instead of initial prop
+  });
 
   return (
     <StepSequencerDrawer
@@ -27,7 +35,7 @@ const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
     >
       <div className="flex flex-row items-start justify-center gap-4">
         <StepSequencerControls
-          bpm={props.bpm}
+          bpmLogic={bpmLogic}
           isSeqPlaying={logic.isSeqPlaying}
           kitName={props.kitName}
           setIsSeqPlaying={logic.setIsSeqPlaying}

--- a/app/renderer/components/StepSequencerControls.tsx
+++ b/app/renderer/components/StepSequencerControls.tsx
@@ -1,29 +1,30 @@
 import React from "react";
 import { FiPlay, FiSquare } from "react-icons/fi";
 
-import { useBpm } from "./hooks/shared/useBpm";
+interface BpmLogic {
+  bpm: number;
+  isEditing: boolean;
+  setBpm: (bpm: number) => void;
+  setIsEditing: (editing: boolean) => void;
+  validateBpm: (bpm: number) => boolean;
+}
 
 interface StepSequencerControlsProps {
-  bpm?: number;
+  bpmLogic: BpmLogic;
   isSeqPlaying: boolean;
   kitName: string;
   setIsSeqPlaying: (playing: boolean) => void;
 }
 
 const StepSequencerControls: React.FC<StepSequencerControlsProps> = ({
-  bpm: initialBpm,
+  bpmLogic,
   isSeqPlaying,
   kitName,
   setIsSeqPlaying,
 }) => {
   console.log("[BPM Debug] StepSequencerControls props:", {
-    initialBpm,
-    kitName,
-  });
-  const bpmLogic = useBpm({ initialBpm, kitName });
-  console.log("[BPM Debug] useBpm result:", {
     bpm: bpmLogic.bpm,
-    isEditing: bpmLogic.isEditing,
+    kitName,
   });
   const [inputValue, setInputValue] = React.useState(bpmLogic.bpm.toString());
 
@@ -39,6 +40,18 @@ const StepSequencerControls: React.FC<StepSequencerControlsProps> = ({
     const newBpm = parseInt(newValue, 10);
     if (bpmLogic.validateBpm(newBpm)) {
       bpmLogic.setBpm(newBpm);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      e.preventDefault();
+      const currentBpm = bpmLogic.bpm;
+      const newBpm = e.key === "ArrowUp" ? currentBpm + 1 : currentBpm - 1;
+
+      if (bpmLogic.validateBpm(newBpm)) {
+        bpmLogic.setBpm(newBpm);
+      }
     }
   };
   return (
@@ -67,6 +80,7 @@ const StepSequencerControls: React.FC<StepSequencerControlsProps> = ({
             max={180}
             min={30}
             onChange={handleBpmChange}
+            onKeyDown={handleKeyDown}
             type="number"
             value={inputValue}
           />


### PR DESCRIPTION
## Summary

Fixed a bug where the sequencer speed (BPM) wouldn't update reliably when users changed the BPM value via up/down arrows or direct input.

**Root Cause**: BPM state was managed separately in `StepSequencerControls` and `useKitStepSequencerLogic`, causing the sequencer logic to use stale BPM values when calculating `stepDuration`.

**Solution**: 
- Lifted BPM state management to `KitStepSequencer` component level using `useBpm` hook
- Pass live BPM value from `useBpm` to `useKitStepSequencerLogic` for real-time updates
- Added arrow key support for BPM adjustment (up/down arrows to increment/decrement)
- Updated `StepSequencerControls` interface to accept `bpmLogic` prop instead of managing its own BPM state

**Changes**:
- Modified `KitStepSequencer.tsx` to manage BPM state and pass live values to sequencer logic
- Updated `StepSequencerControls.tsx` to accept `bpmLogic` prop and handle arrow key input
- Updated component tests to match new interface
- Added tests for arrow key BPM changes and validation

## Test Plan

- [x] Unit tests pass for updated components
- [x] Integration tests pass
- [x] BPM changes via direct input update sequencer speed immediately
- [x] BPM changes via arrow keys update sequencer speed immediately  
- [x] BPM validation works correctly (30-180 range)
- [x] Invalid BPM values are rejected and don't update sequencer speed