### PR TITLE
fix: resolve BPM state race condition for kit switching

### DIFF
--- a/app/renderer/components/StepSequencerControls.tsx
+++ b/app/renderer/components/StepSequencerControls.tsx
@@ -22,10 +22,6 @@ const StepSequencerControls: React.FC<StepSequencerControlsProps> = ({
   kitName,
   setIsSeqPlaying,
 }) => {
-  console.log("[BPM Debug] StepSequencerControls props:", {
-    bpm: bpmLogic.bpm,
-    kitName,
-  });
   const [inputValue, setInputValue] = React.useState(bpmLogic.bpm.toString());
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes sequencer BPM bug where BPM changes were lost when navigating between kits, especially for empty sequences.

### Root Cause  
The `useBpm` hook had a race condition where state would reset to `initialBpm` from stale kit data when:
- Switching between kits after making BPM changes
- Database updates triggered prop changes that overwrote user changes  
- Error reversion used stale `initialBpm` instead of current BPM

### Solution
- Added "dirty state" tracking to prevent overwrites of user changes
- Kit switching now properly resets state for new kits while preserving changes within the same kit
- Error reversion uses current BPM instead of potentially stale `initialBpm`
- Refactored StepSequencerControls to accept BpmLogic interface for better separation of concerns

### Test Coverage
- Added comprehensive test cases for kit switching scenarios
- Tests cover empty sequence BPM changes, kit navigation, and state preservation  
- All existing tests pass with new behavior

## Test plan
- [x] Unit tests pass (including new scenarios)
- [x] Integration tests pass  
- [x] Build succeeds
- [x] Manual testing of specific bug scenarios

### Fixes the specific scenarios:
1. ✅ BPM changes on empty sequences now persist correctly
2. ✅ BPM values no longer "leak" between different kits
3. ✅ Empty sequence kits maintain their set BPM instead of reverting to 120