### PR TITLE
refactor: extract main process pure logic for coverage

### DIFF
--- a/electron/main/__tests__/index.test.ts
+++ b/electron/main/__tests__/index.test.ts
@@ -80,7 +80,6 @@ vi.mock("../applicationMenu.js", () => ({
   createApplicationMenu: vi.fn(),
   registerMenuIpcHandlers: vi.fn(),
 }));
-
 vi.mock("../localStoreValidator.js", () => ({
   validateLocalStoreAndDb: vi.fn(() => ({ isValid: true })),
 }));
@@ -104,23 +103,17 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Clean up process listeners after each test
   process.removeAllListeners("unhandledRejection");
 });
 
+// Orchestration tests for the thin index.ts shell.
+// Pure logic tests (settings, validation, window state) are in mainProcessSetup.test.ts.
 describe.sequential("main/index.ts", () => {
-  it("calls createWindow and loads settings on app ready (settings file exists)", async () => {
+  it("calls app.whenReady on import", async () => {
     const { app } = await import("electron");
     await import("../index");
     expect(app.whenReady).toHaveBeenCalled();
-    // Skipping this assertion for now due to test isolation issues:
-    // expect(registerIpcHandlers).toHaveBeenCalled();
   });
-
-  // Removed two valueless tests that had no assertions and were flagged by SonarQube:
-  // - "falls back to empty settings if file is missing"
-  // - "falls back to empty settings if file is invalid JSON"
-  // These scenarios are implicitly tested by other tests that successfully import the module.
 
   it("registers unhandledRejection handler and logs error", async () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -137,144 +130,6 @@ describe.sequential("main/index.ts", () => {
       process.emit("unhandledRejection", undefined, Promise.resolve()),
     ).not.toThrow();
     spy.mockRestore();
-  });
-
-  it("logs error if settings file is invalid JSON", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("not json");
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await import("../index");
-    expect(spy).toHaveBeenCalledWith(
-      "[Settings] Failed to parse settings file:",
-      expect.any(Error),
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it("does not log warning when settings file is missing (new behavior)", async () => {
-    const existsSyncSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await import("../index");
-    // Verify no warning is logged for missing settings file (simplified logging)
-    expect(spy).not.toHaveBeenCalledWith(
-      expect.stringContaining("Settings file not found"),
-    );
-    spy.mockRestore();
-    existsSyncSpy.mockRestore();
-  });
-
-  it("logs info only when no local store is configured", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue('{"foo": "bar"}');
-    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await import("../index");
-    // Logs settings when loaded
-    expect(spy).toHaveBeenCalledWith(
-      "[Settings] Loaded settings:",
-      expect.any(String),
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it("handles empty settings file", async () => {
-    const readFileSyncSpy = vi.spyOn(fs, "readFileSync").mockReturnValue("");
-    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await import("../index");
-    expect(spy).toHaveBeenCalledWith(
-      "[Settings] Settings file is empty - using empty settings",
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it("handles settings file with invalid object type", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue('["array", "instead", "of", "object"]');
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await import("../index");
-    expect(spy).toHaveBeenCalledWith(
-      "[Settings] Settings file did not contain an object. Using empty settings.",
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it("validates local store path when present in settings", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue('{"localStorePath": "/mock/store/path"}');
-    const { validateLocalStoreAndDb } =
-      await import("../localStoreValidator.js");
-    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await import("../index");
-
-    expect(validateLocalStoreAndDb).toHaveBeenCalledWith("/mock/store/path");
-    expect(spy).toHaveBeenCalledWith(
-      "[Validation] ✓ Local store path is valid",
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it("removes invalid local store path from settings", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue('{"localStorePath": "/invalid/path"}');
-    const writeFileSyncSpy = vi
-      .spyOn(fs, "writeFileSync")
-      .mockImplementation(() => {});
-    const { validateLocalStoreAndDb } =
-      await import("../localStoreValidator.js");
-    vi.mocked(validateLocalStoreAndDb).mockReturnValue({
-      error: "Path does not exist",
-      errorSummary: "Invalid path",
-      isValid: false,
-    });
-
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await import("../index");
-
-    expect(spy).toHaveBeenCalledWith(
-      "[Startup] ✗ Saved local store path is invalid",
-    );
-    expect(writeFileSyncSpy).toHaveBeenCalled();
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-    writeFileSyncSpy.mockRestore();
-  });
-
-  it("handles write error when removing invalid local store path", async () => {
-    const readFileSyncSpy = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue('{"localStorePath": "/invalid/path"}');
-    const writeFileSyncSpy = vi
-      .spyOn(fs, "writeFileSync")
-      .mockImplementation(() => {
-        throw new Error("Write failed");
-      });
-    const { validateLocalStoreAndDb } =
-      await import("../localStoreValidator.js");
-    vi.mocked(validateLocalStoreAndDb).mockReturnValue({
-      error: "Path does not exist",
-      isValid: false,
-    });
-
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await import("../index");
-
-    expect(spy).toHaveBeenCalledWith(
-      "[Startup] Failed to update settings file:",
-      expect.any(Error),
-    );
-    spy.mockRestore();
-    readFileSyncSpy.mockRestore();
-    writeFileSyncSpy.mockRestore();
   });
 
   it("logs environment variables on window creation", async () => {
@@ -357,7 +212,6 @@ describe.sequential("main/index.ts", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     await import("../index");
 
-    // Wait for async error handling
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(spy).toHaveBeenCalledWith("Failed to load URL:", "Load URL failed");
@@ -384,7 +238,6 @@ describe.sequential("main/index.ts", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     await import("../index");
 
-    // Wait for async error handling
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(spy).toHaveBeenCalledWith(

--- a/electron/main/__tests__/mainProcessSetup.test.ts
+++ b/electron/main/__tests__/mainProcessSetup.test.ts
@@ -1,0 +1,244 @@
+import fs from "fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../localStoreValidator.js", () => ({
+  validateLocalStoreAndDb: vi.fn(() => ({ isValid: true })),
+}));
+
+import { validateLocalStoreAndDb } from "../localStoreValidator.js";
+import {
+  loadSettings,
+  loadWindowState,
+  saveWindowState,
+  validateAndFixLocalStore,
+} from "../mainProcessSetup.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(fs, "existsSync").mockReturnValue(true);
+  vi.spyOn(fs, "readFileSync").mockReturnValue('{"foo": "bar"}');
+  vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadSettings", () => {
+  it("returns empty settings when file does not exist", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const result = loadSettings("/mock/settings.json");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.log).toHaveBeenCalledWith(
+      "[Settings] Settings file not found - will use empty settings",
+    );
+  });
+
+  it("returns empty settings when file is empty", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("");
+    const result = loadSettings("/mock/settings.json");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.log).toHaveBeenCalledWith(
+      "[Settings] Settings file is empty - using empty settings",
+    );
+  });
+
+  it("parses valid settings object", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      '{"localStorePath": "/store", "sdCardPath": "/sd", "defaultToMonoSamples": true}',
+    );
+    const result = loadSettings("/mock/settings.json");
+    expect(result).toEqual({
+      defaultToMonoSamples: true,
+      localStorePath: "/store",
+      sdCardPath: "/sd",
+    });
+  });
+
+  it("logs loaded settings", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue('{"foo": "bar"}');
+    loadSettings("/mock/settings.json");
+    expect(console.log).toHaveBeenCalledWith(
+      "[Settings] Loaded settings:",
+      expect.any(String),
+    );
+  });
+
+  it("warns when settings file contains non-object", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      '["array", "instead", "of", "object"]',
+    );
+    const result = loadSettings("/mock/settings.json");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Settings] Settings file did not contain an object. Using empty settings.",
+    );
+  });
+
+  it("logs error for invalid JSON", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("not json");
+    const result = loadSettings("/mock/settings.json");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.error).toHaveBeenCalledWith(
+      "[Settings] Failed to parse settings file:",
+      expect.any(Error),
+    );
+  });
+
+  it("defaults localStorePath to null when not present", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue('{"sdCardPath": "/sd"}');
+    const result = loadSettings("/mock/settings.json");
+    expect(result.localStorePath).toBeNull();
+  });
+});
+
+describe("validateAndFixLocalStore", () => {
+  it("returns settings unchanged when no localStorePath and no env override", () => {
+    const settings = { localStorePath: null };
+    const result = validateAndFixLocalStore(settings, "/mock/settings.json");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.log).toHaveBeenCalledWith(
+      "[Validation] No local store path to validate",
+    );
+  });
+
+  it("validates localStorePath when present and valid", () => {
+    const settings = { localStorePath: "/mock/store" };
+    vi.mocked(validateLocalStoreAndDb).mockReturnValue({ isValid: true });
+    const result = validateAndFixLocalStore(settings, "/mock/settings.json");
+    expect(validateLocalStoreAndDb).toHaveBeenCalledWith("/mock/store");
+    expect(result.localStorePath).toBe("/mock/store");
+    expect(console.log).toHaveBeenCalledWith(
+      "[Validation] ✓ Local store path is valid",
+    );
+  });
+
+  it("removes invalid localStorePath and writes updated settings", () => {
+    const settings = { localStorePath: "/invalid/path" };
+    vi.mocked(validateLocalStoreAndDb).mockReturnValue({
+      error: "Path does not exist",
+      errorSummary: "Invalid path",
+      isValid: false,
+    });
+    const result = validateAndFixLocalStore(settings, "/mock/settings.json");
+    expect(result.localStorePath).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Startup] ✗ Saved local store path is invalid",
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/mock/settings.json",
+      expect.any(String),
+      "utf-8",
+    );
+  });
+
+  it("handles write error when removing invalid localStorePath", () => {
+    const settings = { localStorePath: "/invalid/path" };
+    vi.mocked(validateLocalStoreAndDb).mockReturnValue({
+      error: "Path does not exist",
+      isValid: false,
+    });
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      throw new Error("Write failed");
+    });
+    const result = validateAndFixLocalStore(settings, "/mock/settings.json");
+    expect(result.localStorePath).toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      "[Startup] Failed to update settings file:",
+      expect.any(Error),
+    );
+  });
+
+  it("accepts valid env override and returns settings unchanged", () => {
+    const settings = { localStorePath: null };
+    vi.mocked(validateLocalStoreAndDb).mockReturnValue({ isValid: true });
+    const result = validateAndFixLocalStore(
+      settings,
+      "/mock/settings.json",
+      "/env/override",
+    );
+    expect(validateLocalStoreAndDb).toHaveBeenCalledWith("/env/override");
+    expect(result).toEqual({ localStorePath: null });
+    expect(console.log).toHaveBeenCalledWith(
+      "[Validation] ✓ Environment override path is valid",
+    );
+  });
+
+  it("falls back to settings validation when env override is invalid", () => {
+    const settings = { localStorePath: "/mock/store" };
+    vi.mocked(validateLocalStoreAndDb)
+      .mockReturnValueOnce({ error: "Invalid", isValid: false })
+      .mockReturnValueOnce({ isValid: true });
+    const result = validateAndFixLocalStore(
+      settings,
+      "/mock/settings.json",
+      "/invalid/env",
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      "[Validation] ✗ Environment override path is invalid",
+    );
+    expect(validateLocalStoreAndDb).toHaveBeenCalledWith("/mock/store");
+    expect(result.localStorePath).toBe("/mock/store");
+  });
+});
+
+describe("loadWindowState", () => {
+  it("returns defaults when state file does not exist", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const result = loadWindowState("/mock/window-state.json");
+    expect(result).toEqual({ height: 800, width: 1200 });
+  });
+
+  it("merges saved state with defaults", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      '{"x": 100, "y": 200, "width": 1000, "height": 600, "isMaximized": true}',
+    );
+    const result = loadWindowState("/mock/window-state.json");
+    expect(result).toEqual({
+      height: 600,
+      isMaximized: true,
+      width: 1000,
+      x: 100,
+      y: 200,
+    });
+  });
+
+  it("returns defaults when state file is corrupt", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("not json");
+    const result = loadWindowState("/mock/window-state.json");
+    expect(result).toEqual({ height: 800, width: 1200 });
+  });
+});
+
+describe("saveWindowState", () => {
+  it("writes window bounds and maximized state to file", () => {
+    const bounds = { height: 600, width: 1000, x: 50, y: 75 };
+    saveWindowState(bounds, false, "/mock/window-state.json");
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/mock/window-state.json",
+      JSON.stringify({
+        height: 600,
+        isMaximized: false,
+        width: 1000,
+        x: 50,
+        y: 75,
+      }),
+    );
+  });
+
+  it("does not throw on write error", () => {
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      throw new Error("Disk full");
+    });
+    expect(() =>
+      saveWindowState(
+        { height: 800, width: 1200, x: 0, y: 0 },
+        false,
+        "/mock/state.json",
+      ),
+    ).not.toThrow();
+  });
+});

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -14,26 +14,22 @@ import {
   registerMenuIpcHandlers,
 } from "./applicationMenu.js";
 import { registerDbIpcHandlers } from "./dbIpcHandlers.js";
