### PR TITLE
fix: resolve ESLint config issues and add TypeScript CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,27 @@
+name: TypeCheck
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript type checking
+        run: npm run typecheck

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,13 +14,26 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig([
   {
-    ignores: ["node_modules", "dist", "out", "coverage", "build"],
+    ignores: [
+      "node_modules",
+      "dist",
+      "out",
+      "coverage",
+      "build",
+      "app/node_modules",
+      "**/node_modules",
+    ],
   },
 
   // JS files (browser environment) - excluding Node.js files
   {
     files: ["**/*.js"],
-    ignores: ["scripts/**/*.js", "tailwind.config.js"],
+    ignores: [
+      "scripts/**/*.js",
+      "tailwind.config.js",
+      "docs/**/*.js",
+      "app/node_modules/**/*",
+    ],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",


### PR DESCRIPTION
## Summary
fix: resolve ESLint config issues and add TypeScript CI workflow

- Add proper exclusions to ESLint config for app/node_modules and docs JS files
- Resolves massive linting errors caused by overly broad JS file matching in PR #79  
- Add separate TypeScript workflow for parallel CI execution and clear PR status
- Enables catching type errors in CI that could bypass pre-commit hooks

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed