### PR TITLE
refactor: extract sampleCrudService validation and batch

### DIFF
--- a/electron/main/services/__tests__/sampleBatchOperations.test.ts
+++ b/electron/main/services/__tests__/sampleBatchOperations.test.ts
@@ -1,0 +1,550 @@
+import type { Sample } from "@romper/shared/db/schema.js";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as romperDbCoreORM from "../../db/romperDbCoreORM.js";
+import * as fileSystemUtils from "../../utils/fileSystemUtils.js";
+import { SampleBatchOperationsService } from "../sampleBatchOperations.js";
+import * as sampleValidation from "../sampleValidation.js";
+
+// Mock dependencies
+vi.mock("../../db/romperDbCoreORM.js");
+vi.mock("../../utils/fileSystemUtils.js");
+vi.mock("../sampleValidation.js");
+
+const mockORM = vi.mocked(romperDbCoreORM);
+const mockFileSystem = vi.mocked(fileSystemUtils);
+const mockSampleValidation = vi.mocked(sampleValidation);
+
+describe("SampleBatchOperationsService", () => {
+  let service: SampleBatchOperationsService;
+  const mockSettings = { localStorePath: "/mock/path" };
+  const mockDbPath = "/mock/db.sqlite";
+
+  const mockSample: Sample = {
+    filename: "test.wav",
+    id: 1,
+    is_stereo: false,
+    kit_name: "TestKit",
+    slot_number: 2,
+    source_path: "/path/test.wav",
+    voice_number: 1,
+  };
+
+  beforeEach(() => {
+    service = new SampleBatchOperationsService();
+    vi.clearAllMocks();
+
+    // Setup common mocks
+    mockFileSystem.ServicePathManager.getLocalStorePath.mockReturnValue(
+      "/mock/path",
+    );
+    mockFileSystem.ServicePathManager.getDbPath.mockReturnValue(mockDbPath);
+    mockSampleValidation.sampleValidationService.validateVoiceAndSlot.mockReturnValue(
+      {
+        isValid: true,
+      },
+    );
+  });
+
+  describe("deleteSampleFromSlot", () => {
+    it("should successfully delete a sample", () => {
+      mockSampleValidation.sampleValidationService.checkSampleExists.mockReturnValue(
+        {
+          exists: true,
+          sample: mockSample,
+        },
+      );
+
+      mockORM.deleteSamples.mockReturnValue({
+        data: {
+          affectedSamples: [mockSample],
+          deletedSamples: [mockSample],
+        },
+        success: true,
+      });
+
+      mockORM.markKitAsModified.mockReturnValue({ success: true });
+
+      const result = service.deleteSampleFromSlot(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.deletedSamples).toEqual([mockSample]);
+      expect(mockORM.deleteSamples).toHaveBeenCalledWith(
+        mockDbPath,
+        "TestKit",
+        {
+          slotNumber: 2,
+          voiceNumber: 1,
+        },
+      );
+      expect(mockORM.markKitAsModified).toHaveBeenCalledWith(
+        mockDbPath,
+        "TestKit",
+      );
+    });
+
+    it("should return error when sample doesn't exist", () => {
+      mockSampleValidation.sampleValidationService.checkSampleExists.mockReturnValue(
+        {
+          exists: false,
+        },
+      );
+
+      const result = service.deleteSampleFromSlot(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No sample found in voice 1, slot 3 to delete");
+    });
+
+    it("should return error for invalid voice/slot", () => {
+      mockSampleValidation.sampleValidationService.validateVoiceAndSlot.mockReturnValue(
+        {
+          error: "Invalid voice number",
+          isValid: false,
+        },
+      );
+
+      const result = service.deleteSampleFromSlot(
+        mockSettings,
+        "TestKit",
+        99,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid voice number");
+    });
+
+    it("should return error when no local store path", () => {
+      mockFileSystem.ServicePathManager.getLocalStorePath.mockReturnValue(null);
+
+      const result = service.deleteSampleFromSlot(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No local store path configured");
+    });
+
+    it("should handle database deletion error", () => {
+      mockSampleValidation.sampleValidationService.checkSampleExists.mockReturnValue(
+        {
+          exists: true,
+          sample: mockSample,
+        },
+      );
+
+      mockORM.deleteSamples.mockReturnValue({
+        error: "Database error",
+        success: false,
+      });
+
+      const result = service.deleteSampleFromSlot(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Database error");
+      expect(mockORM.markKitAsModified).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteSampleFromSlotWithoutReindexing", () => {
+    it("should successfully delete without reindexing", () => {
+      mockORM.deleteSamplesWithoutReindexing.mockReturnValue({
+        data: {
+          deletedSamples: [mockSample],
+        },
+        success: true,
+      });
+
+      mockORM.markKitAsModified.mockReturnValue({ success: true });
+
+      const result = service.deleteSampleFromSlotWithoutReindexing(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.deletedSamples).toEqual([mockSample]);
+      expect(result.data?.affectedSamples).toEqual([mockSample]);
+      expect(mockORM.deleteSamplesWithoutReindexing).toHaveBeenCalledWith(
+        mockDbPath,
+        "TestKit",
+        {
+          slotNumber: 2,
+          voiceNumber: 1,
+        },
+      );
+    });
+
+    it("should handle validation error", () => {
+      mockSampleValidation.sampleValidationService.validateVoiceAndSlot.mockReturnValue(
+        {
+          error: "Invalid parameters",
+          isValid: false,
+        },
+      );
+
+      const result = service.deleteSampleFromSlotWithoutReindexing(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid parameters");
+    });
+  });
+
+  describe("moveSampleInKit", () => {
+    const mockMoveResult = {
+      data: {
+        affectedSamples: [{ ...mockSample, original_slot_number: 2 }],
+        movedSample: mockSample,
+        replacedSample: null,
+      },
+      success: true,
+    };
+
+    it("should successfully move sample within kit", () => {
+      mockSampleValidation.sampleValidationService.validateSampleMovement.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      mockSampleValidation.sampleValidationService.validateStereoSampleMove.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.moveSample.mockReturnValue(mockMoveResult);
+      mockORM.markKitAsModified.mockReturnValue({ success: true });
+
+      const result = service.moveSampleInKit(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+        1,
+        3,
+        "insert",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.movedSample).toEqual(mockSample);
+      expect(result.data?.replacedSample).toBeUndefined(); // null converted to undefined
+      expect(mockORM.moveSample).toHaveBeenCalledWith(
+        mockDbPath,
+        "TestKit",
+        1,
+        2,
+        1,
+        3,
+      );
+      expect(mockORM.markKitAsModified).toHaveBeenCalledWith(
+        mockDbPath,
+        "TestKit",
+      );
+    });
+
+    it("should return error when sample not found", () => {
+      mockSampleValidation.sampleValidationService.validateSampleMovement.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.getKitSamples.mockReturnValue({
+        data: [], // No samples
+        success: true,
+      });
+
+      const result = service.moveSampleInKit(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+        1,
+        3,
+        "insert",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No sample found at voice 1, slot 3");
+    });
+
+    it("should return error for validation failure", () => {
+      mockSampleValidation.sampleValidationService.validateSampleMovement.mockReturnValue(
+        {
+          error: "Invalid movement",
+          success: false,
+        },
+      );
+
+      const result = service.moveSampleInKit(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+        1,
+        2,
+        "insert",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid movement");
+    });
+
+    it("should return error for stereo validation failure", () => {
+      mockSampleValidation.sampleValidationService.validateSampleMovement.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      mockSampleValidation.sampleValidationService.validateStereoSampleMove.mockReturnValue(
+        {
+          error: "Stereo conflict",
+          success: false,
+        },
+      );
+
+      const result = service.moveSampleInKit(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+        1,
+        3,
+        "insert",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Stereo conflict");
+    });
+
+    it("should handle database move error", () => {
+      mockSampleValidation.sampleValidationService.validateSampleMovement.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      mockSampleValidation.sampleValidationService.validateStereoSampleMove.mockReturnValue(
+        {
+          success: true,
+        },
+      );
+
+      mockORM.moveSample.mockReturnValue({
+        error: "Database move error",
+        success: false,
+      });
+
+      const result = service.moveSampleInKit(
+        mockSettings,
+        "TestKit",
+        1,
+        2,
+        1,
+        3,
+        "insert",
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockORM.markKitAsModified).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("executeCrossKitMove", () => {
+    const mockAddSampleToSlot = vi.fn();
+
+    it("should successfully execute cross-kit move", () => {
+      mockAddSampleToSlot.mockReturnValue({
+        data: { sampleId: 123 },
+        success: true,
+      });
+
+      // Mock the deleteSampleFromSlot method
+      const deleteSpy = vi
+        .spyOn(service, "deleteSampleFromSlot")
+        .mockReturnValue({
+          data: {
+            affectedSamples: [mockSample],
+            deletedSamples: [mockSample],
+          },
+          success: true,
+        });
+
+      const result = service.executeCrossKitMove(
+        mockAddSampleToSlot,
+        mockSettings,
+        mockSample,
+        "DestKit",
+        2,
+        0,
+        "SourceKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.movedSample).toEqual(mockSample);
+      expect(result.data?.replacedSample).toBeUndefined();
+      expect(mockAddSampleToSlot).toHaveBeenCalledWith(
+        mockSettings,
+        "DestKit",
+        2,
+        0,
+        mockSample.source_path,
+        { forceMono: true, forceStereo: false },
+      );
+      expect(deleteSpy).toHaveBeenCalledWith(mockSettings, "SourceKit", 1, 2);
+
+      deleteSpy.mockRestore();
+    });
+
+    it("should handle add failure", () => {
+      mockAddSampleToSlot.mockReturnValue({
+        error: "Add failed",
+        success: false,
+      });
+
+      const result = service.executeCrossKitMove(
+        mockAddSampleToSlot,
+        mockSettings,
+        mockSample,
+        "DestKit",
+        2,
+        0,
+        "SourceKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "Failed to add sample to destination: Add failed",
+      );
+    });
+
+    it("should handle delete failure with rollback", () => {
+      mockAddSampleToSlot.mockReturnValue({
+        data: { sampleId: 123 },
+        success: true,
+      });
+
+      // Mock methods - first call succeeds (add), second fails (delete), third succeeds (rollback)
+      const deleteSpy = vi
+        .spyOn(service, "deleteSampleFromSlot")
+        .mockReturnValueOnce({
+          error: "Delete failed",
+          success: false,
+        })
+        .mockReturnValueOnce({
+          data: { affectedSamples: [], deletedSamples: [] },
+          success: true,
+        });
+
+      const result = service.executeCrossKitMove(
+        mockAddSampleToSlot,
+        mockSettings,
+        mockSample,
+        "DestKit",
+        2,
+        0,
+        "SourceKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "Failed to delete source sample: Delete failed",
+      );
+      expect(deleteSpy).toHaveBeenCalledTimes(2); // Delete attempt + rollback
+
+      deleteSpy.mockRestore();
+    });
+
+    it("should handle stereo sample correctly", () => {
+      const stereoSample = { ...mockSample, is_stereo: true };
+      mockAddSampleToSlot.mockReturnValue({
+        data: { sampleId: 123 },
+        success: true,
+      });
+
+      const deleteSpy = vi
+        .spyOn(service, "deleteSampleFromSlot")
+        .mockReturnValue({
+          data: {
+            affectedSamples: [stereoSample],
+            deletedSamples: [stereoSample],
+          },
+          success: true,
+        });
+
+      const result = service.executeCrossKitMove(
+        mockAddSampleToSlot,
+        mockSettings,
+        stereoSample,
+        "DestKit",
+        2,
+        0,
+        "SourceKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockAddSampleToSlot).toHaveBeenCalledWith(
+        mockSettings,
+        "DestKit",
+        2,
+        0,
+        stereoSample.source_path,
+        { forceMono: false, forceStereo: true }, // Should force stereo for stereo sample
+      );
+
+      deleteSpy.mockRestore();
+    });
+  });
+});

--- a/electron/main/services/__tests__/sampleValidation.test.ts
+++ b/electron/main/services/__tests__/sampleValidation.test.ts
@@ -1,0 +1,379 @@
+import type { Sample } from "@romper/shared/db/schema.js";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as romperDbCoreORM from "../../db/romperDbCoreORM.js";
+import { SampleValidationService } from "../sampleValidation.js";
+import * as sampleValidator from "../validation/sampleValidator.js";
+
+// Mock dependencies
+vi.mock("../../db/romperDbCoreORM.js");
+vi.mock("../validation/sampleValidator.js");
+
+const mockORM = vi.mocked(romperDbCoreORM);
+const mockValidator = vi.mocked(sampleValidator);
+
+describe("SampleValidationService", () => {
+  let service: SampleValidationService;
+
+  beforeEach(() => {
+    service = new SampleValidationService();
+    vi.clearAllMocks();
+  });
+
+  describe("validateVoiceAndSlot", () => {
+    it("should validate voice and slot parameters", () => {
+      mockValidator.sampleValidator.validateVoiceAndSlot.mockReturnValue({
+        isValid: true,
+      });
+
+      const result = service.validateVoiceAndSlot(1, 5);
+
+      expect(result.isValid).toBe(true);
+      expect(
+        mockValidator.sampleValidator.validateVoiceAndSlot,
+      ).toHaveBeenCalledWith(1, 5);
+    });
+
+    it("should return validation error for invalid parameters", () => {
+      mockValidator.sampleValidator.validateVoiceAndSlot.mockReturnValue({
+        error: "Invalid voice number",
+        isValid: false,
+      });
+
+      const result = service.validateVoiceAndSlot(99, 5);
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Invalid voice number");
+    });
+  });
+
+  describe("validateSampleFile", () => {
+    it("should validate sample file path", () => {
+      mockValidator.sampleValidator.validateSampleFile.mockReturnValue({
+        isValid: true,
+      });
+
+      const result = service.validateSampleFile("/path/to/sample.wav");
+
+      expect(result.isValid).toBe(true);
+      expect(
+        mockValidator.sampleValidator.validateSampleFile,
+      ).toHaveBeenCalledWith("/path/to/sample.wav");
+    });
+
+    it("should return error for invalid file", () => {
+      mockValidator.sampleValidator.validateSampleFile.mockReturnValue({
+        error: "File not found",
+        isValid: false,
+      });
+
+      const result = service.validateSampleFile("/invalid/path.wav");
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("File not found");
+    });
+  });
+
+  describe("validateSampleMovement", () => {
+    beforeEach(() => {
+      mockValidator.sampleValidator.validateVoiceAndSlot.mockReturnValue({
+        isValid: true,
+      });
+    });
+
+    it("should validate successful movement", () => {
+      const result = service.validateSampleMovement(1, 2, 3, 4);
+
+      expect(result.success).toBe(true);
+      expect(
+        mockValidator.sampleValidator.validateVoiceAndSlot,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it("should reject movement to same position", () => {
+      const result = service.validateSampleMovement(1, 2, 1, 2);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Cannot move sample to the same position");
+    });
+
+    it("should return error for invalid source", () => {
+      mockValidator.sampleValidator.validateVoiceAndSlot
+        .mockReturnValueOnce({ error: "Invalid source", isValid: false })
+        .mockReturnValueOnce({ isValid: true });
+
+      const result = service.validateSampleMovement(99, 2, 3, 4);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Source Invalid source");
+    });
+
+    it("should return error for invalid destination", () => {
+      // Reset the mock to ensure clean state
+      mockValidator.sampleValidator.validateVoiceAndSlot.mockReset();
+      mockValidator.sampleValidator.validateVoiceAndSlot
+        .mockReturnValueOnce({ isValid: true })
+        .mockReturnValueOnce({ error: "Invalid destination", isValid: false });
+
+      const result = service.validateSampleMovement(1, 2, 99, 4);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Destination Invalid destination");
+    });
+  });
+
+  describe("validateAndGetSampleToMove", () => {
+    const mockSample: Sample = {
+      filename: "test.wav",
+      id: 1,
+      is_stereo: false,
+      kit_name: "TestKit",
+      slot_number: 2,
+      source_path: "/path/test.wav",
+      voice_number: 1,
+    };
+
+    it("should successfully find and return sample", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      const result = service.validateAndGetSampleToMove(
+        "/db/path",
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(mockSample);
+    });
+
+    it("should return error when sample not found", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      const result = service.validateAndGetSampleToMove(
+        "/db/path",
+        "TestKit",
+        1,
+        5,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "No sample found in kit TestKit at voice 1, slot 6",
+      );
+    });
+
+    it("should handle database error", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        error: "Database error",
+        success: false,
+      });
+
+      const result = service.validateAndGetSampleToMove(
+        "/db/path",
+        "TestKit",
+        1,
+        2,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Database error");
+    });
+  });
+
+  describe("validateStereoSampleMove", () => {
+    const mockSample: Sample = {
+      filename: "test.wav",
+      id: 1,
+      is_stereo: false,
+      kit_name: "TestKit",
+      slot_number: 2,
+      source_path: "/path/test.wav",
+      voice_number: 1,
+    };
+
+    it("should validate stereo sample move", () => {
+      mockValidator.sampleValidator.validateStereoSampleMove.mockReturnValue({
+        success: true,
+      });
+
+      const result = service.validateStereoSampleMove(
+        mockSample,
+        2,
+        3,
+        "insert",
+        [],
+      );
+
+      expect(result.success).toBe(true);
+      expect(
+        mockValidator.sampleValidator.validateStereoSampleMove,
+      ).toHaveBeenCalledWith(mockSample, 2, 3, "insert", []);
+    });
+  });
+
+  describe("checkStereoConflicts", () => {
+    const mockSample: Sample = {
+      filename: "test.wav",
+      id: 1,
+      is_stereo: true,
+      kit_name: "TestKit",
+      slot_number: 2,
+      source_path: "/path/test.wav",
+      voice_number: 1,
+    };
+
+    it("should check for stereo conflicts", () => {
+      mockValidator.sampleValidator.checkStereoConflicts.mockReturnValue({
+        hasConflict: false,
+      });
+
+      const result = service.checkStereoConflicts(
+        mockSample,
+        2,
+        3,
+        [],
+        "insert",
+        "DestKit",
+      );
+
+      expect(result.hasConflict).toBe(false);
+      expect(
+        mockValidator.sampleValidator.checkStereoConflicts,
+      ).toHaveBeenCalledWith(mockSample, 2, 3, [], "insert", "DestKit");
+    });
+
+    it("should return conflict error", () => {
+      mockValidator.sampleValidator.checkStereoConflicts.mockReturnValue({
+        error: "Stereo sample conflict",
+        hasConflict: true,
+      });
+
+      const result = service.checkStereoConflicts(
+        mockSample,
+        2,
+        3,
+        [],
+        "insert",
+        "DestKit",
+      );
+
+      expect(result.hasConflict).toBe(true);
+      expect(result.error).toBe("Stereo sample conflict");
+    });
+  });
+
+  describe("checkSampleExists", () => {
+    const mockSample: Sample = {
+      filename: "test.wav",
+      id: 1,
+      is_stereo: false,
+      kit_name: "TestKit",
+      slot_number: 2,
+      source_path: "/path/test.wav",
+      voice_number: 1,
+    };
+
+    it("should find existing sample", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      const result = service.checkSampleExists("/db/path", "TestKit", 1, 2);
+
+      expect(result.exists).toBe(true);
+      expect(result.sample).toEqual(mockSample);
+    });
+
+    it("should return false when sample doesn't exist", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        data: [mockSample],
+        success: true,
+      });
+
+      const result = service.checkSampleExists("/db/path", "TestKit", 1, 5);
+
+      expect(result.exists).toBe(false);
+      expect(result.sample).toBeUndefined();
+    });
+
+    it("should handle database error", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        error: "Database error",
+        success: false,
+      });
+
+      const result = service.checkSampleExists("/db/path", "TestKit", 1, 2);
+
+      expect(result.exists).toBe(false);
+      expect(result.sample).toBeUndefined();
+    });
+  });
+
+  describe("getDestinationSamplesAndReplacements", () => {
+    const mockSamples: Sample[] = [
+      {
+        filename: "test1.wav",
+        id: 1,
+        is_stereo: false,
+        kit_name: "TestKit",
+        slot_number: 0,
+        source_path: "/path/test1.wav",
+        voice_number: 1,
+      },
+      {
+        filename: "test2.wav",
+        id: 2,
+        is_stereo: false,
+        kit_name: "TestKit",
+        slot_number: 1,
+        source_path: "/path/test2.wav",
+        voice_number: 1,
+      },
+    ];
+
+    it("should get destination samples successfully", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        data: mockSamples,
+        success: true,
+      });
+
+      const result = service.getDestinationSamplesAndReplacements(
+        "/db/path",
+        "TestKit",
+        1,
+        0,
+        "insert",
+      );
+
+      expect(result.destSamples).toEqual(mockSamples);
+      expect(result.replacedSample).toBeUndefined(); // Insert mode doesn't replace
+    });
+
+    it("should handle database error", () => {
+      mockORM.getKitSamples.mockReturnValue({
+        error: "Database error",
+        success: false,
+      });
+
+      const result = service.getDestinationSamplesAndReplacements(
+        "/db/path",
+        "TestKit",
+        1,
+        0,
+        "insert",
+      );
+
+      expect(result.destSamples).toEqual([]);
+      expect(result.replacedSample).toBeUndefined();
+    });
+  });
+});

--- a/electron/main/services/sampleBatchOperations.ts
+++ b/electron/main/services/sampleBatchOperations.ts
@@ -1,0 +1,338 @@
+import type { DbResult, Sample } from "@romper/shared/db/schema.js";
+
+import { getErrorMessage } from "@romper/shared/errorUtils.js";
+
+import {
+  deleteSamples,
+  deleteSamplesWithoutReindexing,
+  getKitSamples,
+  markKitAsModified,
+  moveSample,
+} from "../db/romperDbCoreORM.js";
+import { ServicePathManager } from "../utils/fileSystemUtils.js";
+import { sampleValidationService } from "./sampleValidation.js";
+
+/**
+ * Service for batch and complex sample operations
+ * Handles delete operations, movement operations, and multi-step workflows
+ */
+export class SampleBatchOperationsService {
+  /**
+   * Delete a sample from a specific voice slot with automatic contiguity maintenance
+   */
+  deleteSampleFromSlot(
+    inMemorySettings: Record<string, unknown>,
+    kitName: string,
+    voiceNumber: number,
+    slotNumber: number,
+  ): DbResult<{ affectedSamples: Sample[]; deletedSamples: Sample[] }> {
+    const localStorePath = this.getLocalStorePath(inMemorySettings);
+    if (!localStorePath) {
+      return { error: "No local store path configured", success: false };
+    }
+
+    const dbPath = this.getDbPath(localStorePath);
+
+    // Validate voice and slot
+    const voiceSlotValidation = sampleValidationService.validateVoiceAndSlot(
+      voiceNumber,
+      slotNumber,
+    );
+    if (!voiceSlotValidation.isValid) {
+      return { error: voiceSlotValidation.error, success: false };
+    }
+
+    try {
+      // Check if sample exists before deleting
+      const { exists } = sampleValidationService.checkSampleExists(
+        dbPath,
+        kitName,
+        voiceNumber,
+        slotNumber,
+      );
+
+      if (!exists) {
+        return {
+          error: `No sample found in voice ${voiceNumber}, slot ${slotNumber + 1} to delete`,
+          success: false,
+        };
+      }
+
+      // Delete with automatic contiguity maintenance
+      const deleteResult = deleteSamples(dbPath, kitName, {
+        slotNumber: slotNumber, // Database stores 0-11 directly
+        voiceNumber,
+      });
+
+      // Mark kit as modified if operation succeeded
+      if (deleteResult.success) {
+        markKitAsModified(dbPath, kitName);
+      }
+
+      return deleteResult;
+    } catch (error) {
+      return {
+        error: `Failed to delete sample: ${getErrorMessage(error)}`,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Delete a sample from a specific voice slot WITHOUT automatic reindexing
+   * Used for undo operations where we want precise control over slot positions
+   */
+  deleteSampleFromSlotWithoutReindexing(
+    inMemorySettings: Record<string, unknown>,
+    kitName: string,
+    voiceNumber: number,
+    slotNumber: number,
+  ): DbResult<{ affectedSamples: Sample[]; deletedSamples: Sample[] }> {
+    const localStorePath = this.getLocalStorePath(inMemorySettings);
+    if (!localStorePath) {
+      return { error: "No local store path configured", success: false };
+    }
+
+    const dbPath = this.getDbPath(localStorePath);
+
+    // Validate voice and slot
+    const voiceSlotValidation = sampleValidationService.validateVoiceAndSlot(
+      voiceNumber,
+      slotNumber,
+    );
+    if (!voiceSlotValidation.isValid) {
+      return { error: voiceSlotValidation.error, success: false };
+    }
+
+    try {
+      // Delete WITHOUT automatic contiguity maintenance (for undo operations)
+      const deleteResult = deleteSamplesWithoutReindexing(dbPath, kitName, {
+        slotNumber: slotNumber, // Database stores 0-11 directly
+        voiceNumber,
+      });
+
+      // Mark kit as modified if operation succeeded
+      if (deleteResult.success) {
+        markKitAsModified(dbPath, kitName);
+      }
+
+      return {
+        data: {
+          affectedSamples: deleteResult.data?.deletedSamples || [],
+          deletedSamples: deleteResult.data?.deletedSamples || [],
+        },
+        success: deleteResult.success,
+      };
+    } catch (error) {
+      return {
+        error: `Failed to delete sample: ${getErrorMessage(error)}`,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Execute cross-kit sample movement with rollback support
+   */
+  executeCrossKitMove(
+    addSampleToSlot: (
+      inMemorySettings: Record<string, unknown>,
+      toKit: string,
+      toVoice: number,
+      toSlot: number,
+      sourcePath: string,
+      options?: { forceMono?: boolean; forceStereo?: boolean },
+    ) => DbResult<{ sampleId: number }>,
+    inMemorySettings: Record<string, unknown>,
+    sampleToMove: Sample,
+    toKit: string,
+    toVoice: number,
+    toSlot: number,
+    fromKit: string,
+    fromVoice: number,
+    fromSlot: number,
+  ): DbResult<{
+    affectedSamples: ({ original_slot_number: number } & Sample)[];
+    movedSample: Sample;
+    replacedSample?: Sample;
+  }> {
+    try {
+      // Step 1: Add the sample to destination kit
+      const addResult = addSampleToSlot(
+        inMemorySettings,
+        toKit,
+        toVoice,
+        toSlot,
+        sampleToMove.source_path,
+        {
+          forceMono: !sampleToMove.is_stereo,
+          forceStereo: sampleToMove.is_stereo,
+        },
+      );
+
+      if (!addResult.success) {
+        return {
+          error: `Failed to add sample to destination: ${addResult.error}`,
+          success: false,
+        };
+      }
+
+      // Step 2: Delete the sample from source kit (with reindexing)
+      const deleteResult = this.deleteSampleFromSlot(
+        inMemorySettings,
+        fromKit,
+        fromVoice,
+        fromSlot,
+      );
+
+      if (!deleteResult.success) {
+        // Rollback: remove the sample we just added
+        this.deleteSampleFromSlot(inMemorySettings, toKit, toVoice, toSlot);
+        return {
+          error: `Failed to delete source sample: ${deleteResult.error}`,
+          success: false,
+        };
+      }
+
+      // Prepare the result data
+      const affectedSamples = (deleteResult.data?.affectedSamples || []).map(
+        (sample) => ({
+          ...sample,
+          original_slot_number: sample.slot_number, // Use current slot as original since it's from delete result
+        }),
+      );
+
+      return {
+        data: {
+          affectedSamples,
+          movedSample: sampleToMove,
+          replacedSample: undefined, // Cross-kit moves don't replace in insert mode
+        },
+        success: true,
+      };
+    } catch (error) {
+      return {
+        error: `Failed to execute cross-kit move: ${getErrorMessage(error)}`,
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Move a sample from one slot to another with contiguity maintenance
+   * Task 22.2: Cross-voice sample movement within same kit
+   */
+  moveSampleInKit(
+    inMemorySettings: Record<string, unknown>,
+    kitName: string,
+    fromVoice: number,
+    fromSlot: number,
+    toVoice: number,
+    toSlot: number,
+    mode: "insert",
+  ): DbResult<{
+    affectedSamples: ({ original_slot_number: number } & Sample)[];
+    movedSample: Sample;
+    replacedSample?: Sample;
+  }> {
+    const localStorePath = this.getLocalStorePath(inMemorySettings);
+    if (!localStorePath) {
+      return { error: "No local store path configured", success: false };
+    }
+
+    const dbPath = this.getDbPath(localStorePath);
+
+    // Validate movement parameters
+    const validationResult = sampleValidationService.validateSampleMovement(
+      fromVoice,
+      fromSlot,
+      toVoice,
+      toSlot,
+    );
+    if (!validationResult.success) {
+      return { error: validationResult.error, success: false };
+    }
+
+    try {
+      // Get existing samples and find sample to move
+      const existingSamplesResult = getKitSamples(dbPath, kitName);
+      if (!existingSamplesResult.success || !existingSamplesResult.data) {
+        return { error: existingSamplesResult.error, success: false };
+      }
+
+      const sampleToMove = existingSamplesResult.data.find(
+        (s) => s.voice_number === fromVoice && s.slot_number === fromSlot, // Database stores 0-11 directly
+      );
+
+      if (!sampleToMove) {
+        return {
+          error: `No sample found at voice ${fromVoice}, slot ${fromSlot + 1}`,
+          success: false,
+        };
+      }
+
+      // Validate stereo sample constraints
+      const stereoValidation = sampleValidationService.validateStereoSampleMove(
+        sampleToMove,
+        toVoice,
+        toSlot,
+        mode,
+        existingSamplesResult.data,
+      );
+      if (!stereoValidation.success) {
+        return { error: stereoValidation.error, success: false };
+      }
+
+      // Use database moveSample operation
+      const moveResult = moveSample(
+        dbPath,
+        kitName,
+        fromVoice,
+        fromSlot,
+        toVoice,
+        toSlot,
+      );
+
+      // Mark kit as modified if operation succeeded
+      if (moveResult.success) {
+        markKitAsModified(dbPath, kitName);
+      }
+
+      if (!moveResult.success) {
+        return moveResult as DbResult<{
+          affectedSamples: ({ original_slot_number: number } & Sample)[];
+          movedSample: Sample;
+          replacedSample?: Sample;
+        }>;
+      }
+
+      // Convert null to undefined for TypeScript compatibility
+      return {
+        data: {
+          affectedSamples: moveResult.data!.affectedSamples,
+          movedSample: moveResult.data!.movedSample,
+          replacedSample: moveResult.data!.replacedSample || undefined,
+        },
+        success: true,
+      };
+    } catch (error) {
+      return {
+        error: `Failed to move sample in kit: ${getErrorMessage(error)}`,
+        success: false,
+      };
+    }
+  }
+
+  private getDbPath(localStorePath: string): string {
+    return ServicePathManager.getDbPath(localStorePath);
+  }
+
+  private getLocalStorePath(
+    inMemorySettings: Record<string, unknown>,
+  ): null | string {
+    return ServicePathManager.getLocalStorePath(inMemorySettings);
+  }
+}
+
+// Export singleton instance
+export const sampleBatchOperationsService = new SampleBatchOperationsService();

--- a/electron/main/services/sampleValidation.ts
+++ b/electron/main/services/sampleValidation.ts
@@ -1,0 +1,175 @@
+import type { DbResult, Sample } from "@romper/shared/db/schema.js";
+
+import { getKitSamples } from "../db/romperDbCoreORM.js";
+import { sampleValidator } from "./validation/sampleValidator.js";
+
+/**
+ * Service for sample-specific validation operations
+ * Handles validation logic for sample operations, movement, and conflict detection
+ */
+export class SampleValidationService {
+  /**
+   * Check if sample exists in specified slot
+   */
+  checkSampleExists(
+    dbPath: string,
+    kitName: string,
+    voiceNumber: number,
+    slotNumber: number,
+  ): { exists: boolean; sample?: Sample } {
+    const existingSamplesResult = getKitSamples(dbPath, kitName);
+
+    if (!existingSamplesResult.success || !existingSamplesResult.data) {
+      return { exists: false };
+    }
+
+    const sample = existingSamplesResult.data.find(
+      (s) => s.voice_number === voiceNumber && s.slot_number === slotNumber,
+    );
+
+    return { exists: !!sample, sample };
+  }
+
+  /**
+   * Check for stereo conflicts when moving samples between kits
+   */
+  checkStereoConflicts(
+    sampleToMove: Sample,
+    toVoice: number,
+    toSlot: number,
+    destSamples: Sample[],
+    mode: "insert",
+    toKit: string,
+  ): { error?: string; hasConflict: boolean } {
+    return sampleValidator.checkStereoConflicts(
+      sampleToMove,
+      toVoice,
+      toSlot,
+      destSamples,
+      mode,
+      toKit,
+    );
+  }
+
+  /**
+   * Get destination kit samples and check for replacements
+   */
+  getDestinationSamplesAndReplacements(
+    dbPath: string,
+    toKit: string,
+    _toVoice: number,
+    _toSlot: number,
+    _mode: "insert",
+  ): { destSamples: Sample[]; replacedSample?: Sample } {
+    const destSamplesResult = getKitSamples(dbPath, toKit);
+    let destSamples: Sample[] = [];
+    let replacedSample: Sample | undefined;
+
+    if (destSamplesResult.success && destSamplesResult.data) {
+      destSamples = destSamplesResult.data;
+
+      // Insert-only mode: no samples are replaced
+    }
+
+    return { destSamples, replacedSample };
+  }
+
+  /**
+   * Validate and get sample to move for cross-kit operations
+   */
+  validateAndGetSampleToMove(
+    dbPath: string,
+    fromKit: string,
+    fromVoice: number,
+    fromSlot: number,
+  ): DbResult<Sample> {
+    const sourceSamplesResult = getKitSamples(dbPath, fromKit);
+    if (!sourceSamplesResult.success || !sourceSamplesResult.data) {
+      return { error: sourceSamplesResult.error, success: false };
+    }
+
+    const sampleToMove = sourceSamplesResult.data.find(
+      (s) => s.voice_number === fromVoice && s.slot_number === fromSlot,
+    );
+
+    if (!sampleToMove) {
+      return {
+        error: `No sample found in kit ${fromKit} at voice ${fromVoice}, slot ${fromSlot + 1}`,
+        success: false,
+      };
+    }
+
+    return { data: sampleToMove, success: true };
+  }
+
+  /**
+   * Validate sample file for adding to kit
+   */
+  validateSampleFile(filePath: string): { error?: string; isValid: boolean } {
+    return sampleValidator.validateSampleFile(filePath);
+  }
+
+  /**
+   * Validate sample movement parameters
+   */
+  validateSampleMovement(
+    fromVoice: number,
+    fromSlot: number,
+    toVoice: number,
+    toSlot: number,
+  ): DbResult<void> {
+    // Validate source voice and slot
+    const fromValidation = this.validateVoiceAndSlot(fromVoice, fromSlot);
+    if (!fromValidation.isValid) {
+      return { error: `Source ${fromValidation.error}`, success: false };
+    }
+
+    // Validate destination voice and slot
+    const toValidation = this.validateVoiceAndSlot(toVoice, toSlot);
+    if (!toValidation.isValid) {
+      return { error: `Destination ${toValidation.error}`, success: false };
+    }
+
+    // Cannot move to the same position
+    if (fromVoice === toVoice && fromSlot === toSlot) {
+      return {
+        error: "Cannot move sample to the same position",
+        success: false,
+      };
+    }
+
+    return { success: true };
+  }
+
+  /**
+   * Validate stereo sample constraints for movement
+   */
+  validateStereoSampleMove(
+    sampleToMove: Sample,
+    toVoice: number,
+    toSlot: number,
+    mode: "insert",
+    existingSamples: Sample[],
+  ): { error?: string; success: boolean } {
+    return sampleValidator.validateStereoSampleMove(
+      sampleToMove,
+      toVoice,
+      toSlot,
+      mode,
+      existingSamples,
+    );
+  }
+
+  /**
+   * Validate voice and slot parameters for sample operations
+   */
+  validateVoiceAndSlot(
+    voiceNumber: number,
+    slotNumber: number,
+  ): { error?: string; isValid: boolean } {
+    return sampleValidator.validateVoiceAndSlot(voiceNumber, slotNumber);
+  }
+}
+
+// Export singleton instance
+export const sampleValidationService = new SampleValidationService();

--- a/reports/architectural-assessment.md
+++ b/reports/architectural-assessment.md
@@ -1,6 +1,6 @@
 # Romper Architectural Assessment Report
 
-**Generated**: 2025-09-02T17:45:47.757Z
+**Generated**: 2025-09-03T05:39:11.260Z
 **Overall Health Score**: 0/100
 
 ## Executive Summary
@@ -9,8 +9,8 @@
 
 ### Key Metrics
 
-- **Total Files**: 199
-- **Total LOC**: 25,358
+- **Total Files**: 201
+- **Total LOC**: 25,564
 - **Average LOC/File**: 127
 - **Components**: 57
 - **Custom Hooks**: 67
@@ -18,14 +18,14 @@
 ## Critical Issues Requiring Attention
 
 ### CRITICAL: Lines of Code
-11 files exceed 300 LOC limit
+10 files exceed 300 LOC limit
 
 **Top Offenders:**
-- electron/main/services/crud/sampleCrudService.ts (467 LOC)
 - electron/main/db/operations/crudOperations.ts (466 LOC)
 - app/renderer/components/dialogs/SyncUpdateDialog.tsx (406 LOC)
 - app/renderer/components/hooks/voice-panels/useVoicePanelSlots.tsx (374 LOC)
 - app/renderer/components/dialogs/PreferencesDialog.tsx (371 LOC)
+- app/renderer/components/utils/databaseScanning.ts (342 LOC)
 
 ### HIGH: Component Complexity
 57 files with excessive complexity
@@ -51,9 +51,9 @@
 Break down files exceeding 300 LOC
 
 **Priority Files:**
-- electron/main/services/crud/sampleCrudService.ts
 - electron/main/db/operations/crudOperations.ts
 - app/renderer/components/dialogs/SyncUpdateDialog.tsx
+- app/renderer/components/hooks/voice-panels/useVoicePanelSlots.tsx
 **Impact**: Reduces maintenance burden and improves testability
 
 ### NEAR-TERM: Simplify component complexity
@@ -76,7 +76,7 @@ Add pre-commit hooks for LOC limits and complexity checks
 ## Health Score Breakdown
 
 Starting Score: 100
-LOC red flags: -110 (11 files >300 LOC)
+LOC red flags: -100 (10 files >300 LOC)
 Excessive complexity: -285 (57 files)
 
 **Final Score**: 0/100

--- a/reports/architectural-summary.json
+++ b/reports/architectural-summary.json
@@ -4,22 +4,22 @@
     "level": "POOR"
   },
   "codebase": {
-    "totalFiles": 199,
-    "totalLoc": 25358,
+    "totalFiles": 201,
+    "totalLoc": 25564,
     "avgLoc": 127,
     "components": 57,
     "hooks": 67
   },
   "criticalIssues": 1,
-  "redFlagFiles": 11,
+  "redFlagFiles": 10,
   "excessiveComplexity": 57,
   "topProblems": [
     {
       "category": "Lines of Code",
       "count": 5,
       "files": [
-        "electron/main/services/crud/sampleCrudService.ts (467 LOC)",
-        "electron/main/db/operations/crudOperations.ts (466 LOC)"
+        "electron/main/db/operations/crudOperations.ts (466 LOC)",
+        "app/renderer/components/dialogs/SyncUpdateDialog.tsx (406 LOC)"
       ]
     },
     {
@@ -43,9 +43,9 @@
     {
       "action": "Refactor oversized files",
       "files": [
-        "electron/main/services/crud/sampleCrudService.ts",
         "electron/main/db/operations/crudOperations.ts",
-        "app/renderer/components/dialogs/SyncUpdateDialog.tsx"
+        "app/renderer/components/dialogs/SyncUpdateDialog.tsx",
+        "app/renderer/components/hooks/voice-panels/useVoicePanelSlots.tsx"
       ]
     }
   ],

--- a/reports/complexity-analysis.json
+++ b/reports/complexity-analysis.json
@@ -2,8 +2,8 @@
   "healthScore": 0,
   "complexityDistribution": {
     "simple": 76,
-    "moderate": 43,
-    "complex": 39,
+    "moderate": 44,
+    "complex": 40,
     "excessive": 57
   },
   "mostComplex": [
@@ -224,33 +224,6 @@
       "overallComplexity": "excessive"
     },
     {
-      "path": "electron/main/services/crud/sampleCrudService.ts",
-      "isComponent": false,
-      "isHook": false,
-      "metrics": {
-        "props": {
-          "count": 0,
-          "complexity": "simple"
-        },
-        "hooks": {
-          "total": 0,
-          "unique": 0,
-          "complexity": "simple"
-        },
-        "conditionals": {
-          "count": 41,
-          "ternary": 0,
-          "logical": 8,
-          "complexity": "excessive"
-        },
-        "returns": {
-          "count": 2,
-          "complexity": "simple"
-        }
-      },
-      "overallComplexity": "excessive"
-    },
-    {
       "path": "app/renderer/components/SampleWaveform.tsx",
       "isComponent": true,
       "isHook": false,
@@ -273,6 +246,33 @@
         "returns": {
           "count": 1,
           "complexity": "simple"
+        }
+      },
+      "overallComplexity": "excessive"
+    },
+    {
+      "path": "app/renderer/components/hooks/kit-management/useKitDetailsLogic.ts",
+      "isComponent": false,
+      "isHook": true,
+      "metrics": {
+        "props": {
+          "count": 0,
+          "complexity": "simple"
+        },
+        "hooks": {
+          "total": 6,
+          "unique": 6,
+          "complexity": "moderate"
+        },
+        "conditionals": {
+          "count": 30,
+          "ternary": 1,
+          "logical": 7,
+          "complexity": "excessive"
+        },
+        "returns": {
+          "count": 23,
+          "complexity": "excessive"
         }
       },
       "overallComplexity": "excessive"
@@ -4668,17 +4668,17 @@
           "complexity": "simple"
         },
         "conditionals": {
-          "count": 41,
+          "count": 9,
           "ternary": 0,
-          "logical": 8,
-          "complexity": "excessive"
+          "logical": 0,
+          "complexity": "moderate"
         },
         "returns": {
           "count": 2,
           "complexity": "simple"
         }
       },
-      "overallComplexity": "excessive"
+      "overallComplexity": "moderate"
     },
     {
       "path": "electron/main/services/kitService.ts",
@@ -4789,6 +4789,33 @@
       "overallComplexity": "moderate"
     },
     {
+      "path": "electron/main/services/sampleBatchOperations.ts",
+      "isComponent": false,
+      "isHook": false,
+      "metrics": {
+        "props": {
+          "count": 0,
+          "complexity": "simple"
+        },
+        "hooks": {
+          "total": 0,
+          "unique": 0,
+          "complexity": "simple"
+        },
+        "conditionals": {
+          "count": 17,
+          "ternary": 0,
+          "logical": 1,
+          "complexity": "complex"
+        },
+        "returns": {
+          "count": 2,
+          "complexity": "simple"
+        }
+      },
+      "overallComplexity": "excessive"
+    },
+    {
       "path": "electron/main/services/sampleService.ts",
       "isComponent": false,
       "isHook": false,
@@ -4814,6 +4841,33 @@
         }
       },
       "overallComplexity": "simple"
+    },
+    {
+      "path": "electron/main/services/sampleValidation.ts",
+      "isComponent": false,
+      "isHook": false,
+      "metrics": {
+        "props": {
+          "count": 0,
+          "complexity": "simple"
+        },
+        "hooks": {
+          "total": 0,
+          "unique": 0,
+          "complexity": "simple"
+        },
+        "conditionals": {
+          "count": 11,
+          "ternary": 0,
+          "logical": 4,
+          "complexity": "complex"
+        },
+        "returns": {
+          "count": 2,
+          "complexity": "simple"
+        }
+      },
+      "overallComplexity": "complex"
     },
     {
       "path": "electron/main/services/scanService.ts",
@@ -6085,9 +6139,9 @@
       "overallComplexity": "simple"
     }
   ],
-  "timestamp": "2025-09-02T17:45:47.712Z",
+  "timestamp": "2025-09-03T05:39:11.221Z",
   "config": {
-    "rootDir": "/Users/pete/workspace/romper/worktrees/refactor-sync-service",
+    "rootDir": "/Users/pete/workspace/romper/worktrees/refactor-sample-crud",
     "thresholds": {
       "props": {
         "simple": 5,

--- a/reports/dependency-analysis.json
+++ b/reports/dependency-analysis.json
@@ -134,9 +134,9 @@
     },
     "totalViolations": 0
   },
-  "timestamp": "2025-09-02T17:45:47.035Z",
+  "timestamp": "2025-09-03T05:39:10.550Z",
   "config": {
-    "rootDir": "/Users/pete/workspace/romper/worktrees/refactor-sync-service",
+    "rootDir": "/Users/pete/workspace/romper/worktrees/refactor-sample-crud",
     "extensions": [
       ".ts",
       ".tsx"

--- a/reports/loc-analysis.json
+++ b/reports/loc-analysis.json
@@ -1136,8 +1136,8 @@
     },
     {
       "path": "electron/main/services/crud/sampleCrudService.ts",
-      "loc": 467,
-      "category": "redFlag",
+      "loc": 238,
+      "category": "large",
       "isComponent": false,
       "isHook": false
     },
@@ -1170,9 +1170,23 @@
       "isHook": false
     },
     {
+      "path": "electron/main/services/sampleBatchOperations.ts",
+      "loc": 284,
+      "category": "large",
+      "isComponent": false,
+      "isHook": false
+    },
+    {
       "path": "electron/main/services/sampleService.ts",
       "loc": 236,
       "category": "large",
+      "isComponent": false,
+      "isHook": false
+    },
+    {
+      "path": "electron/main/services/sampleValidation.ts",
+      "loc": 148,
+      "category": "medium",
       "isComponent": false,
       "isHook": false
     },
@@ -1206,7 +1220,7 @@
     },
     {
       "path": "electron/main/services/syncFileOperations.ts",
-      "loc": 220,
+      "loc": 226,
       "category": "large",
       "isComponent": false,
       "isHook": false
@@ -1220,7 +1234,7 @@
     },
     {
       "path": "electron/main/services/syncProgressManager.ts",
-      "loc": 165,
+      "loc": 164,
       "category": "medium",
       "isComponent": false,
       "isHook": false
@@ -1234,14 +1248,14 @@
     },
     {
       "path": "electron/main/services/syncSampleProcessing.ts",
-      "loc": 93,
+      "loc": 96,
       "category": "small",
       "isComponent": false,
       "isHook": false
     },
     {
       "path": "electron/main/services/syncService.ts",
-      "loc": 221,
+      "loc": 215,
       "category": "large",
       "isComponent": false,
       "isHook": false
@@ -1255,7 +1269,7 @@
     },
     {
       "path": "electron/main/services/syncValidationService.ts",
-      "loc": 172,
+      "loc": 173,
       "category": "medium",
       "isComponent": false,
       "isHook": false
@@ -2044,7 +2058,7 @@
       },
       {
         "path": "electron/main/services/syncSampleProcessing.ts",
-        "loc": 93,
+        "loc": 96,
         "category": "small",
         "isComponent": false,
         "isHook": false
@@ -2451,6 +2465,13 @@
         "isHook": false
       },
       {
+        "path": "electron/main/services/sampleValidation.ts",
+        "loc": 148,
+        "category": "medium",
+        "isComponent": false,
+        "isHook": false
+      },
+      {
         "path": "electron/main/services/slot/sampleSlotService.ts",
         "loc": 113,
         "category": "medium",
@@ -2459,7 +2480,7 @@
       },
       {
         "path": "electron/main/services/syncProgressManager.ts",
-        "loc": 165,
+        "loc": 164,
         "category": "medium",
         "isComponent": false,
         "isHook": false
@@ -2480,7 +2501,7 @@
       },
       {
         "path": "electron/main/services/syncValidationService.ts",
-        "loc": 172,
+        "loc": 173,
         "category": "medium",
         "isComponent": false,
         "isHook": false
@@ -2677,8 +2698,22 @@
         "isHook": false
       },
       {
+        "path": "electron/main/services/crud/sampleCrudService.ts",
+        "loc": 238,
+        "category": "large",
+        "isComponent": false,
+        "isHook": false
+      },
+      {
         "path": "electron/main/services/localStoreService.ts",
         "loc": 220,
+        "category": "large",
+        "isComponent": false,
+        "isHook": false
+      },
+      {
+        "path": "electron/main/services/sampleBatchOperations.ts",
+        "loc": 284,
         "category": "large",
         "isComponent": false,
         "isHook": false
@@ -2692,7 +2727,7 @@
       },
       {
         "path": "electron/main/services/syncFileOperations.ts",
-        "loc": 220,
+        "loc": 226,
         "category": "large",
         "isComponent": false,
         "isHook": false
@@ -2706,20 +2741,13 @@
       },
       {
         "path": "electron/main/services/syncService.ts",
-        "loc": 221,
+        "loc": 215,
         "category": "large",
         "isComponent": false,
         "isHook": false
       }
     ],
     "redFlag": [
-      {
-        "path": "electron/main/services/crud/sampleCrudService.ts",
-        "loc": 467,
-        "category": "redFlag",
-        "isComponent": false,
-        "isHook": false
-      },
       {
         "path": "electron/main/db/operations/crudOperations.ts",
         "loc": 466,
@@ -2802,8 +2830,8 @@
     ]
   },
   "stats": {
-    "totalFiles": 199,
-    "totalLines": 25358,
+    "totalFiles": 201,
+    "totalLines": 25564,
     "averageLines": 127
   }
 }


### PR DESCRIPTION
## Summary
refactor: extract sampleCrudService validation and batch operations

- Reduce sampleCrudService.ts from 567 LOC to 274 LOC (51% reduction)
- Extract sampleValidation.ts (174 LOC) for validation logic
- Extract sampleBatchOperations.ts (337 LOC) for batch operations
- Add comprehensive test coverage for extracted services
- Maintain 100% API compatibility and functionality
- Remove sampleCrudService from architectural red flags list

Addresses Task 1.2 from architectural refactoring roadmap

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed