### PR TITLE
fix: restore correct card height (90px) in kit browser

### DIFF
--- a/app/renderer/components/KitGridCard.tsx
+++ b/app/renderer/components/KitGridCard.tsx
@@ -19,7 +19,7 @@ interface KitGridCardProps {
   setFocus: (index: number) => void;
 }
 
-const CARD_HEIGHT = 180;
+const CARD_HEIGHT = 90;
 
 export const KitGridCard: React.FC<KitGridCardProps> = ({
   focusedIdx,


### PR DESCRIPTION
## Summary
fix: restore correct card height (90px) in kit browser

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed