### PR TITLE
fix: check file_path instead of CWD in worktree hook

### DIFF
--- a/.claude/hooks/require-worktree.sh
+++ b/.claude/hooks/require-worktree.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
-# Block file edits unless we're in a git worktree (not the main working tree)
+# Block file edits to the main working tree — require worktree usage
 INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-# Allow writes to paths outside the project directory (e.g. ~/.claude/plans/)
-if [ -n "$FILE_PATH" ]; then
-  PROJECT_DIR="$CLAUDE_PROJECT_DIR"
-  case "$FILE_PATH" in
-    "$PROJECT_DIR"/*) ;; # Inside project, continue to worktree check
-    *) exit 0 ;;         # Outside project, allow
-  esac
+# If no file path provided, allow (defensive)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
 fi
 
-# Check if git worktree — .git is a file (not a directory) in worktrees
-if [ -f "$CWD/.git" ] || git -C "$CWD" rev-parse --is-inside-work-tree &>/dev/null && \
-   [ "$(git -C "$CWD" rev-parse --git-common-dir 2>/dev/null)" != "$(git -C "$CWD" rev-parse --git-dir 2>/dev/null)" ]; then
-  exit 0  # In worktree, allow
+PROJECT_DIR="$CLAUDE_PROJECT_DIR"
+
+# Guard: if PROJECT_DIR is unset, allow (don't block without context)
+if [ -z "$PROJECT_DIR" ]; then
+  exit 0
 fi
 
-echo "BLOCKED: You must create a worktree before editing files. Run: npm run worktree:create <task-name>" >&2
+# Allow writes outside the project directory (e.g., ~/.claude/plans/)
+case "$FILE_PATH" in
+  "$PROJECT_DIR"/*) ;; # Inside project, continue checks
+  *) exit 0 ;;         # Outside project, allow
+esac
+
+# Allow writes inside a worktree subdirectory
+case "$FILE_PATH" in
+  "$PROJECT_DIR"/worktrees/*) exit 0 ;;
+esac
+
+# File is inside the main repo but NOT in a worktree — block
+echo "BLOCKED: You must create a worktree before editing project files." >&2
+echo "Run: npm run worktree:create <task-name>" >&2
+echo "Then edit files in worktrees/<task-name>/ using absolute paths." >&2
 exit 2


### PR DESCRIPTION
## Summary
fix: check file_path instead of CWD in worktree hook

## Test plan
- [x] All pre-commit checks pass
- [x] Code builds successfully  
- [x] Tests pass
- [ ] Manual testing completed