### PR TITLE
fix: improve worktree exclusion pattern in dependency

### DIFF
--- a/reports/dependency-analysis.json
+++ b/reports/dependency-analysis.json
@@ -134,9 +134,9 @@
     },
     "totalViolations": 0
   },
-  "timestamp": "2025-09-03T05:39:10.550Z",
+  "timestamp": "2025-09-06T02:50:02.382Z",
   "config": {
-    "rootDir": "/Users/pete/workspace/romper/worktrees/refactor-sample-crud",
+    "rootDir": "/Users/pete/workspace/romper/worktrees/fix-dependency-analyzer-worktree-exclusion",
     "extensions": [
       ".ts",
       ".tsx"

--- a/scripts/architecture/analyze-dependencies.js
+++ b/scripts/architecture/analyze-dependencies.js
@@ -53,7 +53,7 @@ async function analyzeCircularDependencies() {
   try {
     const result = await madge(CONFIG.rootDir, {
       extensions: CONFIG.extensions,
-      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|worktrees)/,
+      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|\/worktrees\/|^worktrees\/)/,
       tsConfig: path.join(CONFIG.rootDir, 'tsconfig.json')
     });
     
@@ -84,7 +84,7 @@ async function analyzeDependencyDepth() {
   try {
     const result = await madge(CONFIG.rootDir, {
       extensions: CONFIG.extensions,
-      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|worktrees)/,
+      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|\/worktrees\/|^worktrees\/)/,
       tsConfig: path.join(CONFIG.rootDir, 'tsconfig.json')
     });
     
@@ -135,7 +135,7 @@ async function analyzeArchitecturalBoundaries() {
   try {
     const result = await madge(CONFIG.rootDir, {
       extensions: CONFIG.extensions,
-      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|worktrees)/,
+      excludePattern: /(__tests__|\.test\.|\.spec\.|node_modules|dist|coverage|\/worktrees\/|^worktrees\/)/,
       tsConfig: path.join(CONFIG.rootDir, 'tsconfig.json')
     });
     


### PR DESCRIPTION
## Summary
fix: improve worktree exclusion pattern in dependency analyzer

- Add more comprehensive regex patterns to exclude worktrees directory
- Use both /worktrees/ and ^worktrees/ patterns to catch all variations  
- Ensures dependency analysis works correctly from main directory
- Prevents false circular dependency detection from worktree files

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed