### PR TITLE
feat: improve marketing website for Rample owners

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,17 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Romper Sample Manager - Essential desktop app for your Squarp Rample</title>
-    <meta name="description" content="Organize, preview, and sync your sample kits for the Squarp Rample with this cross-platform desktop application.">
-    <meta property="og:title" content="Romper Sample Manager">
-    <meta property="og:description" content="The essential desktop app for your Squarp Rample">
+    <title>Romper - Sample Kit Manager for the Squarp Rample</title>
+    <meta name="description" content="Desktop app for managing sample kits on the Squarp Rample eurorack sampler. Browse 26 banks, audition 4 voices, drag in samples, sync to SD card.">
+    <meta property="og:title" content="Romper - Sample Kit Manager for the Squarp Rample">
+    <meta property="og:description" content="Browse 26 banks. Audition 4 voices. Drag in samples. Sync to SD card. Done.">
     <meta property="og:type" content="website">
+    <meta property="og:image" content="images/app-screenshot.png">
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" type="image/png" href="images/app-icon.png">
     <link rel="apple-touch-icon" href="images/app-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <noscript><style>.fade-in { opacity: 1 !important; transform: none !important; }</style></noscript>
 </head>
 <body>
     <header class="header">
@@ -37,13 +39,13 @@
             <div class="container">
                 <div class="hero-content">
                     <h1 class="hero-title">
-                        <span class="title-main">Romper Sample Manager</span>
+                        <span class="title-main">Romper</span>
                     </h1>
-                    <p class="hero-subtitle">The essential desktop app for your Squarp Rample</p>
+                    <p class="hero-subtitle">Sample kit manager for the Squarp Rample</p>
                     <p class="hero-description">
-                        Organize, preview, and sync your sample kits
+                        Browse 26 banks of kits. Audition all 4 voices. Drag in new samples. Sync to SD card. Done.
                     </p>
-                    
+
                     <div class="hero-cta">
                         <a href="https://github.com/peteb4ker/romper/releases" class="cta-button primary" id="download-btn">
                             Download for <span id="platform">Your Platform</span>
@@ -53,12 +55,21 @@
                         </a>
                     </div>
                 </div>
-                
+
                 <div class="hero-visual">
                     <div class="app-screenshot">
-                        <img src="images/app-screenshot.png" alt="Romper Sample Manager Application" class="screenshot-main">
+                        <img src="images/app-screenshot.png" alt="Romper showing the kit browser with 26 banks of sample kits" class="screenshot-main">
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <!-- Rample Context -->
+        <section class="rample-context">
+            <div class="container">
+                <p class="context-text">
+                    The <a href="https://squarp.net/rample" class="context-link">Squarp Rample</a> is a 4-voice eurorack sample player with 26 kit banks on an SD card. Managing the folder structure by hand is tedious and error-prone &mdash; Romper gives you a proper desktop interface for it.
+                </p>
             </div>
         </section>
 
@@ -66,64 +77,116 @@
         <section class="features">
             <div class="container">
                 <div class="features-grid">
-                    <div class="feature">
-                        <div class="feature-icon">🎵</div>
-                        <h3 class="feature-title">Smart Kit Management</h3>
+                    <div class="feature fade-in">
+                        <div class="feature-icon">
+                            <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="4" y="4" width="17" height="17" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <rect x="27" y="4" width="17" height="17" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <rect x="4" y="27" width="17" height="17" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <rect x="27" y="27" width="17" height="17" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <circle cx="12.5" cy="12.5" r="3" fill="currentColor"/>
+                                <circle cx="35.5" cy="12.5" r="3" fill="currentColor"/>
+                                <circle cx="12.5" cy="35.5" r="3" fill="currentColor"/>
+                                <circle cx="35.5" cy="35.5" r="3" fill="currentColor"/>
+                            </svg>
+                        </div>
+                        <h3 class="feature-title">All 26 Banks at a Glance</h3>
                         <p class="feature-description">
-                            Browse and organize your Rample kits with visual previews and custom labels for easy organization.
+                            See every kit across banks A&ndash;Z with 4 voice slots per card. Color-coded sync status shows you what's changed at a glance.
                         </p>
                     </div>
-                    
-                    <div class="feature">
-                        <div class="feature-icon">🔊</div>
-                        <h3 class="feature-title">Built-in Sample Preview</h3>
+
+                    <div class="feature fade-in">
+                        <div class="feature-icon">
+                            <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M8 36V12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <path d="M16 30V18" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <path d="M24 38V10" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <path d="M32 32V16" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <path d="M40 28V20" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+                                <circle cx="8" cy="12" r="3" fill="currentColor"/>
+                                <circle cx="16" cy="18" r="3" fill="currentColor"/>
+                                <circle cx="24" cy="10" r="3" fill="currentColor"/>
+                                <circle cx="32" cy="16" r="3" fill="currentColor"/>
+                                <circle cx="40" cy="20" r="3" fill="currentColor"/>
+                            </svg>
+                        </div>
+                        <h3 class="feature-title">Audition Before You Sync</h3>
                         <p class="feature-description">
-                            Audition samples before committing changes with built-in XOX sequencer for full kit previews.
+                            Play samples directly in the app. Use the built-in XOX step sequencer to hear all 4 voices together before committing to your SD card.
                         </p>
                     </div>
-                    
-                    <div class="feature">
-                        <div class="feature-icon">💾</div>
-                        <h3 class="feature-title">Safe SD Card Operations</h3>
+
+                    <div class="feature fade-in">
+                        <div class="feature-icon">
+                            <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="8" y="6" width="32" height="10" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <rect x="8" y="32" width="32" height="10" rx="3" stroke="currentColor" stroke-width="2.5"/>
+                                <path d="M24 16V32" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="4 4"/>
+                                <path d="M18 28L24 32L30 28" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                <circle cx="14" cy="11" r="2" fill="currentColor"/>
+                                <circle cx="14" cy="37" r="2" fill="currentColor"/>
+                            </svg>
+                        </div>
+                        <h3 class="feature-title">Drag, Drop, Done</h3>
                         <p class="feature-description">
-                            Non-destructive editing that preserves original SD card state. Restore from factory samples anytime.
+                            Drag .wav files onto voice slots. Romper handles folder naming, supports up to 12 layers per voice, and works with mono and stereo samples.
+                        </p>
+                    </div>
+
+                    <div class="feature fade-in">
+                        <div class="feature-icon">
+                            <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="12" y="6" width="24" height="32" rx="4" stroke="currentColor" stroke-width="2.5"/>
+                                <rect x="18" y="12" width="12" height="8" rx="2" stroke="currentColor" stroke-width="2"/>
+                                <line x1="18" y1="26" x2="30" y2="26" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                <line x1="18" y1="30" x2="26" y2="30" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                                <path d="M20 42L24 38L28 42" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+                            </svg>
+                        </div>
+                        <h3 class="feature-title">Safe SD Card Sync</h3>
+                        <p class="feature-description">
+                            Non-destructive reference-based editing. Samples only copy on sync. Automatic backup and validation keep your card safe.
                         </p>
                     </div>
                 </div>
             </div>
         </section>
+
+        <!-- Section Separator -->
+        <div class="section-separator"></div>
 
         <!-- How It Works Section -->
         <section class="how-it-works">
             <div class="container">
                 <h2 class="section-title">How It Works</h2>
                 <div class="steps">
-                    <div class="step">
+                    <div class="step fade-in">
                         <div class="step-number">1</div>
                         <div class="step-content">
-                            <h3 class="step-title">Bootstrap Your Library</h3>
+                            <h3 class="step-title">Point Romper at Your SD Card</h3>
                             <p class="step-description">
-                                Bootstrap the app from SD card, factory samples or a blank folder
+                                Romper reads the existing Rample folder structure and imports your kits automatically. Start from your current SD card, factory samples, or a blank library.
                             </p>
                         </div>
                     </div>
-                    
-                    <div class="step">
+
+                    <div class="step fade-in">
                         <div class="step-number">2</div>
                         <div class="step-content">
-                            <h3 class="step-title">Organize and Preview</h3>
+                            <h3 class="step-title">Build and Audition Kits</h3>
                             <p class="step-description">
-                                Organize and preview your samples using the built-in browser and sequencer
+                                Each kit has the familiar 4-voice layout with up to 12 sample slots per voice. Drag samples in, rearrange, and preview with the built-in step sequencer.
                             </p>
                         </div>
                     </div>
-                    
-                    <div class="step">
+
+                    <div class="step fade-in">
                         <div class="step-number">3</div>
                         <div class="step-content">
-                            <h3 class="step-title">Sync Safely</h3>
+                            <h3 class="step-title">Sync and Play</h3>
                             <p class="step-description">
-                                Sync changes safely to your device with automatic validation and backup
+                                Sync validates your kits, converts formats if needed, creates a backup, and writes to the SD card. Eject, slot it into your Rample, and go.
                             </p>
                         </div>
                     </div>
@@ -131,19 +194,39 @@
             </div>
         </section>
 
+        <!-- Section Separator -->
+        <div class="section-separator reverse"></div>
+
         <!-- Screenshots Section -->
         <section class="screenshots">
             <div class="container">
                 <h2 class="section-title">See It In Action</h2>
-                <div class="screenshot-grid">
-                    <div class="screenshot-item">
-                        <img src="images/app-screenshot.png" alt="Romper Sample Manager Main Interface" class="screenshot">
-                        <p class="screenshot-caption">Main Kit Browser and Sample Management</p>
+                <div class="screenshot-gallery">
+                    <div class="screenshot-item fade-in">
+                        <img src="images/app-screenshot.png" alt="Kit browser showing all 26 banks with color-coded sync status" class="screenshot">
+                        <p class="screenshot-caption">Kit browser &mdash; all 26 banks with sync status at a glance</p>
                     </div>
-                    <div class="screenshot-item">
-                        <img src="images/kit-details.png" alt="Kit Details View" class="screenshot">
-                        <p class="screenshot-caption">Kit Details and Voice Panel Editing</p>
+                    <div class="screenshot-item fade-in">
+                        <img src="images/kit-details.png" alt="Kit detail view showing 4 voice slots with sample layers" class="screenshot">
+                        <p class="screenshot-caption">Kit detail &mdash; 4 voice slots, sample layers, and built-in sequencer</p>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Latest Features Section -->
+        <section class="latest-features">
+            <div class="container">
+                <h2 class="section-title">Latest Features</h2>
+                <div class="feature-pills">
+                    <span class="pill">Stereo Samples</span>
+                    <span class="pill">XOX Step Sequencer</span>
+                    <span class="pill">Kit Editing</span>
+                    <span class="pill">Keyboard Shortcuts</span>
+                    <span class="pill">Dark &amp; Light Themes</span>
+                    <span class="pill">Non-Destructive Editing</span>
+                    <span class="pill">Factory Sample Import</span>
+                    <span class="pill">Cross-Platform</span>
                 </div>
             </div>
         </section>
@@ -154,19 +237,28 @@
                 <div class="download-content">
                     <h2 class="section-title">Download Romper</h2>
                     <p class="download-description">
-                        Cross-platform support for Windows, macOS, and Linux
+                        Free and open source. Available for macOS, Windows, and Linux.
                     </p>
-                    
+
                     <div class="download-buttons">
                         <a href="https://github.com/peteb4ker/romper/releases" class="download-btn">
                             <span class="download-platform">Latest Release</span>
                             <span class="download-note">All Platforms</span>
                         </a>
                     </div>
-                    
+
+                    <div class="user-docs">
+                        <h3 class="user-docs-title">User Guide</h3>
+                        <div class="user-docs-links">
+                            <a href="https://github.com/peteb4ker/romper/blob/main/docs/user/getting-started.md" class="doc-link">Getting Started</a>
+                            <a href="https://github.com/peteb4ker/romper/blob/main/docs/user/kit-browser.md" class="doc-link">Kit Browser</a>
+                            <a href="https://github.com/peteb4ker/romper/blob/main/docs/user/kit-details.md" class="doc-link">Kit Details</a>
+                            <a href="https://github.com/peteb4ker/romper/blob/main/docs/user/syncing.md" class="doc-link">Syncing</a>
+                            <a href="https://github.com/peteb4ker/romper/blob/main/docs/user/keyboard-shortcuts.md" class="doc-link">Keyboard Shortcuts</a>
+                        </div>
+                    </div>
+
                     <div class="download-links">
-                        <a href="https://github.com/peteb4ker/romper#-getting-started" class="download-link">Developer Guide</a>
-                        <span class="separator">•</span>
                         <a href="https://github.com/peteb4ker/romper" class="download-link">Source Code</a>
                         <span class="separator">•</span>
                         <a href="https://squarp.net/rample" class="download-link">About Squarp Rample</a>
@@ -185,7 +277,7 @@
                 <p class="footer-text">
                     <a href="https://github.com/peteb4ker/romper" class="footer-link">Open Source</a> • MIT License
                 </p>
-                <p class="footer-text" style="font-size: 0.85em; opacity: 0.8; margin-top: 0.5rem;">
+                <p class="footer-text footer-disclaimer">
                     Not affiliated with Squarp. This is an open source community project.
                 </p>
             </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,93 +1,44 @@
-// Platform detection and dynamic content
 document.addEventListener("DOMContentLoaded", function () {
-  // Detect user platform
-  const platform = detectPlatform();
-
-  // Update download button text
+  // Platform detection
   const platformSpan = document.getElementById("platform");
   if (platformSpan) {
-    platformSpan.textContent = platform;
+    platformSpan.textContent = detectPlatform();
   }
 
-  // Add smooth scrolling for anchor links
-  document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+  // Smooth scrolling for anchor links
+  document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
     anchor.addEventListener("click", function (e) {
       e.preventDefault();
-      const target = document.querySelector(this.getAttribute("href"));
+      var target = document.querySelector(this.getAttribute("href"));
       if (target) {
-        target.scrollIntoView({
-          behavior: "smooth",
-          block: "start",
-        });
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
       }
     });
   });
 
-  // Add loading states for external links
-  document.querySelectorAll('a[href^="https://github.com"]').forEach((link) => {
-    link.addEventListener("click", function () {
-      // Add subtle loading indication
-      this.style.opacity = "0.7";
-      setTimeout(() => {
-        this.style.opacity = "1";
-      }, 200);
-    });
+  // Fade-in animations via IntersectionObserver
+  var observer = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("visible");
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1, rootMargin: "0px 0px -40px 0px" }
+  );
+
+  document.querySelectorAll(".fade-in").forEach(function (el) {
+    observer.observe(el);
   });
-
-  // App screenshot is static - no animation needed
-
-  // Intersection Observer for fade-in animations
-  const observerOptions = {
-    threshold: 0.1,
-    rootMargin: "0px 0px -50px 0px",
-  };
-
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.style.opacity = "1";
-        entry.target.style.transform = "translateY(0)";
-      }
-    });
-  }, observerOptions);
-
-  // Observe sections for animations
-  document
-    .querySelectorAll(".feature, .step, .screenshot-item")
-    .forEach((el) => {
-      el.style.opacity = "0";
-      el.style.transform = "translateY(20px)";
-      el.style.transition = "opacity 0.6s ease, transform 0.6s ease";
-      observer.observe(el);
-    });
 });
 
 function detectPlatform() {
-  const userAgent = window.navigator.userAgent.toLowerCase();
-  const platform = window.navigator.platform.toLowerCase();
-
-  if (userAgent.includes("mac") || platform.includes("mac")) {
-    return "macOS";
-  } else if (userAgent.includes("win") || platform.includes("win")) {
-    return "Windows";
-  } else if (userAgent.includes("linux") || platform.includes("linux")) {
-    return "Linux";
-  } else {
-    return "Your Platform";
-  }
+  var ua = navigator.userAgent.toLowerCase();
+  var p = (navigator.platform || "").toLowerCase();
+  if (ua.includes("mac") || p.includes("mac")) return "macOS";
+  if (ua.includes("win") || p.includes("win")) return "Windows";
+  if (ua.includes("linux") || p.includes("linux")) return "Linux";
+  return "Your Platform";
 }
-
-// Terminal animation removed - using app screenshot instead
-
-// Add some easter eggs for developers
-console.log(`
-╭───────────────────────────────────────╮
-│  Welcome to Romper Sample Manager!   │
-│                                       │
-│  🎵 Built for Squarp Rample users    │
-│  🔊 Open source and cross-platform   │
-│  💾 Safe, non-destructive editing    │
-│                                       │
-│  GitHub: github.com/peteb4ker/romper  │
-╰───────────────────────────────────────╯
-`);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -14,6 +14,7 @@
     --text-muted: #656d76;
     --accent-purple: #8b5cf6;
     --accent-purple-hover: #7c3aed;
+    --accent-purple-glow: rgba(139, 92, 246, 0.3);
     --accent-blue: #58a6ff;
     --border-primary: #30363d;
     --border-secondary: #21262d;
@@ -25,6 +26,8 @@
 body {
     font-family: var(--font-sans);
     background-color: var(--bg-primary);
+    background-image: radial-gradient(circle, var(--border-secondary) 1px, transparent 1px);
+    background-size: 24px 24px;
     color: var(--text-primary);
     line-height: 1.6;
     min-height: 100vh;
@@ -35,6 +38,28 @@ body {
     margin: 0 auto;
     padding: 0 1.5rem;
 }
+
+/* Fade-in animation */
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Staggered animation delays for feature cards */
+.feature.fade-in:nth-child(1) { transition-delay: 0s; }
+.feature.fade-in:nth-child(2) { transition-delay: 0.1s; }
+.feature.fade-in:nth-child(3) { transition-delay: 0.2s; }
+.feature.fade-in:nth-child(4) { transition-delay: 0.3s; }
+
+.step.fade-in:nth-child(1) { transition-delay: 0s; }
+.step.fade-in:nth-child(2) { transition-delay: 0.15s; }
+.step.fade-in:nth-child(3) { transition-delay: 0.3s; }
 
 /* Header */
 .header {
@@ -91,6 +116,7 @@ body {
 .hero {
     padding: 6rem 0;
     background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+    background-image: none;
 }
 
 .hero-content {
@@ -105,7 +131,7 @@ body {
 
 .title-main {
     display: block;
-    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-size: clamp(3rem, 6vw, 5rem);
     font-weight: 700;
     background: linear-gradient(135deg, var(--text-primary) 0%, var(--accent-purple) 100%);
     background-clip: text;
@@ -125,7 +151,7 @@ body {
     font-size: 1.25rem;
     color: var(--text-secondary);
     margin-bottom: 3rem;
-    max-width: 600px;
+    max-width: 650px;
     margin-left: auto;
     margin-right: auto;
 }
@@ -178,14 +204,16 @@ body {
 
 /* App Screenshot */
 .hero-visual {
-    max-width: 800px;
+    max-width: 1000px;
     margin: 0 auto;
 }
 
 .app-screenshot {
     border-radius: 0.75rem;
     overflow: hidden;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    box-shadow:
+        0 20px 40px rgba(0, 0, 0, 0.3),
+        0 0 80px var(--accent-purple-glow);
     border: 1px solid var(--border-primary);
 }
 
@@ -196,17 +224,45 @@ body {
     background-color: var(--bg-tertiary);
 }
 
+/* Rample Context */
+.rample-context {
+    padding: 3rem 0;
+    background-color: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-primary);
+    background-image: none;
+}
+
+.context-text {
+    max-width: 700px;
+    margin: 0 auto;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.7;
+}
+
+.context-link {
+    color: var(--accent-purple);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.context-link:hover {
+    color: var(--text-primary);
+}
+
 /* Features Section */
 .features {
     padding: 6rem 0;
     background-color: var(--bg-secondary);
+    background-image: none;
 }
 
 .features-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 3rem;
-    margin-top: 3rem;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem;
 }
 
 .feature {
@@ -215,7 +271,7 @@ body {
     border-radius: 1rem;
     border: 1px solid var(--border-primary);
     text-align: center;
-    transition: transform 0.2s ease, border-color 0.2s ease;
+    transition: transform 0.2s ease, border-color 0.2s ease, opacity 0.6s ease;
 }
 
 .feature:hover {
@@ -224,12 +280,20 @@ body {
 }
 
 .feature-icon {
-    font-size: 3rem;
     margin-bottom: 1.5rem;
+    color: var(--accent-purple);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.feature-icon svg {
+    width: 48px;
+    height: 48px;
 }
 
 .feature-title {
-    font-size: 1.5rem;
+    font-size: 1.35rem;
     font-weight: 600;
     margin-bottom: 1rem;
     color: var(--text-primary);
@@ -238,6 +302,18 @@ body {
 .feature-description {
     color: var(--text-secondary);
     line-height: 1.7;
+}
+
+/* Section Separator */
+.section-separator {
+    height: 4px;
+    background: linear-gradient(90deg, transparent, var(--accent-purple), transparent);
+    opacity: 0.3;
+}
+
+.section-separator.reverse {
+    background: linear-gradient(90deg, transparent, var(--accent-purple), transparent);
+    opacity: 0.2;
 }
 
 /* How It Works Section */
@@ -257,7 +333,7 @@ body {
 .steps {
     display: flex;
     flex-direction: column;
-    gap: 3rem;
+    gap: 2rem;
     max-width: 800px;
     margin: 0 auto;
 }
@@ -270,6 +346,7 @@ body {
     background-color: var(--bg-secondary);
     border-radius: 1rem;
     border: 1px solid var(--border-primary);
+    transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
 .step-number {
@@ -288,7 +365,7 @@ body {
 }
 
 .step-title {
-    font-size: 1.5rem;
+    font-size: 1.35rem;
     font-weight: 600;
     margin-bottom: 0.5rem;
     color: var(--text-primary);
@@ -303,26 +380,31 @@ body {
 .screenshots {
     padding: 6rem 0;
     background-color: var(--bg-secondary);
+    background-image: none;
 }
 
-.screenshot-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+.screenshot-gallery {
+    display: flex;
+    flex-direction: column;
     gap: 3rem;
     margin-top: 3rem;
-    justify-items: center;
+    align-items: center;
 }
 
 .screenshot-item {
     text-align: center;
+    max-width: 1000px;
+    width: 100%;
 }
 
 .screenshot {
     max-width: 100%;
     height: auto;
-    border-radius: 1rem;
+    border-radius: 0.75rem;
     border: 1px solid var(--border-primary);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    box-shadow:
+        0 10px 30px rgba(0, 0, 0, 0.3),
+        0 0 60px var(--accent-purple-glow);
 }
 
 .screenshot-caption {
@@ -331,10 +413,43 @@ body {
     font-weight: 500;
 }
 
+/* Latest Features Section */
+.latest-features {
+    padding: 5rem 0;
+    background-color: var(--bg-primary);
+}
+
+.feature-pills {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.pill {
+    display: inline-block;
+    padding: 0.5rem 1.25rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: 2rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    font-weight: 500;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.pill:hover {
+    border-color: var(--accent-purple);
+    color: var(--text-primary);
+}
+
 /* Download Section */
 .download {
     padding: 6rem 0;
-    background-color: var(--bg-primary);
+    background-color: var(--bg-secondary);
+    background-image: none;
 }
 
 .download-content {
@@ -350,7 +465,7 @@ body {
 }
 
 .download-buttons {
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
 }
 
 .download-btn {
@@ -382,6 +497,43 @@ body {
     opacity: 0.8;
 }
 
+/* User Docs */
+.user-docs {
+    margin-bottom: 2.5rem;
+}
+
+.user-docs-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+}
+
+.user-docs-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.doc-link {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: 0.5rem;
+    color: var(--accent-blue);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.doc-link:hover {
+    border-color: var(--accent-purple);
+    color: var(--text-primary);
+}
+
 .download-links {
     display: flex;
     justify-content: center;
@@ -410,6 +562,7 @@ body {
     padding: 3rem 0;
     background-color: var(--bg-secondary);
     border-top: 1px solid var(--border-primary);
+    background-image: none;
 }
 
 .footer-content {
@@ -419,6 +572,12 @@ body {
 
 .footer-text {
     margin-bottom: 0.5rem;
+}
+
+.footer-disclaimer {
+    font-size: 0.85em;
+    opacity: 0.8;
+    margin-top: 0.5rem;
 }
 
 .footer-link {
@@ -436,56 +595,60 @@ body {
     .container {
         padding: 0 1rem;
     }
-    
+
     .hero {
         padding: 4rem 0;
     }
-    
+
     .hero-cta {
         flex-direction: column;
         align-items: center;
     }
-    
+
     .cta-button {
         width: 100%;
         max-width: 300px;
         justify-content: center;
     }
-    
+
     .features-grid {
         grid-template-columns: 1fr;
-        gap: 2rem;
+        gap: 1.5rem;
     }
-    
+
     .step {
         flex-direction: column;
         text-align: center;
     }
-    
+
     .step-number {
         margin: 0 auto 1rem;
     }
-    
+
     .download-links {
         flex-direction: column;
         gap: 0.5rem;
     }
-    
+
     .separator {
         display: none;
     }
-    
+
     .nav-links {
         gap: 1rem;
     }
-    
+
     .nav-link {
         font-size: 0.9rem;
     }
-    
+
     .hero-visual {
         max-width: 100%;
         margin: 2rem auto 0;
+    }
+
+    .user-docs-links {
+        gap: 0.5rem;
     }
 }
 
@@ -493,20 +656,29 @@ body {
     .hero-subtitle {
         font-size: 1.25rem;
     }
-    
+
     .hero-description {
         font-size: 1.1rem;
     }
-    
+
     .section-title {
         font-size: 2rem;
     }
-    
+
     .feature {
         padding: 2rem;
     }
-    
+
     .step {
         padding: 1.5rem;
+    }
+
+    .feature-pills {
+        gap: 0.5rem;
+    }
+
+    .pill {
+        font-size: 0.85rem;
+        padding: 0.4rem 1rem;
     }
 }


### PR DESCRIPTION
## Summary

- **Fix broken animations**: Fade-in observer was setting inline `opacity: 0` but often failing to trigger, leaving ~80% of the page invisible. Replaced with CSS class-based `.fade-in`/`.visible` toggling + `unobserve()` after reveal + `<noscript>` fallback
- **Rewrite all copy for Rample owners**: Hero, features (expanded from 3 to 4 cards), How It Works steps, and screenshot captions now use Rample-specific language (26 banks, 4 voices, SD card sync, XOX sequencer)
- **Visual improvements**: SVG icons replace emoji, purple glow on screenshots, dot-grid background texture, section separator gradients, staggered animation delays, hero screenshot expanded to 1000px max-width
- **Add new content**: Rample context blurb (SEO), "Latest Features" pill section, User Guide doc links in download section, updated meta tags with `og:image`
- **Simplify script.js**: 94 lines → 42 lines, removed console easter egg and inline style manipulation

## Test plan

- [ ] Open `https://peteb4ker.github.io/romper/` after deploy — all sections visible, animations fire on scroll
- [ ] Test with JS disabled — all content still visible (noscript fallback)
- [ ] Test responsive at 768px and 480px — layout stacks cleanly
- [ ] Verify all links work (GitHub releases, user docs, Squarp website)