### PR TITLE
perf: parallelize pre-commit and build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs/
 dist/
 build/
 out/
+*.tsbuildinfo
 
 # Dependency directories
 .DS_Store

--- a/electron/preload/tsconfig.preload.json
+++ b/electron/preload/tsconfig.preload.json
@@ -12,6 +12,7 @@
     "module": "CommonJS",
     "outDir": "../../dist/",
     "target": "ES2020",
+    "incremental": false,
     "typeRoots": ["../../electron/types", "../../node_modules/@types"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "main": "dist/electron/main/index.js",
   "scripts": {
-    "build": "npm run build:main && npm run build:preload && npm run build:renderer",
+    "build": "concurrently -n main,preload,renderer \"npm run build:main\" \"npm run build:preload\" \"npm run build:renderer\"",
     "build:main": "vite build --config vite.main.config.ts",
     "build:preload": "tsc -p electron/preload/tsconfig.preload.json && mv dist/electron/preload/index.js dist/electron/preload/index.cjs",
     "build:renderer": "vite build --config vite.config.ts",
@@ -38,7 +38,7 @@
     "db:studio": "drizzle-kit studio",
     "typecheck": "tsc --noEmit",
     "check-test-coverage": "node scripts/check-test-coverage.js",
-    "pre-commit": "npm run typecheck && npm run lint:check && npm run test:husky && npm run build",
+    "pre-commit": "concurrently --kill-others-on-fail -n tsc,lint,test,build \"npm run typecheck\" \"npm run lint:check\" \"npm run test:husky\" \"npm run build\"",
     "test:husky": "npm run test:unit:husky && npm run test:integration:husky",
     "test:unit:husky": "NO_COLOR=true npm run test:unit:fast",
     "test:integration:husky": "NO_COLOR=true npm run test:integration:fast",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "rootDir": ".",
     "esModuleInterop": true,
     "strict": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,9 +83,9 @@ export default defineConfig({
       pool: "threads",
       poolOptions: {
         threads: {
-          // Use more threads in CI for faster execution
-          maxThreads: isCI ? 4 : 2,
+          maxThreads: isCI ? 8 : 2,
           minThreads: isCI ? 2 : 1,
+          useAtomics: true,
         },
       },
       // Optimized reporters for CI


### PR DESCRIPTION
## Summary
- Run typecheck, lint, tests, and build **concurrently** in pre-commit hook instead of sequentially
- Parallelize `build:main`, `build:preload`, and `build:renderer` using concurrently
- Enable TypeScript **incremental compilation** (`incremental: true` + `.tsbuildinfo` cache) for faster repeated typechecks
- Increase CI test thread pool from 4 to 8 and enable `useAtomics` for better thread synchronization

## Test plan
- [x] Parallel build produces correct output (`npm run build`)
- [x] Parallel pre-commit passes all checks (typecheck, lint, 2914 unit + 125 integration tests, build)
- [x] Incremental tsc doesn't conflict with preload build (disabled incremental in preload tsconfig)
- [ ] CI passes on all platforms