-// Import IPC handlers
 import { registerIpcHandlers } from "./ipcHandlers.js";
-import { validateLocalStoreAndDb } from "./localStoreValidator.js";
+import {
+  loadSettings,
+  loadWindowState,
+  saveWindowState,
+  validateAndFixLocalStore,
+} from "./mainProcessSetup.js";
 
 let inMemorySettings: InMemorySettings = {
   localStorePath: null,
-}; // Store settings in memory
+};
 
 const isDev = process.env.NODE_ENV === "development";
 
 const preloadPath = path.resolve(__dirname, "../preload/index.mjs");
 console.log(" Electron will use preload:", preloadPath);
-
-interface WindowState {
-  height: number;
-  isMaximized?: boolean;
-  width: number;
-  x?: number;
-  y?: number;
-}
 
 function createWindow() {
   console.log("[Electron Main] Environment variables check:");
@@ -56,7 +52,8 @@ function createWindow() {
     );
   }
 
-  const windowState = loadWindowState();
+  const statePath = getWindowStatePath();
+  const windowState = loadWindowState(statePath);
 
   const win: BrowserWindow = new BrowserWindow({
     height: windowState.height,
@@ -76,17 +73,17 @@ function createWindow() {
   }
 
   win.on("close", () => {
+    const windowStatePath = getWindowStatePath();
     if (!win.isMaximized()) {
-      saveWindowState(win);
+      saveWindowState(win.getBounds(), win.isMaximized(), windowStatePath);
     } else {
       // Save maximized flag but keep previous bounds for restore
       try {
-        const statePath = getWindowStatePath();
-        const existing = fs.existsSync(statePath)
-          ? JSON.parse(fs.readFileSync(statePath, "utf-8"))
+        const existing = fs.existsSync(windowStatePath)
+          ? JSON.parse(fs.readFileSync(windowStatePath, "utf-8"))
           : {};
         fs.writeFileSync(
-          statePath,
+          windowStatePath,
           JSON.stringify({ ...existing, isMaximized: true }),
         );
       } catch {
@@ -96,7 +93,6 @@ function createWindow() {
   });
 
   if (isDev) {
-    // Type-safe error handling for loadURL
     const vitePort = process.env.VITE_DEV_SERVER_PORT || "5173";
     win.loadURL(`http://localhost:${vitePort}`).catch((err: unknown) => {
       console.error(
@@ -121,172 +117,17 @@ function createWindow() {
   }
 }
 
+function getSettingsPath(): string {
+  return path.join(app.getPath("userData"), "romper-settings.json");
+}
+
 function getWindowStatePath(): string {
   return path.join(app.getPath("userData"), "window-state.json");
-}
-
-function loadSettings(): InMemorySettings {
-  const userDataPath = app.getPath("userData");
-  const settingsPath = path.join(userDataPath, "romper-settings.json");
-
-  console.log("[Settings] Loading settings from:", settingsPath);
-  console.log("[Settings] User data path:", userDataPath);
-
-  if (!fs.existsSync(settingsPath)) {
-    console.log("[Settings] Settings file not found - will use empty settings");
-    return { localStorePath: null };
-  }
-
-  let settings: InMemorySettings = { localStorePath: null };
-  try {
-    const fileContent = fs.readFileSync(settingsPath, "utf-8");
-
-    if (fileContent.length === 0) {
-      console.log("[Settings] Settings file is empty - using empty settings");
-      return { localStorePath: null };
-    }
-
-    const parsed = JSON.parse(fileContent);
-
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      settings = {
-        defaultToMonoSamples: parsed.defaultToMonoSamples,
-        localStorePath: parsed.localStorePath || null,
-        sdCardPath: parsed.sdCardPath,
-      };
-      console.log(
-        "[Settings] Loaded settings:",
-        JSON.stringify(settings, null, 2),
-      );
-    } else {
-      console.warn(
-        "[Settings] Settings file did not contain an object. Using empty settings.",
-      );
-      console.warn(
-        "[Settings] Parsed type:",
-        typeof parsed,
-        "Is array:",
-        Array.isArray(parsed),
-      );
-    }
-  } catch (error) {
-    console.error("[Settings] Failed to parse settings file:", error);
-    console.error("[Settings] Using empty settings");
-  }
-
-  return settings;
-}
-
-function loadWindowState(): WindowState {
-  const defaults: WindowState = { height: 800, width: 1200 };
-  try {
-    const statePath = getWindowStatePath();
-    if (fs.existsSync(statePath)) {
-      const data = JSON.parse(fs.readFileSync(statePath, "utf-8"));
-      return { ...defaults, ...data };
-    }
-  } catch {
-    // Ignore corrupt state file
-  }
-  return defaults;
 }
 
 function registerAllIpcHandlers(settings: InMemorySettings) {
   registerIpcHandlers(settings);
   registerDbIpcHandlers(settings);
-}
-
-function saveWindowState(win: BrowserWindow): void {
-  try {
-    const bounds = win.getBounds();
-    const state: WindowState = {
-      height: bounds.height,
-      isMaximized: win.isMaximized(),
-      width: bounds.width,
-      x: bounds.x,
-      y: bounds.y,
-    };
-    fs.writeFileSync(getWindowStatePath(), JSON.stringify(state));
-  } catch {
-    // Ignore write errors
-  }
-}
-
-function validateAndFixLocalStore(
-  settings: InMemorySettings,
-): InMemorySettings {
-  const userDataPath = app.getPath("userData");
-  const settingsPath = path.join(userDataPath, "romper-settings.json");
-
-  console.log("[Validation] Starting local store validation");
-
-  // Check if we have an environment override first
-  const envOverridePath = process.env.ROMPER_LOCAL_PATH;
-  if (envOverridePath) {
-    console.log("[Validation] Environment override detected:", envOverridePath);
-    const envValidation = validateLocalStoreAndDb(envOverridePath);
-    console.log("[Validation] Environment override validation result:", {
-      error: envValidation.error,
-      errorSummary: envValidation.errorSummary,
-      isValid: envValidation.isValid,
-    });
-
-    if (envValidation.isValid) {
-      console.log("[Validation] ✓ Environment override path is valid");
-      // Don't modify settings - environment override is temporary
-      return settings;
-    } else {
-      console.warn("[Validation] ✗ Environment override path is invalid");
-      console.warn("  - Path:", envOverridePath);
-      console.warn("  - Error:", envValidation.error);
-      // Continue to check settings path as fallback
-    }
-  }
-
-  console.log(
-    "[Validation] Settings have localStorePath:",
-    !!settings.localStorePath,
-  );
-
-  if (settings.localStorePath) {
-    console.log(
-      "[Validation] Validating local store path:",
-      settings.localStorePath,
-    );
-    const validation = validateLocalStoreAndDb(settings.localStorePath);
-    console.log("[Validation] Validation result:", {
-      error: validation.error,
-      errorSummary: validation.errorSummary,
-      isValid: validation.isValid,
-    });
-
-    if (!validation.isValid) {
-      console.warn("[Startup] ✗ Saved local store path is invalid");
-      console.warn("  - Path:", settings.localStorePath);
-      console.warn("  - Error:", validation.error);
-      console.warn("[Startup] Removing invalid path from settings...");
-
-      settings.localStorePath = null;
-      try {
-        fs.writeFileSync(
-          settingsPath,
-          JSON.stringify(settings, null, 2),
-          "utf-8",
-        );
-        console.log(
-          "[Startup] Invalid local store path removed from settings file",
-        );
-      } catch (writeError) {
-        console.error("[Startup] Failed to update settings file:", writeError);
-      }
-    } else {
-      console.log("[Validation] ✓ Local store path is valid");
-    }
-  } else {
-    console.log("[Validation] No local store path to validate");
-  }
-
-  return settings;
 }
 
 app.whenReady().then(async () => {
@@ -298,8 +139,13 @@ app.whenReady().then(async () => {
     registerMenuIpcHandlers();
 
     // Load and validate settings
-    inMemorySettings = loadSettings();
-    inMemorySettings = validateAndFixLocalStore(inMemorySettings);
+    const settingsPath = getSettingsPath();
+    inMemorySettings = loadSettings(settingsPath);
+    inMemorySettings = validateAndFixLocalStore(
+      inMemorySettings,
+      settingsPath,
+      process.env.ROMPER_LOCAL_PATH,
+    );
 
     // Final summary of local store configuration
     console.log("[Startup] Final local store configuration:");
@@ -328,7 +174,6 @@ app.whenReady().then(async () => {
   }
 });
 
-// Add helper function to validate local store and DB
 process.on("unhandledRejection", (reason: unknown) => {
   console.error(
     "Unhandled Promise Rejection:",

--- a/electron/main/mainProcessSetup.ts
+++ b/electron/main/mainProcessSetup.ts
@@ -1,0 +1,165 @@
+import fs from "fs";
+
+import type { InMemorySettings } from "./types/settings.js";
+
+import { validateLocalStoreAndDb } from "./localStoreValidator.js";
+
+export interface WindowState {
+  height: number;
+  isMaximized?: boolean;
+  width: number;
+  x?: number;
+  y?: number;
+}
+
+export function loadSettings(settingsPath: string): InMemorySettings {
+  console.log("[Settings] Loading settings from:", settingsPath);
+
+  if (!fs.existsSync(settingsPath)) {
+    console.log("[Settings] Settings file not found - will use empty settings");
+    return { localStorePath: null };
+  }
+
+  let settings: InMemorySettings = { localStorePath: null };
+  try {
+    const fileContent = fs.readFileSync(settingsPath, "utf-8");
+
+    if (fileContent.length === 0) {
+      console.log("[Settings] Settings file is empty - using empty settings");
+      return { localStorePath: null };
+    }
+
+    const parsed = JSON.parse(fileContent);
+
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      settings = {
+        defaultToMonoSamples: parsed.defaultToMonoSamples,
+        localStorePath: parsed.localStorePath || null,
+        sdCardPath: parsed.sdCardPath,
+      };
+      console.log(
+        "[Settings] Loaded settings:",
+        JSON.stringify(settings, null, 2),
+      );
+    } else {
+      console.warn(
+        "[Settings] Settings file did not contain an object. Using empty settings.",
+      );
+      console.warn(
+        "[Settings] Parsed type:",
+        typeof parsed,
+        "Is array:",
+        Array.isArray(parsed),
+      );
+    }
+  } catch (error) {
+    console.error("[Settings] Failed to parse settings file:", error);
+    console.error("[Settings] Using empty settings");
+  }
+
+  return settings;
+}
+
+export function loadWindowState(statePath: string): WindowState {
+  const defaults: WindowState = { height: 800, width: 1200 };
+  try {
+    if (fs.existsSync(statePath)) {
+      const data = JSON.parse(fs.readFileSync(statePath, "utf-8"));
+      return { ...defaults, ...data };
+    }
+  } catch {
+    // Ignore corrupt state file
+  }
+  return defaults;
+}
+
+export function saveWindowState(
+  bounds: { height: number; width: number; x: number; y: number },
+  isMaximized: boolean,
+  statePath: string,
+): void {
+  try {
+    const state: WindowState = {
+      height: bounds.height,
+      isMaximized,
+      width: bounds.width,
+      x: bounds.x,
+      y: bounds.y,
+    };
+    fs.writeFileSync(statePath, JSON.stringify(state));
+  } catch {
+    // Ignore write errors
+  }
+}
+
+export function validateAndFixLocalStore(
+  settings: InMemorySettings,
+  settingsPath: string,
+  envOverridePath?: string,
+): InMemorySettings {
+  console.log("[Validation] Starting local store validation");
+
+  if (envOverridePath) {
+    console.log("[Validation] Environment override detected:", envOverridePath);
+    const envValidation = validateLocalStoreAndDb(envOverridePath);
+    console.log("[Validation] Environment override validation result:", {
+      error: envValidation.error,
+      errorSummary: envValidation.errorSummary,
+      isValid: envValidation.isValid,
+    });
+
+    if (envValidation.isValid) {
+      console.log("[Validation] ✓ Environment override path is valid");
+      return settings;
+    } else {
+      console.warn("[Validation] ✗ Environment override path is invalid");
+      console.warn("  - Path:", envOverridePath);
+      console.warn("  - Error:", envValidation.error);
+    }
+  }
+
+  console.log(
+    "[Validation] Settings have localStorePath:",
+    !!settings.localStorePath,
+  );
+
+  if (settings.localStorePath) {
+    console.log(
+      "[Validation] Validating local store path:",
+      settings.localStorePath,
+    );
+    const validation = validateLocalStoreAndDb(settings.localStorePath);
+    console.log("[Validation] Validation result:", {
+      error: validation.error,
+      errorSummary: validation.errorSummary,
+      isValid: validation.isValid,
+    });
+
+    if (!validation.isValid) {
+      console.warn("[Startup] ✗ Saved local store path is invalid");
+      console.warn("  - Path:", settings.localStorePath);
+      console.warn("  - Error:", validation.error);
+      console.warn("[Startup] Removing invalid path from settings...");
+
+      settings.localStorePath = null;
+      try {
+        fs.writeFileSync(
+          settingsPath,
+          JSON.stringify(settings, null, 2),
+          "utf-8",
+        );
+        console.log(
+          "[Startup] Invalid local store path removed from settings file",
+        );
+      } catch (writeError) {
+        console.error("[Startup] Failed to update settings file:", writeError);
+      }
+    } else {
+      console.log("[Validation] ✓ Local store path is valid");
+    }
+  } else {
+    console.log("[Validation] No local store path to validate");
+  }
+
+  return settings;
+}


### PR DESCRIPTION
## Summary
- Extract `loadSettings`, `validateAndFixLocalStore`, `loadWindowState`, `saveWindowState` from `index.ts` into `mainProcessSetup.ts` with dependency-injected paths
- Enables static imports in tests so V8 coverage provider tracks coverage (was 0% due to `vi.resetModules()` + dynamic imports)
- `mainProcessSetup.ts` achieves 100% coverage across all metrics
- `index.ts` slimmed from 338 to ~180 lines (thin orchestration shell)

## Test plan
- [x] All 3,540 tests pass (3,338 unit + 202 integration)
- [x] `mainProcessSetup.ts` has 100% statement/branch/function coverage
- [x] TypeScript, linting, and build all pass
- [ ] CI/CD checks pass