### PR TITLE
refactor: extract SyncUpdateDialog types to separate file

### DIFF
--- a/app/renderer/components/dialogs/SyncUpdateDialog.tsx
+++ b/app/renderer/components/dialogs/SyncUpdateDialog.tsx
@@ -8,69 +8,12 @@ import {
   FiX,
 } from "react-icons/fi";
 
-export interface SyncChangeSummary {
-  fileCount: number;
-  kitCount: number;
-}
+import type {
+  SyncChangeSummary,
+  SyncProgress,
+  SyncUpdateDialogProps,
+} from "./SyncUpdateDialog.types.js";
 
-export interface SyncErrorDetails {
-  canRetry: boolean;
-  error: string;
-  fileName: string;
-  operation: "convert" | "copy";
-}
-
-export interface SyncFileOperation {
-  destinationPath: string;
-  filename: string;
-  operation: "convert" | "copy";
-  originalFormat?: string;
-  reason?: string;
-  sourcePath: string;
-  targetFormat?: string;
-}
-
-export interface SyncValidationError {
-  error: string;
-  filename: string;
-  sourcePath: string;
-  type: "access_denied" | "invalid_format" | "missing_file" | "other";
-}
-
-interface SyncProgress {
-  bytesCompleted: number;
-  currentFile: string;
-  error?: string;
-  errorDetails?: SyncErrorDetails;
-  filesCompleted: number;
-  status:
-    | "completed"
-    | "converting"
-    | "copying"
-    | "error"
-    | "finalizing"
-    | "preparing";
-  totalBytes: number;
-  totalFiles: number;
-}
-
-interface SyncUpdateDialogProps {
-  isLoading?: boolean;
-  isOpen: boolean;
-  kitName: string;
-  localChangeSummary: null | SyncChangeSummary;
-  onClose: () => void;
-  onConfirm: (options: {
-    sdCardPath: null | string;
-    wipeSdCard: boolean;
-  }) => void;
-  onGenerateChangeSummary?: (
-    sdCardPath: string,
-  ) => Promise<null | SyncChangeSummary>;
-  onSdCardPathChange?: (path: null | string) => void;
-  sdCardPath?: null | string;
-  syncProgress?: null | SyncProgress;
-}
 
 const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
   isLoading = false,

--- a/app/renderer/components/dialogs/SyncUpdateDialog.types.ts
+++ b/app/renderer/components/dialogs/SyncUpdateDialog.types.ts
@@ -1,0 +1,63 @@
+export interface SyncChangeSummary {
+  fileCount: number;
+  kitCount: number;
+}
+
+export interface SyncErrorDetails {
+  canRetry: boolean;
+  error: string;
+  fileName: string;
+  operation: "convert" | "copy";
+}
+
+export interface SyncFileOperation {
+  destinationPath: string;
+  filename: string;
+  operation: "convert" | "copy";
+  originalFormat?: string;
+  reason?: string;
+  sourcePath: string;
+  targetFormat?: string;
+}
+
+export interface SyncValidationError {
+  error: string;
+  filename: string;
+  sourcePath: string;
+  type: "access_denied" | "invalid_format" | "missing_file" | "other";
+}
+
+export interface SyncProgress {
+  bytesCompleted: number;
+  currentFile: string;
+  error?: string;
+  errorDetails?: SyncErrorDetails;
+  filesCompleted: number;
+  status:
+    | "completed"
+    | "converting"
+    | "copying"
+    | "error"
+    | "finalizing"
+    | "preparing";
+  totalBytes: number;
+  totalFiles: number;
+}
+
+export interface SyncUpdateDialogProps {
+  isLoading?: boolean;
+  isOpen: boolean;
+  kitName: string;
+  localChangeSummary: null | SyncChangeSummary;
+  onClose: () => void;
+  onConfirm: (options: {
+    sdCardPath: null | string;
+    wipeSdCard: boolean;
+  }) => void;
+  onGenerateChangeSummary?: (
+    sdCardPath: string,
+  ) => Promise<null | SyncChangeSummary>;
+  onSdCardPathChange?: (path: null | string) => void;
+  sdCardPath?: null | string;
+  syncProgress?: null | SyncProgress;
+}

--- a/app/renderer/components/hooks/kit-management/useKitSync.ts
+++ b/app/renderer/components/hooks/kit-management/useKitSync.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-import type { SyncChangeSummary } from "../../dialogs/SyncUpdateDialog";
+import type { SyncChangeSummary } from "../../dialogs/SyncUpdateDialog.types";
 
 import { useSyncUpdate } from "../shared/useSyncUpdate";
 

--- a/app/renderer/components/hooks/shared/useSyncUpdate.ts
+++ b/app/renderer/components/hooks/shared/useSyncUpdate.ts
@@ -1,4 +1,4 @@
-import type { SyncChangeSummary } from "@romper/app/renderer/components/dialogs/SyncUpdateDialog";
+import type { SyncChangeSummary } from "@romper/app/renderer/components/dialogs/SyncUpdateDialog.types";
 
 import { useCallback, useState } from "react";
 


### PR DESCRIPTION
## Summary
refactor: extract SyncUpdateDialog types to separate file

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed