### PR TITLE
fix: auto-migrate kits with missing WAV metadata on startup

### DIFF
--- a/app/renderer/electron.d.ts
+++ b/app/renderer/electron.d.ts
@@ -230,6 +230,13 @@ export interface ElectronAPI {
   rescanKit: (
     kitName: string,
   ) => Promise<DbResult<{ scannedSamples: number; updatedVoices: number }>>;
+  rescanKitsMissingMetadata: () => Promise<
+    DbResult<{
+      kitsNeedingRescan: string[];
+      kitsRescanned: string[];
+      totalSamplesUpdated: number;
+    }>
+  >;
   scanBanks?: () => Promise<
     DbResult<{ scannedAt: Date; scannedFiles: number; updatedBanks: number }>
   >;

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -174,8 +174,8 @@ const KitsView: React.FC = () => {
       }
 
       try {
-        const result = await window.electronAPI?.rescanKitsMissingMetadata?.();
-        if (result?.success && result.data) {
+        const result = await window.electronAPI.rescanKitsMissingMetadata();
+        if (result.success && result.data) {
           const { kitsRescanned, totalSamplesUpdated } = result.data;
 
           if (kitsRescanned.length > 0) {

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -155,6 +155,60 @@ const KitsView: React.FC = () => {
     needsLocalStoreSetup: needsLocalStoreSetup || hasInvalidLocalStore,
   });
 
+  // Migrate kits with missing metadata on startup (one-time migration)
+  useEffect(() => {
+    const migrateMetadata = async () => {
+      if (
+        !isInitialized ||
+        !localStorePath ||
+        needsLocalStoreSetup ||
+        hasInvalidLocalStore
+      ) {
+        return;
+      }
+
+      // Check if migration has already been done in this session
+      const migrationKey = "metadata-migration-completed";
+      if (sessionStorage.getItem(migrationKey)) {
+        return;
+      }
+
+      try {
+        const result = await window.electronAPI?.rescanKitsMissingMetadata?.();
+        if (result?.success && result.data) {
+          const { kitsRescanned, totalSamplesUpdated } = result.data;
+
+          if (kitsRescanned.length > 0) {
+            console.info(
+              `Metadata migration completed: ${kitsRescanned.length} kits rescanned, ${totalSamplesUpdated} samples updated`,
+            );
+            showMessage(
+              `Updated metadata for ${kitsRescanned.length} kit${kitsRescanned.length === 1 ? "" : "s"}`,
+              "success",
+            );
+
+            // Refresh the current view to show the new metadata
+            await refreshAllKitsAndSamples();
+          }
+
+          // Mark migration as complete for this session
+          sessionStorage.setItem(migrationKey, "true");
+        }
+      } catch (error) {
+        console.error("Failed to migrate metadata:", error);
+      }
+    };
+
+    migrateMetadata();
+  }, [
+    isInitialized,
+    localStorePath,
+    needsLocalStoreSetup,
+    hasInvalidLocalStore,
+    showMessage,
+    refreshAllKitsAndSamples,
+  ]);
+
   // Auto-trigger wizard on startup if local store is not configured
   useEffect(() => {
     if (needsLocalStoreSetup && !wizardJustCompleted) {

--- a/electron/main/__tests__/dbIpcHandlers.test.ts
+++ b/electron/main/__tests__/dbIpcHandlers.test.ts
@@ -38,6 +38,7 @@ vi.mock("../services/sampleService.js", () => ({
 vi.mock("../services/scanService.js", () => ({
   scanService: {
     rescanKit: vi.fn(),
+    rescanKitsWithMissingMetadata: vi.fn(),
     scanBanks: vi.fn(),
   },
 }));
@@ -139,6 +140,7 @@ describe("dbIpcHandlers - Routing Tests", () => {
         "get-all-samples",
         "get-all-samples-for-kit",
         "rescan-kit",
+        "rescan-kits-missing-metadata",
         "delete-all-samples-for-kit",
         "get-all-banks",
         "scan-banks",
@@ -262,6 +264,26 @@ describe("dbIpcHandlers - Routing Tests", () => {
         mockInMemorySettings,
         "TestKit",
       );
+    });
+
+    it("rescan-kits-missing-metadata routes to scanService.rescanKitsWithMissingMetadata", async () => {
+      mockScanService.rescanKitsWithMissingMetadata.mockResolvedValue({
+        data: {
+          kitsNeedingRescan: ["A1", "A2"],
+          kitsRescanned: ["A1", "A2"],
+          totalSamplesUpdated: 50,
+        },
+        success: true,
+      });
+
+      const handler = handlerRegistry["rescan-kits-missing-metadata"];
+      const result = await handler({});
+
+      expect(result.success).toBe(true);
+      expect(result.data?.totalSamplesUpdated).toBe(50);
+      expect(
+        mockScanService.rescanKitsWithMissingMetadata,
+      ).toHaveBeenCalledWith(mockInMemorySettings);
     });
 
     it("scan-banks routes to scanService.scanBanks", async () => {

--- a/electron/main/dbIpcHandlers.ts
+++ b/electron/main/dbIpcHandlers.ts
@@ -193,6 +193,10 @@ export function registerDbIpcHandlers(inMemorySettings: InMemorySettings) {
     return scanService.rescanKit(inMemorySettings, kitName);
   });
 
+  ipcMain.handle("rescan-kits-missing-metadata", async () => {
+    return scanService.rescanKitsWithMissingMetadata(inMemorySettings);
+  });
+
   ipcMain.handle(
     "delete-all-samples-for-kit",
     async (_event, dbDir: string, kitName: string) => {

--- a/electron/main/services/scanService.ts
+++ b/electron/main/services/scanService.ts
@@ -12,6 +12,7 @@ import { getAudioMetadata } from "../audioUtils.js";
 import {
   addSample,
   deleteSamples,
+  getAllSamples,
   updateBank,
   updateSampleMetadata,
   updateVoiceAlias,
@@ -136,9 +137,6 @@ export class ScanService {
     try {
       // First, find all kits that have samples with missing metadata
       const kitsNeedingRescan: string[] = [];
-
-      // Import the necessary functions to query the database
-      const { getAllSamples } = await import("../db/romperDbCoreORM.js");
 
       const samplesResult = getAllSamples(dbDir);
       if (!samplesResult.success || !samplesResult.data) {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -447,6 +447,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     isDev && console.debug("[IPC] rescanKit invoked", kitName);
     return ipcRenderer.invoke("rescan-kit", kitName);
   },
+  rescanKitsMissingMetadata: () => {
+    isDev && console.debug("[IPC] rescanKitsMissingMetadata invoked");
+    return ipcRenderer.invoke("rescan-kits-missing-metadata");
+  },
   scanBanks: () => {
     isDev && console.debug("[IPC] scanBanks invoked");
     return ipcRenderer.invoke("scan-banks");


### PR DESCRIPTION
## Summary
fix: auto-migrate kits with missing WAV metadata on startup

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed