### PR TITLE
feat: redesign kit cards with hardware panel aesthetic

### DIFF
--- a/app/renderer/components/KitGridCard.tsx
+++ b/app/renderer/components/KitGridCard.tsx
@@ -19,7 +19,7 @@ interface KitGridCardProps {
   setFocus: (index: number) => void;
 }
 
-const CARD_HEIGHT = 90;
+const CARD_HEIGHT = 104;
 
 export const KitGridCard: React.FC<KitGridCardProps> = ({
   focusedIdx,

--- a/app/renderer/components/KitGridItem.tsx
+++ b/app/renderer/components/KitGridItem.tsx
@@ -1,4 +1,4 @@
-import { Copy, Star } from "@phosphor-icons/react";
+import { Copy, FileAudio, MusicNote, Star, Tag } from "@phosphor-icons/react";
 import { toCapitalCase } from "@romper/shared/kitUtilsShared";
 import React from "react";
 
@@ -12,7 +12,66 @@ import {
 
 interface KitGridItemProps extends BaseKitItemProps {}
 
-// Add ref forwarding and selection props
+type KitState = "editable" | "factory" | "invalid" | "modified";
+
+const LED_STYLES: Record<
+  KitState,
+  { bg: string; border: string; dot: string }
+> = {
+  editable: {
+    bg: "bg-surface-1",
+    border: "border-border-subtle",
+    dot: "bg-accent-success shadow-[0_0_4px_var(--accent-success)]",
+  },
+  factory: {
+    bg: "bg-surface-1",
+    border: "border-border-subtle",
+    dot: "bg-text-tertiary opacity-40",
+  },
+  invalid: {
+    bg: "bg-accent-danger/5 opacity-70",
+    border: "border-accent-danger/40",
+    dot: "bg-accent-danger shadow-[0_0_4px_var(--accent-danger)]",
+  },
+  modified: {
+    bg: "bg-accent-warning/3",
+    border: "border-accent-warning/40",
+    dot: "bg-accent-warning shadow-[0_0_4px_var(--accent-warning)] animate-[led-pulse_2s_ease-in-out_infinite]",
+  },
+};
+
+const getKitState = (
+  isValid: boolean,
+  kitData?: { editable?: boolean; modified_since_sync?: boolean } | null,
+): KitState => {
+  if (!isValid) return "invalid";
+  if (kitData?.modified_since_sync) return "modified";
+  if (kitData?.editable) return "editable";
+  return "factory";
+};
+
+const getVoiceLedStyle = (count: number) => {
+  if (count === 0) {
+    return {
+      dot: "bg-accent-danger shadow-[0_0_3px_var(--accent-danger)]",
+      text: "text-accent-danger",
+      weight: "",
+    };
+  }
+  if (count === 12) {
+    return {
+      dot: "bg-accent-success shadow-[0_0_4px_var(--accent-success)]",
+      text: "text-accent-success",
+      weight: "font-bold",
+    };
+  }
+  return {
+    dot: "bg-accent-primary shadow-[0_0_3px_var(--accent-primary)]",
+    text: "text-accent-primary",
+    weight: "",
+  };
+};
+
 const KitGridItem = React.memo(
   React.forwardRef<HTMLDivElement, KitGridItemProps & KitItemRenderProps>(
     (
@@ -30,72 +89,17 @@ const KitGridItem = React.memo(
       },
       ref,
     ) => {
-      // Extract voice names using shared utility
       const voiceNames = extractVoiceNames(kitData);
-
       const { iconLabel, iconType } = useKitItem(voiceNames);
-
-      // Use shared icon renderer with medium size for grid view
       const icon = <KitIconRenderer iconType={iconType} size="md" />;
-
-      // Use direct prop value or fallback to kit data
       const isFavorite = isFavoriteProp ?? kitData?.is_favorite ?? false;
+      const kitState = getKitState(isValid, kitData);
+      const styles = LED_STYLES[kitState];
 
-      // Kit type visual identification borders and backgrounds
-      const getKitTypeStyles = () => {
-        if (!isValid) {
-          return {
-            background: "bg-accent-danger/5",
-            border: "border-l-4 border-l-accent-danger",
-          };
-        }
-
-        // Check if kit has unsaved changes (modified since sync)
-        if (kitData?.modified_since_sync) {
-          return {
-            background: "bg-accent-warning/5",
-            border: "border-l-4 border-l-accent-warning",
-          };
-        }
-
-        // Check if kit is editable (user-created)
-        if (kitData?.editable) {
-          return {
-            background: "bg-accent-success/5",
-            border: "border-l-4 border-l-accent-success",
-          };
-        }
-
-        // Factory kits (read-only baseline)
-        return {
-          background: "bg-surface-2",
-          border: "border-l-4 border-l-border-strong",
-        };
-      };
-
-      const kitTypeStyles = getKitTypeStyles();
-
-      // Task 20.2.1: Determine if kit is high priority
-      const isHighPriority = () => {
-        if (!isValid || !kitData) return false;
-
-        // High priority conditions:
-        // 1. Favorite kits (user marked as important)
-        // 2. Modified kits with unsaved changes (need attention)
-        // 3. Well-loaded kits (high sample count across voices - useful for performance)
-        const wellLoaded =
-          sampleCounts &&
-          sampleCounts.filter((count) => count >= 8).length >= 2;
-
-        return kitData.is_favorite || kitData.modified_since_sync || wellLoaded;
-      };
-
-      // Selection highlighting
       const selectedHighlight = isSelected
-        ? "ring-2 ring-accent-primary border-accent-primary bg-accent-primary/10"
+        ? "ring-2 ring-accent-primary border-accent-primary bg-accent-primary/8"
         : "";
 
-      // Calculate sample count for aria-label
       const totalSamples =
         (sampleCounts?.[0] || 0) +
         (sampleCounts?.[1] || 0) +
@@ -104,16 +108,13 @@ const KitGridItem = React.memo(
       const statusText = !isValid ? "Invalid kit" : `${totalSamples} samples`;
       const ariaLabel = `Kit ${kit} - ${statusText}`;
 
-      // vertical card layout with optimized spacing
       return (
         <div
           aria-label={ariaLabel}
           aria-selected={isSelected ? "true" : "false"}
-          className={`relative flex flex-col justify-between p-2 rounded border text-sm h-full w-full ${kitTypeStyles.border} ${kitTypeStyles.background} ${
-            isValid
-              ? "border-border-subtle hover:brightness-95 dark:hover:brightness-110"
-              : "border-accent-danger"
-          } cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary ${selectedHighlight}`}
+          className={`relative flex flex-col justify-between p-2 rounded-md border text-sm h-full w-full ${styles.border} ${styles.bg} ${
+            kitState === "invalid" ? "cursor-not-allowed" : ""
+          } cursor-pointer hover:bg-surface-2 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary ${selectedHighlight}`}
           data-kit={kit}
           data-testid={`kit-item-${kit}`}
           onClick={onSelect}
@@ -128,20 +129,20 @@ const KitGridItem = React.memo(
           tabIndex={isSelected ? 0 : -1}
           {...rest}
         >
-          {/* Task 20.2.1: High priority indicator */}
-          {isHighPriority() && (
-            <div
-              className="absolute top-1 left-1 w-2 h-2 bg-accent-warning rounded-full shadow-sm border border-accent-warning/80"
-              title="High priority kit (favorite, modified, or well-loaded)"
-            />
-          )}
-          {/* Top row: icon, kit name, status badges */}
+          {/* Top row: icon with LED, kit name, badges, actions */}
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span title={iconLabel}>{icon}</span>
+              {/* Icon with state LED overlay */}
+              <span className="relative" title={iconLabel}>
+                {icon}
+                <span
+                  className={`absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full ${styles.dot}`}
+                  data-testid="state-led"
+                />
+              </span>
               <div className="flex flex-col flex-1 min-w-0">
                 <span
-                  className={`font-mono text-sm truncate ${
+                  className={`font-mono text-sm font-semibold tracking-wide truncate ${
                     isValid ? "text-text-primary" : "text-accent-danger"
                   }`}
                 >
@@ -158,48 +159,47 @@ const KitGridItem = React.memo(
               </div>
             </div>
 
-            {/* Search match indicators - compact badges */}
+            {/* MOD badge for modified state */}
+            {kitState === "modified" && (
+              <span
+                className="px-1.5 py-0.5 text-[10px] font-mono font-medium uppercase tracking-wider text-accent-warning bg-accent-warning/15 rounded border border-accent-warning/30"
+                data-testid="mod-badge"
+              >
+                MOD
+              </span>
+            )}
+
+            {/* Search match indicators */}
             {isValid && kitData?.searchMatch && (
-              <div className="flex flex-wrap gap-1 mt-1">
+              <div className="flex flex-wrap gap-1 ml-1">
                 {kitData.searchMatch.matchedSamples.length > 0 && (
                   <span
-                    className="px-1 py-0.5 text-xs bg-accent-success/15 text-accent-success rounded border border-accent-success/30 font-mono truncate max-w-full cursor-help"
+                    className="px-1 py-0.5 text-xs bg-accent-success/15 text-accent-success rounded border border-accent-success/30 font-mono truncate max-w-full cursor-help inline-flex items-center gap-0.5"
                     title={`Sample matches:\n${kitData.searchMatch.matchedSamples.join("\n")}`}
                   >
-                    📄
+                    <FileAudio data-testid="icon-file-audio" size={12} />
                     {kitData.searchMatch.matchedSamples.length > 1
                       ? ` ${kitData.searchMatch.matchedSamples.length}`
                       : ""}
                   </span>
                 )}
                 {kitData.searchMatch.matchedArtist && (
-                  <span className="px-1 py-0.5 text-xs bg-voice-3-muted text-voice-3 rounded border border-voice-3/30 font-mono truncate">
-                    🎵 {kitData.searchMatch.matchedArtist}
+                  <span className="px-1 py-0.5 text-xs bg-voice-3-muted text-voice-3 rounded border border-voice-3/30 font-mono truncate inline-flex items-center gap-0.5">
+                    <MusicNote data-testid="icon-music-note" size={12} />{" "}
+                    {kitData.searchMatch.matchedArtist}
                   </span>
                 )}
                 {kitData.searchMatch.matchedAlias && (
-                  <span className="px-1 py-0.5 text-xs bg-accent-primary/15 text-accent-primary rounded border border-accent-primary/30 font-mono truncate">
-                    🏷️ {kitData.searchMatch.matchedAlias}
+                  <span className="px-1 py-0.5 text-xs bg-accent-primary/15 text-accent-primary rounded border border-accent-primary/30 font-mono truncate inline-flex items-center gap-0.5">
+                    <Tag data-testid="icon-tag" size={12} />{" "}
+                    {kitData.searchMatch.matchedAlias}
                   </span>
                 )}
               </div>
             )}
 
-            {/* Enhanced Status indicators */}
+            {/* Actions */}
             <div className="flex items-center gap-1">
-              {isValid && kitData?.modified_since_sync && (
-                <span className="px-1.5 py-0.5 text-xs font-medium bg-accent-warning/15 text-accent-warning rounded border border-accent-warning/30">
-                  Unsaved
-                </span>
-              )}
-              {isValid &&
-                kitData?.editable &&
-                !kitData?.modified_since_sync && (
-                  <span className="px-1.5 py-0.5 text-xs font-medium bg-accent-success/15 text-accent-success rounded border border-accent-success/30">
-                    Editable
-                  </span>
-                )}
-              {/* Favorite toggle button */}
               {onToggleFavorite && (
                 <button
                   className={`p-1 text-xs ml-1 transition-colors duration-150 ${
@@ -238,55 +238,50 @@ const KitGridItem = React.memo(
             </div>
           </div>
 
-          {/* Voice indicators: Unified voice names and sample counts */}
+          {/* Voice channel strip */}
           {isValid && sampleCounts && (
-            <div className="flex items-end gap-1 w-full">
-              {sampleCounts.map((count, idx) => {
-                const voiceNumber = idx + 1;
-                const voiceName = voiceNames?.[voiceNumber];
+            <>
+              <div className="border-t border-border-subtle mt-1.5 mb-1" />
+              <div className="flex items-end gap-1 w-full">
+                {sampleCounts.map((count, idx) => {
+                  const voiceNumber = idx + 1;
+                  const voiceName = voiceNames?.[voiceNumber];
+                  const voiceDisplayName =
+                    typeof voiceName === "string"
+                      ? toCapitalCase(voiceName)
+                      : voiceName;
+                  const ledStyle = getVoiceLedStyle(count);
 
-                // Color coding for sample counts
-                let color = "";
-                let fontWeight = "";
-                if (count === 0) {
-                  color =
-                    "bg-accent-danger/20 text-accent-danger border border-accent-danger/30";
-                } else if (count === 12) {
-                  color =
-                    "bg-accent-success/30 text-accent-success border border-accent-success/40";
-                  fontWeight = "font-bold";
-                } else {
-                  color =
-                    "bg-accent-primary/20 text-accent-primary border border-accent-primary/30";
-                }
-
-                // Unified label: voice name + count, or just count
-                const voiceDisplayName =
-                  typeof voiceName === "string"
-                    ? toCapitalCase(voiceName)
-                    : voiceName;
-                const displayText = voiceName
-                  ? `${voiceDisplayName} ${count}`
-                  : count.toString();
-
-                return (
-                  <div
-                    className="w-1/4 flex justify-center"
-                    key={`voice-${voiceNumber}`}
-                    title={
-                      `Voice ${voiceNumber}: ${count} samples` +
-                      (voiceName ? ` (${voiceName})` : "")
-                    }
-                  >
-                    <span
-                      className={`px-1 py-1 rounded text-xs font-mono ${color} ${fontWeight} text-center truncate w-full max-w-full`}
+                  return (
+                    <div
+                      className="w-1/4 flex flex-col items-center gap-0.5"
+                      key={`voice-${voiceNumber}`}
+                      title={
+                        `Voice ${voiceNumber}: ${count} samples` +
+                        (voiceName ? ` (${voiceName})` : "")
+                      }
                     >
-                      {displayText}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
+                      {voiceDisplayName && (
+                        <span className="text-[10px] text-text-secondary font-mono truncate w-full text-center">
+                          {voiceDisplayName}
+                        </span>
+                      )}
+                      <div className="flex items-center gap-1">
+                        <span
+                          className={`w-1.5 h-1.5 rounded-full ${ledStyle.dot}`}
+                          data-testid={`voice-led-${voiceNumber}`}
+                        />
+                        <span
+                          className={`text-xs font-mono ${ledStyle.text} ${ledStyle.weight}`}
+                        >
+                          {count}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
           )}
         </div>
       );

--- a/app/renderer/components/__tests__/KitGridCard.test.tsx
+++ b/app/renderer/components/__tests__/KitGridCard.test.tsx
@@ -84,7 +84,7 @@ describe("KitGridCard", () => {
       const wrapper = container.firstChild as HTMLElement;
       expect(wrapper).toBeInTheDocument();
       expect(wrapper.tagName).toBe("DIV");
-      expect(wrapper.style.height).toBe("90px");
+      expect(wrapper.style.height).toBe("104px");
     });
 
     it("renders the KitGridItem child", () => {

--- a/app/renderer/components/__tests__/KitGridItem.test.tsx
+++ b/app/renderer/components/__tests__/KitGridItem.test.tsx
@@ -83,16 +83,31 @@ describe("KitGridItem", () => {
     });
   });
 
-  describe("Kit type styling", () => {
-    it("applies invalid kit styling when isValid is false", () => {
+  describe("Kit state LED indicators", () => {
+    it("renders state LED dot", () => {
+      render(<KitGridItem {...defaultProps} />);
+
+      expect(screen.getByTestId("state-led")).toBeInTheDocument();
+    });
+
+    it("applies factory state styling for read-only kits", () => {
+      render(<KitGridItem {...defaultProps} />);
+
+      const container = screen.getByTestId("kit-item-A0");
+      expect(container).toHaveClass("border-border-subtle", "bg-surface-1");
+      expect(container).not.toHaveClass("border-accent-warning/40");
+    });
+
+    it("applies invalid state styling when isValid is false", () => {
       render(<KitGridItem {...defaultProps} isValid={false} />);
 
       const container = screen.getByTestId("kit-item-A0");
-      expect(container).toHaveClass("border-l-4", "border-l-accent-danger");
-      expect(container).toHaveClass("border-accent-danger");
+      expect(container).toHaveClass("border-accent-danger/40", "opacity-70");
+      const led = screen.getByTestId("state-led");
+      expect(led).toHaveClass("bg-accent-danger");
     });
 
-    it("applies unsaved changes styling when modified_since_sync is true", () => {
+    it("applies modified state styling when modified_since_sync is true", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -103,10 +118,12 @@ describe("KitGridItem", () => {
       render(<KitGridItem {...props} />);
 
       const container = screen.getByTestId("kit-item-A0");
-      expect(container).toHaveClass("border-l-4", "border-l-accent-warning");
+      expect(container).toHaveClass("border-accent-warning/40");
+      const led = screen.getByTestId("state-led");
+      expect(led).toHaveClass("bg-accent-warning");
     });
 
-    it("applies editable kit styling when editable is true", () => {
+    it("applies editable state styling when editable is true", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -117,14 +134,9 @@ describe("KitGridItem", () => {
       render(<KitGridItem {...props} />);
 
       const container = screen.getByTestId("kit-item-A0");
-      expect(container).toHaveClass("border-l-4", "border-l-accent-success");
-    });
-
-    it("applies factory kit styling for read-only kits", () => {
-      render(<KitGridItem {...defaultProps} />);
-
-      const container = screen.getByTestId("kit-item-A0");
-      expect(container).toHaveClass("border-l-4", "border-l-border-strong");
+      expect(container).toHaveClass("border-border-subtle");
+      const led = screen.getByTestId("state-led");
+      expect(led).toHaveClass("bg-accent-success");
     });
   });
 
@@ -148,86 +160,8 @@ describe("KitGridItem", () => {
     });
   });
 
-  describe("High priority indicator", () => {
-    it("shows high priority indicator for favorite kits", () => {
-      const props = {
-        ...defaultProps,
-        kitData: {
-          ...defaultProps.kitData,
-          is_favorite: true,
-        },
-      };
-      render(<KitGridItem {...props} />);
-
-      const indicator = screen.getByTitle(
-        "High priority kit (favorite, modified, or well-loaded)",
-      );
-      expect(indicator).toBeInTheDocument();
-      expect(indicator).toHaveClass("bg-accent-warning");
-    });
-
-    it("shows high priority indicator for modified kits", () => {
-      const props = {
-        ...defaultProps,
-        kitData: {
-          ...defaultProps.kitData,
-          modified_since_sync: true,
-        },
-      };
-      render(<KitGridItem {...props} />);
-
-      expect(
-        screen.getByTitle(
-          "High priority kit (favorite, modified, or well-loaded)",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("shows high priority indicator for well-loaded kits", () => {
-      const props = {
-        ...defaultProps,
-        sampleCounts: [8, 9, 10, 12], // Two voices with >= 8 samples
-      };
-      render(<KitGridItem {...props} />);
-
-      expect(
-        screen.getByTitle(
-          "High priority kit (favorite, modified, or well-loaded)",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("does not show high priority indicator for regular kits", () => {
-      render(<KitGridItem {...defaultProps} />);
-
-      expect(
-        screen.queryByTitle(
-          "High priority kit (favorite, modified, or well-loaded)",
-        ),
-      ).not.toBeInTheDocument();
-    });
-
-    it("does not show high priority indicator for invalid kits", () => {
-      const props = {
-        ...defaultProps,
-        isValid: false,
-        kitData: {
-          ...defaultProps.kitData,
-          is_favorite: true, // Should be ignored for invalid kits
-        },
-      };
-      render(<KitGridItem {...props} />);
-
-      expect(
-        screen.queryByTitle(
-          "High priority kit (favorite, modified, or well-loaded)",
-        ),
-      ).not.toBeInTheDocument();
-    });
-  });
-
   describe("Status badges", () => {
-    it("shows unsaved badge when modified_since_sync is true", () => {
+    it("shows MOD badge when modified_since_sync is true", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -237,10 +171,11 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      expect(screen.getByText("Unsaved")).toBeInTheDocument();
+      expect(screen.getByTestId("mod-badge")).toBeInTheDocument();
+      expect(screen.getByText("MOD")).toBeInTheDocument();
     });
 
-    it("shows editable badge when editable and not modified", () => {
+    it("does not show MOD badge for editable kits without modifications", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -251,25 +186,16 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      expect(screen.getByText("Editable")).toBeInTheDocument();
+      expect(screen.queryByTestId("mod-badge")).not.toBeInTheDocument();
     });
 
-    it("prioritizes unsaved badge over editable badge", () => {
-      const props = {
-        ...defaultProps,
-        kitData: {
-          ...defaultProps.kitData,
-          editable: true,
-          modified_since_sync: true,
-        },
-      };
-      render(<KitGridItem {...props} />);
+    it("does not show MOD badge for factory kits", () => {
+      render(<KitGridItem {...defaultProps} />);
 
-      expect(screen.getByText("Unsaved")).toBeInTheDocument();
-      expect(screen.queryByText("Editable")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("mod-badge")).not.toBeInTheDocument();
     });
 
-    it("does not show badges for invalid kits", () => {
+    it("does not show MOD badge for invalid kits", () => {
       const props = {
         ...defaultProps,
         isValid: false,
@@ -281,8 +207,7 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      expect(screen.queryByText("Unsaved")).not.toBeInTheDocument();
-      expect(screen.queryByText("Editable")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("mod-badge")).not.toBeInTheDocument();
     });
   });
 
@@ -376,16 +301,15 @@ describe("KitGridItem", () => {
       const mockOnToggleFavorite = vi.fn();
       const props = {
         ...defaultProps,
-        isFavorite: true, // but prop says it is favorite
+        isFavorite: true,
         kitData: {
           ...defaultProps.kitData,
-          is_favorite: false, // kitData says not favorite
+          is_favorite: false,
         },
         onToggleFavorite: mockOnToggleFavorite,
       };
       render(<KitGridItem {...props} />);
 
-      // Should show as favorited (using prop value)
       const favoriteButton = screen.getByTitle("Remove from favorites");
       expect(favoriteButton).toBeInTheDocument();
       expect(favoriteButton).toHaveClass("text-accent-warning");
@@ -395,7 +319,7 @@ describe("KitGridItem", () => {
       const mockOnToggleFavorite = vi.fn();
       const props = {
         ...defaultProps,
-        isFavorite: undefined, // No prop value provided
+        isFavorite: undefined,
         kitData: {
           ...defaultProps.kitData,
           is_favorite: true,
@@ -404,7 +328,6 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      // Should fall back to kitData value
       const favoriteButton = screen.getByTitle("Remove from favorites");
       expect(favoriteButton).toBeInTheDocument();
       expect(favoriteButton).toHaveClass("text-accent-warning");
@@ -414,13 +337,12 @@ describe("KitGridItem", () => {
       const mockOnToggleFavorite = vi.fn();
       const props = {
         ...defaultProps,
-        isFavorite: undefined, // No prop value
-        kitData: undefined, // No kitData
+        isFavorite: undefined,
+        kitData: undefined,
         onToggleFavorite: mockOnToggleFavorite,
       };
       render(<KitGridItem {...props} />);
 
-      // Should default to not favorited
       const favoriteButton = screen.getByTitle("Add to favorites");
       expect(favoriteButton).toBeInTheDocument();
       expect(favoriteButton).not.toHaveClass("text-accent-warning");
@@ -430,16 +352,15 @@ describe("KitGridItem", () => {
       const mockOnToggleFavorite = vi.fn();
       const props = {
         ...defaultProps,
-        isFavorite: false, // but prop explicitly says not favorite
+        isFavorite: false,
         kitData: {
           ...defaultProps.kitData,
-          is_favorite: true, // kitData says favorite
+          is_favorite: true,
         },
         onToggleFavorite: mockOnToggleFavorite,
       };
       render(<KitGridItem {...props} />);
 
-      // Should use prop value (not favorited)
       const favoriteButton = screen.getByTitle("Add to favorites");
       expect(favoriteButton).toBeInTheDocument();
       expect(favoriteButton).not.toHaveClass("text-accent-warning");
@@ -489,70 +410,70 @@ describe("KitGridItem", () => {
     });
   });
 
-  describe("Voice indicators", () => {
-    it("renders voice indicators with sample counts", () => {
+  describe("Voice channel strip", () => {
+    it("renders voice LED dots with sample counts", () => {
       render(<KitGridItem {...defaultProps} />);
 
-      // Should render 4 voice indicators
-      const voiceIndicators = screen.getAllByText(
-        /Kick|Snare|Hihat|Percussion/,
-      );
-      expect(voiceIndicators).toHaveLength(4);
+      // Check LED dots exist
+      expect(screen.getByTestId("voice-led-1")).toBeInTheDocument();
+      expect(screen.getByTestId("voice-led-2")).toBeInTheDocument();
+      expect(screen.getByTestId("voice-led-3")).toBeInTheDocument();
+      expect(screen.getByTestId("voice-led-4")).toBeInTheDocument();
 
-      // Check sample count display
-      expect(screen.getByText("Kick 4")).toBeInTheDocument();
-      expect(screen.getByText("Snare 3")).toBeInTheDocument();
-      expect(screen.getByText("Hihat 2")).toBeInTheDocument();
-      expect(screen.getByText("Percussion 1")).toBeInTheDocument();
+      // Check voice alias names are rendered
+      expect(screen.getByText("Kick")).toBeInTheDocument();
+      expect(screen.getByText("Snare")).toBeInTheDocument();
+      expect(screen.getByText("Hihat")).toBeInTheDocument();
+      expect(screen.getByText("Percussion")).toBeInTheDocument();
+
+      // Check counts are rendered separately
+      expect(screen.getByText("4")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
     });
 
-    it("applies correct styling for empty voices", () => {
+    it("applies correct LED styling for empty voices (0 samples)", () => {
       const props = {
         ...defaultProps,
         sampleCounts: [0, 3, 2, 1],
       };
       render(<KitGridItem {...props} />);
 
-      const voiceWithZero = screen.getByText("Kick 0");
-      expect(voiceWithZero).toHaveClass(
-        "bg-accent-danger/20",
-        "text-accent-danger",
-      );
+      const led = screen.getByTestId("voice-led-1");
+      expect(led).toHaveClass("bg-accent-danger");
     });
 
-    it("applies correct styling for full voices (12 samples)", () => {
+    it("applies correct LED styling for full voices (12 samples)", () => {
       const props = {
         ...defaultProps,
         sampleCounts: [12, 3, 2, 1],
       };
       render(<KitGridItem {...props} />);
 
-      const fullVoice = screen.getByText("Kick 12");
-      expect(fullVoice).toHaveClass("bg-accent-success/30", "font-bold");
+      const led = screen.getByTestId("voice-led-1");
+      expect(led).toHaveClass("bg-accent-success");
     });
 
-    it("applies correct styling for partial voices", () => {
+    it("applies correct LED styling for partial voices", () => {
       render(<KitGridItem {...defaultProps} />);
 
-      const partialVoice = screen.getByText("Snare 3");
-      expect(partialVoice).toHaveClass("bg-accent-primary/20");
+      const led = screen.getByTestId("voice-led-2");
+      expect(led).toHaveClass("bg-accent-primary");
     });
 
-    it("does not render voice indicators for invalid kits", () => {
+    it("does not render voice strip for invalid kits", () => {
       render(<KitGridItem {...defaultProps} isValid={false} />);
 
-      expect(
-        screen.queryByText(/Kick|Snare|Hihat|Percussion/),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("voice-led-1")).not.toBeInTheDocument();
     });
 
     it("handles missing voice names gracefully", () => {
-      // Mock extractVoiceNames to return undefined voice names
       mockExtractVoiceNames.mockReturnValue({});
 
       render(<KitGridItem {...defaultProps} />);
 
-      // Should still render counts without voice names, and tooltips should be without voice names
+      // Should still render counts without voice names
       expect(screen.getByText("4")).toBeInTheDocument();
       expect(screen.getByText("3")).toBeInTheDocument();
       expect(screen.getByText("2")).toBeInTheDocument();
@@ -636,7 +557,6 @@ describe("KitGridItem", () => {
     });
 
     it("has proper voice tooltips with voice names", () => {
-      // Reset the mock to return voice names for this test
       mockExtractVoiceNames.mockReturnValue({
         1: "kick",
         2: "snare",
@@ -646,18 +566,18 @@ describe("KitGridItem", () => {
 
       render(<KitGridItem {...defaultProps} />);
 
-      // The tooltips should include voice names
-      const voiceElement1 = screen.getByTitle("Voice 1: 4 samples (kick)");
-      const voiceElement2 = screen.getByTitle("Voice 2: 3 samples (snare)");
-      const voiceElement3 = screen.getByTitle("Voice 3: 2 samples (hihat)");
-      const voiceElement4 = screen.getByTitle(
-        "Voice 4: 1 samples (percussion)",
-      );
-
-      expect(voiceElement1).toBeInTheDocument();
-      expect(voiceElement2).toBeInTheDocument();
-      expect(voiceElement3).toBeInTheDocument();
-      expect(voiceElement4).toBeInTheDocument();
+      expect(
+        screen.getByTitle("Voice 1: 4 samples (kick)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle("Voice 2: 3 samples (snare)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle("Voice 3: 2 samples (hihat)"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle("Voice 4: 1 samples (percussion)"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -697,7 +617,7 @@ describe("KitGridItem", () => {
     it("handles partial sample counts array", () => {
       const props = {
         ...defaultProps,
-        sampleCounts: [5, 3], // Only 2 elements instead of 4
+        sampleCounts: [5, 3],
       };
       render(<KitGridItem {...props} />);
 
@@ -707,7 +627,7 @@ describe("KitGridItem", () => {
   });
 
   describe("Search match indicators", () => {
-    it("renders search match badges when searchMatch data is present", () => {
+    it("renders search match badges with Phosphor icons when searchMatch data is present", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -722,17 +642,19 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      // Check for sample match badge
-      const sampleBadge = screen.getByTitle(/Sample matches:/);
-      expect(sampleBadge).toBeInTheDocument();
-      expect(sampleBadge).toHaveTextContent("📄 2");
+      // Check for Phosphor FileAudio icon
+      expect(screen.getByTestId("icon-file-audio")).toBeInTheDocument();
 
-      // Check for artist match badge
-      const artistBadge = screen.getByText("🎵 Test Artist");
-      expect(artistBadge).toBeInTheDocument();
+      // Check for sample count
+      const sampleBadge = screen.getByTitle(/Sample matches:/);
+      expect(sampleBadge).toHaveTextContent("2");
+
+      // Check for Phosphor MusicNote icon and artist text
+      expect(screen.getByTestId("icon-music-note")).toBeInTheDocument();
+      expect(screen.getByText(/Test Artist/)).toBeInTheDocument();
     });
 
-    it("renders alias match badge", () => {
+    it("renders alias match badge with Tag icon", () => {
       const props = {
         ...defaultProps,
         kitData: {
@@ -747,8 +669,8 @@ describe("KitGridItem", () => {
       };
       render(<KitGridItem {...props} />);
 
-      const aliasBadge = screen.getByText("🏷️ My Custom Kit");
-      expect(aliasBadge).toBeInTheDocument();
+      expect(screen.getByTestId("icon-tag")).toBeInTheDocument();
+      expect(screen.getByText(/My Custom Kit/)).toBeInTheDocument();
     });
 
     it("shows single sample without count", () => {
@@ -766,16 +688,18 @@ describe("KitGridItem", () => {
       render(<KitGridItem {...props} />);
 
       const sampleBadge = screen.getByTitle(/Sample matches:/);
-      expect(sampleBadge).toHaveTextContent("📄");
-      expect(sampleBadge).not.toHaveTextContent("📄 1");
+      expect(screen.getByTestId("icon-file-audio")).toBeInTheDocument();
+      // Should not show count "1"
+      expect(sampleBadge).not.toHaveTextContent("1");
     });
 
     it("does not render search badges when no searchMatch data", () => {
       render(<KitGridItem {...defaultProps} />);
 
       expect(screen.queryByTitle(/Sample matches:/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/🎵/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/🏷️/)).not.toBeInTheDocument();
+      expect(screen.queryByTestId("icon-file-audio")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("icon-music-note")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("icon-tag")).not.toBeInTheDocument();
     });
 
     it("does not render search badges when kit is invalid", () => {

--- a/app/renderer/styles/index.css
+++ b/app/renderer/styles/index.css
@@ -221,3 +221,12 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-tertiary);
 }
+
+/* ───────────────────────────────────────────────────────────
+   LED Pulse Animation — Kit card modified state indicator
+   ─────────────────────────────────────────────────────────── */
+
+@keyframes led-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Summary
- Replace webapp-style `border-l-4` sidebar with LED state indicators (factory=gray dim, editable=green glow, modified=yellow pulse, invalid=red)
- Add "MOD" badge for modified kits, remove "Unsaved"/"Editable" text badges and yellow high-priority dot
- Redesign voice channel strip with LED dots + counts (red=0, blue=partial, green=12) and alias names above
- Replace emoji search badges with Phosphor icons (`FileAudio`, `MusicNote`, `Tag`)
- Increase card height from 90px to 104px

## Test plan
- [x] All 3203 unit tests pass
- [x] All 195 integration tests pass
- [x] TypeScript compiles clean
- [x] ESLint passes (0 errors)
- [x] Build succeeds
- [ ] Visual review: verify all 4 states (factory, editable, modified, invalid) in dark and light mode
- [ ] Verify hover, selection, and keyboard navigation still work
- [ ] Verify search badges render correctly during search