### PR TITLE
fix: allow hook to pass for writes outside project

### DIFF
--- a/.claude/hooks/require-worktree.sh
+++ b/.claude/hooks/require-worktree.sh
@@ -3,6 +3,17 @@
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd')
 
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Allow writes to paths outside the project directory (e.g. ~/.claude/plans/)
+if [ -n "$FILE_PATH" ]; then
+  PROJECT_DIR="$CLAUDE_PROJECT_DIR"
+  case "$FILE_PATH" in
+    "$PROJECT_DIR"/*) ;; # Inside project, continue to worktree check
+    *) exit 0 ;;         # Outside project, allow
+  esac
+fi
+
 # Check if git worktree — .git is a file (not a directory) in worktrees
 if [ -f "$CWD/.git" ] || git -C "$CWD" rev-parse --is-inside-work-tree &>/dev/null && \
    [ "$(git -C "$CWD" rev-parse --git-common-dir 2>/dev/null)" != "$(git -C "$CWD" rev-parse --git-dir 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary
- Updates `require-worktree.sh` hook to allow writes to paths outside the project directory (e.g. `~/.claude/plans/`)
- Extracts `file_path` from tool input and skips the worktree check if it's not under `$CLAUDE_PROJECT_DIR`

## Test plan
- [x] All pre-commit checks pass (TypeScript, lint, 3523 tests, build)
- [ ] Verify `~/.claude/plans/` writes are no longer blocked
- [ ] Verify in-project writes still require worktree