### PR TITLE
fix: resolve ESLint no-undef warnings for Node.js globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,9 +17,10 @@ export default defineConfig([
     ignores: ["node_modules", "dist", "out", "coverage", "build"],
   },
 
-  // JS files (browser environment)
+  // JS files (browser environment) - excluding Node.js files
   {
     files: ["**/*.js"],
+    ignores: ["scripts/**/*.js", "*.config.js", "tailwind.config.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
@@ -196,7 +197,7 @@ export default defineConfig([
 
   // Config files (Node environment)
   {
-    files: ["*.config.js", "*.config.ts"],
+    files: ["*.config.js", "*.config.ts", "tailwind.config.js"],
     languageOptions: {
       globals: trimGlobals(globals.node),
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default defineConfig([
   // JS files (browser environment) - excluding Node.js files
   {
     files: ["**/*.js"],
-    ignores: ["scripts/**/*.js", "*.config.js", "tailwind.config.js"],
+    ignores: ["scripts/**/*.js", "tailwind.config.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-prettier": "^5.4.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-sonarjs": "^3.0.4",
+        "globals": "^16.3.0",
         "handlebars": "^4.7.8",
         "husky": "^9.1.7",
         "istanbul-merge": "^2.0.0",
@@ -4583,6 +4584,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -13214,9 +13227,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-prettier": "^5.4.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-sonarjs": "^3.0.4",
+    "globals": "^16.3.0",
     "handlebars": "^4.7.8",
     "husky": "^9.1.7",
     "istanbul-merge": "^2.0.0",


### PR DESCRIPTION
## Summary
fix: resolve ESLint no-undef warnings for Node.js globals

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed