### PR TITLE
feat: add app signing and docs website for launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
+  id-token: write # Required for Azure Trusted Signing OIDC
 
 jobs:
   quality-gate:
@@ -65,13 +66,13 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             artifact-name: linux-artifacts
-          - os: macos-latest  
+          - os: macos-latest
             platform: darwin
             artifact-name: mac-artifacts
           - os: windows-latest
             platform: win32
             artifact-name: windows-artifacts
-    
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
@@ -101,6 +102,45 @@ jobs:
             libasound2-dev \
             libgtk-3-0
 
+      # ── macOS: Import signing certificate into temporary keychain ──
+      - name: Import macOS signing certificate
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate from base64 secret
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          # Set partition list to allow codesign access without UI prompt
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Add temporary keychain to search list (prepend so it's found first)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # Extract identity name for Electron Forge
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "APPLE_IDENTITY=$IDENTITY" >> $GITHUB_ENV
+
+          echo "Certificate imported successfully. Identity: $IDENTITY"
+
       - name: Install dependencies
         run: npm ci
 
@@ -108,7 +148,39 @@ jobs:
         run: npm run build
 
       - name: Package application (Electron)
+        env:
+          # macOS notarization credentials (only used when secrets are configured)
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # APPLE_IDENTITY is set by the certificate import step above
         run: npm run make
+
+      # ── Windows: Sign artifacts with Azure Trusted Signing ──
+      - name: Sign Windows artifacts with Azure Trusted Signing
+        if: matrix.os == 'windows-latest' && secrets.AZURE_CLIENT_ID != ''
+        uses: azure/trusted-signing-action@v0.5.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
+          files-folder: out/make/squirrel.windows/x64/
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      # ── macOS: Clean up temporary keychain ──
+      - name: Clean up macOS keychain
+        if: always() && matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          fi
 
       - name: Debug artifact structure (Windows)
         if: matrix.os == 'windows-latest'
@@ -174,7 +246,7 @@ jobs:
         run: |
           # Generate release notes using the Node.js script
           RELEASE_NOTES=$(node scripts/generate-github-release-notes.js ${{ github.ref_name }})
-          
+
           # Output to GitHub Actions
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,8 @@ kramdown:
   input: GFM
   syntax_highlighter: rouge
 permalink: pretty
+plugins:
+  - jekyll-sitemap
 exclude:
   - developer/
   - templates/

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,104 @@
+---
+layout: default
+title: FAQ
+description: Frequently asked questions about Romper, the sample kit manager for Squarp Rample
+---
+
+<section class="page-content">
+<div class="container">
+<div class="prose">
+
+# Frequently Asked Questions
+
+Common questions about using Romper to manage your Squarp Rample sample kits.
+
+---
+
+## How is Romper different from editing my SD card directly?
+
+When you edit your SD card directly, you're working with the raw folder structure -- renaming folders, moving WAV files, and manually keeping track of which samples go where. One wrong move and you can end up with a broken kit or lost files.
+
+Romper gives you a visual interface on top of that process with several key advantages:
+
+- **Non-destructive editing** -- Romper stores references to your samples rather than moving the files themselves. Your original sample library stays untouched until you explicitly sync.
+- **Full undo/redo support** -- Every sample assignment, removal, and rearrangement can be undone. Try different kit arrangements without worrying about losing your work.
+- **Validation before sync** -- Romper checks your kits for issues (missing files, format problems, naming conflicts) before writing anything to the SD card.
+- **Automatic backups** -- When you sync, Romper creates a backup of the existing SD card content first.
+
+Think of Romper as a working copy for your Rample kits. You experiment freely, then commit the results to the SD card when you're ready.
+
+---
+
+## What audio formats are supported?
+
+**WAV is the primary format.** The Squarp Rample reads WAV files from the SD card, so Romper is built around WAV workflow.
+
+When you assign samples to a kit:
+- **WAV files** (.wav) are used directly with no conversion needed.
+- During sync to the SD card, Romper can convert samples to ensure compatibility with the Rample's requirements (sample rate, bit depth, channel format).
+
+If you have samples in other formats (AIFF, MP3, FLAC, etc.), convert them to WAV before importing into Romper.
+
+---
+
+## Will Romper modify my original sample files?
+
+**No.** Romper uses a reference-only architecture. When you assign a sample to a voice slot, Romper stores a reference (the file path) to where that sample lives on your filesystem. It never moves, renames, or modifies the original file.
+
+Your sample files are only copied during an explicit sync operation, and only to the SD card destination. Your source sample library is never touched.
+
+---
+
+## Can I undo changes?
+
+**Yes.** Romper provides full undo and redo for all sample operations:
+
+- Assigning a sample to a voice slot
+- Removing a sample from a voice slot
+- Reordering sample layers
+- Clearing a voice or kit
+
+Use the standard keyboard shortcuts (**Cmd+Z** / **Ctrl+Z** to undo, **Cmd+Shift+Z** / **Ctrl+Shift+Z** to redo) or the Edit menu. Undo history is maintained for the duration of your session.
+
+---
+
+## What SD card formats are compatible?
+
+Romper works with the standard Rample SD card folder structure:
+
+- **26 banks** labeled A through Z
+- **Up to 100 kit slots** per bank (00 through 99)
+- **4 voices per kit** with up to 12 sample layers each
+- Standard FAT32-formatted SD cards (the same format the Rample expects)
+
+If your SD card is already set up for the Rample, Romper will recognize it. You can also start from the Rample factory samples or build a fresh library from scratch.
+
+---
+
+## How much disk space do I need?
+
+Disk space depends on how many samples you work with:
+
+- **Romper application** -- Approximately 200 MB installed
+- **Factory samples** -- Approximately 1 GB if you choose to download the Rample factory sample set during setup
+- **Local store** -- The Romper database and metadata are small (a few MB). The bulk of space goes to your sample files.
+- **Your sample library** -- Varies based on your collection. WAV files range from a few KB (short one-shots) to tens of MB (long stereo recordings).
+
+Romper references your existing sample files in place, so it does not duplicate your sample library. The only copies made are to the SD card during sync.
+
+---
+
+## Does Romper work offline?
+
+**Yes.** Romper is a desktop application that runs entirely offline after installation. No internet connection is required for:
+
+- Browsing and editing kits
+- Assigning and previewing samples
+- Using the step sequencer
+- Syncing to the SD card
+
+The only feature that requires an internet connection is downloading the Rample factory samples during initial setup. Once downloaded, everything works offline.
+
+</div>
+</div>
+</section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -335,8 +335,12 @@ title: Home
                         <path d="M3 2.5A1.5 1.5 0 014.5 1h9A1.5 1.5 0 0115 2.5v13a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 013 15.5v-13z" stroke="currentColor" stroke-width="1.5"/>
                         <path d="M6 5h6M6 8h6M6 11h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
                     </svg>
-                    <h3 class="user-docs-title">User Guide</h3>
-                    <a href="{{ site.baseurl }}/manual/" class="doc-link">Read the Manual</a>
+                    <h3 class="user-docs-title">Documentation</h3>
+                </div>
+                <div class="user-docs-links">
+                    <a href="{{ site.baseurl }}/manual/" class="doc-link">User Manual</a>
+                    <a href="{{ site.baseurl }}/faq" class="doc-link">FAQ</a>
+                    <a href="{{ site.baseurl }}/troubleshooting" class="doc-link">Troubleshooting</a>
                 </div>
             </div>
 
@@ -345,6 +349,43 @@ title: Home
                 <span class="separator">&bull;</span>
                 <a href="https://squarp.net/rample" class="download-link">About Squarp Rample</a>
             </div>
+        </div>
+    </div>
+</section>
+
+<!-- Community & Support -->
+<section class="community">
+    <div class="container">
+        <h2 class="section-title">Community &amp; Support</h2>
+        <p class="community-description">
+            Romper is an open source community project. Get help, report issues, and share ideas.
+        </p>
+        <div class="community-links">
+            <a href="https://github.com/peteb4ker/romper/issues" class="community-card">
+                <div class="community-card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/>
+                        <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
+                        <path d="M12 7v3" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </div>
+                <div>
+                    <div class="community-card-title">GitHub Issues</div>
+                    <div class="community-card-desc">Report bugs and request features</div>
+                </div>
+            </a>
+            <a href="https://github.com/peteb4ker/romper/discussions" class="community-card">
+                <div class="community-card-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2v10z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                        <path d="M8 9h8M8 13h5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </div>
+                <div>
+                    <div class="community-card-title">Discussions</div>
+                    <div class="community-card-desc">Ask questions and share ideas</div>
+                </div>
+            </a>
         </div>
     </div>
 </section>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://peteb4ker.github.io/romper/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,46 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://peteb4ker.github.io/romper/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/</loc>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/getting-started</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/kit-browser</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/kit-editor</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/step-sequencer</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/syncing</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/manual/keyboard-shortcuts</loc>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/faq</loc>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://peteb4ker.github.io/romper/troubleshooting</loc>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -797,6 +797,63 @@ html.js-ready .fade-in.visible {
 }
 
 /* ===================================================================
+   Community & Support
+   =================================================================== */
+.community {
+    padding: 3rem 0 4rem;
+    text-align: center;
+}
+
+.community-description {
+    color: var(--text-secondary);
+    max-width: 500px;
+    margin: 0.5rem auto 2rem;
+    font-size: 1.05rem;
+}
+
+.community-links {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.community-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.25rem 1.75rem;
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    text-decoration: none;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+    min-width: 260px;
+}
+
+.community-card:hover {
+    border-color: var(--accent-primary);
+    transform: translateY(-2px);
+}
+
+.community-card-icon {
+    color: var(--accent-primary);
+    flex-shrink: 0;
+}
+
+.community-card-title {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 1rem;
+    margin-bottom: 0.15rem;
+}
+
+.community-card-desc {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+/* ===================================================================
    Footer
    =================================================================== */
 .footer {
@@ -1139,6 +1196,128 @@ html.js-ready .fade-in.visible {
 }
 
 /* ===================================================================
+   Standalone Content Pages (FAQ, Troubleshooting, etc.)
+   =================================================================== */
+.page-content {
+    padding: 3rem 0 4rem;
+}
+
+.prose {
+    max-width: 740px;
+    margin: 0 auto;
+}
+
+.prose h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+}
+
+.prose h1 + p {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+}
+
+.prose h1 + p + hr {
+    margin-top: 0;
+}
+
+.prose h2 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+}
+
+.prose h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.prose p {
+    margin-bottom: 1rem;
+    color: var(--text-secondary);
+    line-height: 1.8;
+}
+
+.prose ul,
+.prose ol {
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+    color: var(--text-secondary);
+}
+
+.prose li {
+    margin-bottom: 0.35rem;
+    line-height: 1.7;
+}
+
+.prose strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.prose code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background-color: var(--surface-3);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    color: var(--text-primary);
+}
+
+.prose pre {
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 1.25rem;
+    overflow-x: auto;
+    margin-bottom: 1.5rem;
+}
+
+.prose pre code {
+    background: none;
+    padding: 0;
+    font-size: 0.85rem;
+    line-height: 1.6;
+}
+
+.prose a {
+    color: var(--accent-primary);
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+
+.prose a:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+}
+
+.prose hr {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 2rem 0;
+}
+
+.prose blockquote {
+    border-left: 3px solid var(--accent-primary);
+    padding: 0.75rem 1.25rem;
+    margin: 1.5rem 0;
+    background-color: var(--surface-2);
+    border-radius: 0 6px 6px 0;
+}
+
+.prose blockquote p {
+    margin-bottom: 0;
+}
+
+/* ===================================================================
    Custom Scrollbar
    =================================================================== */
 ::-webkit-scrollbar {
@@ -1221,6 +1400,17 @@ html.js-ready .fade-in.visible {
         display: none;
     }
 
+    .community-links {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .community-card {
+        min-width: auto;
+        width: 100%;
+        max-width: 320px;
+    }
+
     .nav-links {
         gap: 1rem;
     }
@@ -1294,6 +1484,14 @@ html.js-ready .fade-in.visible {
 
     .manual-pagination-link--next {
         text-align: left;
+    }
+
+    .page-content {
+        padding: 2rem 0 3rem;
+    }
+
+    .prose h1 {
+        font-size: 1.6rem;
     }
 }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,104 @@
+---
+layout: default
+title: Troubleshooting
+description: Solutions for common issues with Romper, the sample kit manager for Squarp Rample
+---
+
+<section class="page-content">
+<div class="container">
+<div class="prose">
+
+# Troubleshooting
+
+Solutions for common issues you may encounter when using Romper.
+
+---
+
+## SD card not detected
+
+If Romper cannot see your SD card when syncing:
+
+**macOS**
+- Insert the SD card and check that it appears in Finder under Locations.
+- Open **Disk Utility** and verify the card is mounted.
+- If the card does not mount, try a different card reader or USB port.
+
+**Windows**
+- Insert the SD card and check that it appears as a drive letter in File Explorer.
+- If it does not appear, open **Disk Management** (right-click Start > Disk Management) and check if the card is listed but unassigned.
+- Try a different card reader or USB port.
+
+**Linux**
+- Check if the card is recognized with `lsblk` in a terminal.
+- If listed but not mounted, mount it manually: `sudo mount /dev/sdX1 /mnt/sdcard` (replace `sdX1` with your device).
+- Some desktop environments auto-mount removable media -- check your file manager.
+
+**General tips**
+- The SD card must be formatted as FAT32 (the standard format for the Rample).
+- Try ejecting and reinserting the card.
+- Test with a different SD card to rule out hardware issues.
+
+---
+
+## No kit folders found
+
+When Romper imports from an SD card but finds no kits, the folder structure may not match what the Rample expects.
+
+The Rample uses this naming convention:
+- Bank folders are single letters: `A`, `B`, `C`, ... `Z`
+- Kit folders within a bank are numbered: `A/0`, `A/1`, ... `A/99`
+- Voice sample files within a kit follow specific naming patterns
+
+If your SD card has a different structure (e.g., folders named `Bank_A` or `Kit_01`), Romper will not recognize them. Check the [Rample manual](https://squarp.net/rample/manual/) for the exact folder structure specification.
+
+**Quick fix**: Start fresh by choosing "Factory Samples" or "Empty Library" in the Romper setup wizard, then rebuild your kits from within Romper.
+
+---
+
+## Factory download fails
+
+Downloading the Rample factory samples requires an internet connection. If the download fails:
+
+- **Check your connection** -- Ensure you have a stable internet connection. The factory sample set is approximately 1 GB.
+- **Firewall or proxy** -- If you are behind a corporate firewall or proxy, the download may be blocked. Try from a different network.
+- **Retry** -- Romper will offer to retry the download. Partial downloads are resumed automatically where possible.
+- **Skip for now** -- You can skip the factory download during setup and start with an empty library. You can always import factory samples later.
+
+---
+
+## Not enough disk space
+
+Romper needs space for its local store and for syncing to the SD card.
+
+- **Local store**: Requires a few MB for the database, plus space for any cached data.
+- **SD card sync**: The SD card needs enough free space for all the WAV files in your configured kits. Check the card's capacity -- standard Rample SD cards are typically 4 GB or larger.
+- **Factory samples**: If downloading factory samples, ensure you have approximately 1 GB of free disk space on the drive where your local store is located.
+
+**To free up space on the SD card**: Remove unused kits from banks you are not using. Romper's kit browser makes it easy to see which slots are occupied.
+
+---
+
+## Audio not playing
+
+If samples do not produce sound when you click play or use the step sequencer:
+
+- **Check system volume** -- Ensure your system volume is not muted and is turned up.
+- **Check audio output device** -- In your operating system's sound settings, verify the correct output device is selected.
+- **Try a different sample** -- The file may be corrupted or in an unsupported format. Romper supports WAV files.
+- **Restart Romper** -- If audio worked previously but stopped, restarting the application can resolve transient audio system issues.
+- **Check file paths** -- If you moved or deleted the original sample file after assigning it to a kit, Romper cannot play it. Reassign the sample from its new location.
+
+---
+
+## Local store became invalid
+
+If Romper reports that your local store is invalid or corrupted:
+
+- **Re-run the setup wizard** -- Romper will prompt you to set up a new local store. You can point it to the same directory, and Romper will attempt to recover existing data.
+- **Choose a new directory** -- If recovery fails, choose a fresh directory for your local store and reimport your kits from your SD card.
+- **Check disk health** -- Corrupted stores can indicate disk issues. Run your operating system's disk checking utility.
+- **Backup consideration** -- The local store is a working copy. Your definitive data lives on your SD card and in your original sample files. Losing the local store means rebuilding your kit configurations, but no samples are lost.
+
+</div>
+</div>
+</section>

--- a/electron/resources/entitlements.plist
+++ b/electron/resources/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Allow JIT compilation (required for better-sqlite3 native module) -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!-- Allow unsigned executable memory (required for Electron/V8) -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Allow DYLD environment variables (required for Electron framework loading) -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -1,3 +1,13 @@
+// Determine if macOS signing credentials are available
+const hasMacSigningCreds = !!(
+  process.env.APPLE_IDENTITY || process.env.APPLE_SIGNING_IDENTITY
+);
+const hasMacNotarizeCreds = !!(
+  process.env.APPLE_ID &&
+  process.env.APPLE_ID_PASSWORD &&
+  process.env.APPLE_TEAM_ID
+);
+
 const config = {
   packagerConfig: {
     name: "Romper",
@@ -37,20 +47,33 @@ const config = {
     extraResource: [
       // Include any additional resources needed at runtime
     ],
-    // Code signing configuration framework (requires certificates)
-    // Uncomment and configure when Apple Developer certificates are available
-    // osxSign: {
-    //   identity: "Developer ID Application: Your Name (TEAM_ID)",
-    //   hardened_runtime: true,
-    //   entitlements: "./electron/resources/entitlements.plist",
-    //   "entitlements-inherit": "./electron/resources/entitlements.plist",
-    //   "signature-flags": "library"
-    // },
-    // osxNotarize: {
-    //   appleId: "your-apple-id@example.com",
-    //   appleIdPassword: "@env:APPLE_ID_PASSWORD", // App-specific password
-    //   teamId: "YOUR_TEAM_ID"
-    // }
+    // macOS code signing -- enabled only when APPLE_IDENTITY env var is set
+    ...(hasMacSigningCreds
+      ? {
+          osxSign: {
+            identity:
+              process.env.APPLE_IDENTITY ||
+              process.env.APPLE_SIGNING_IDENTITY,
+            optionsForFile: () => ({
+              hardenedRuntime: true,
+              entitlements: "./electron/resources/entitlements.plist",
+              "entitlements-inherit":
+                "./electron/resources/entitlements.plist",
+              "signature-flags": "library",
+            }),
+          },
+        }
+      : {}),
+    // macOS notarization -- enabled only when Apple ID credentials are set
+    ...(hasMacNotarizeCreds
+      ? {
+          osxNotarize: {
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.APPLE_TEAM_ID,
+          },
+        }
+      : {}),
   },
   rebuildConfig: {},
   makers: [
@@ -62,6 +85,14 @@ const config = {
         authors: "Romper Development Team",
         description: "Sample manager for Squarp Rample Eurorack sampler",
         setupIcon: "./electron/resources/app-icon.ico",
+        // Windows code signing via pfx file (when available)
+        ...(process.env.WINDOWS_CERTIFICATE_FILE
+          ? {
+              certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
+              certificatePassword:
+                process.env.WINDOWS_CERTIFICATE_PASSWORD || "",
+            }
+          : {}),
       },
     },
     {

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -90,6 +90,36 @@ const checks = [
     fix: "Add license, description, and author fields to package.json for RPM packaging",
   },
   {
+    name: "macOS signing environment configured",
+    check: () => {
+      // Check if macOS signing env vars are set (for local builds)
+      const hasIdentity = !!(
+        process.env.APPLE_IDENTITY || process.env.APPLE_SIGNING_IDENTITY
+      );
+      const hasNotarize = !!(
+        process.env.APPLE_ID &&
+        process.env.APPLE_ID_PASSWORD &&
+        process.env.APPLE_TEAM_ID
+      );
+      return hasIdentity && hasNotarize;
+    },
+    fix: "Set APPLE_IDENTITY, APPLE_ID, APPLE_ID_PASSWORD, and APPLE_TEAM_ID for signed macOS builds. Unsigned builds will still work.",
+    warning: true, // Warning only — unsigned local builds are fine
+  },
+  {
+    name: "Windows signing environment configured",
+    check: () => {
+      // Check if Windows signing env vars are set (for local builds)
+      // In CI, Azure Trusted Signing Action handles this via secrets
+      return !!(
+        process.env.WINDOWS_CERTIFICATE_FILE ||
+        process.env.AZURE_CLIENT_ID
+      );
+    },
+    fix: "Set WINDOWS_CERTIFICATE_FILE (local) or AZURE_CLIENT_ID (CI) for signed Windows builds. Unsigned builds will still work.",
+    warning: true, // Warning only — unsigned local builds are fine
+  },
+  {
     name: "Tests passing",
     check: async () => {
       // This would require running tests, which is expensive


### PR DESCRIPTION
## Summary

- **App Signing (Unit 7)**: macOS codesigning + notarization and Windows Azure Trusted Signing configured in release workflow. All signing is conditional on secrets being present — unsigned builds still work.
- **Docs Website (Unit 8)**: FAQ page (7 questions), Troubleshooting page (6 issues), SEO essentials (robots.txt, sitemap.xml), Community & Support section on landing page.

## Changes

**New files:** entitlements.plist, faq.md, troubleshooting.md, robots.txt, sitemap.xml

**Modified:** forge.config.cjs (conditional signing), release.yml (signing workflow steps), validate.js (signing warnings), _config.yml (sitemap plugin), index.html (doc links + community section), styles.css (page content + community styles)

## Test Results

- 3,499 unit tests passing (237 files)
- 324 integration tests passing (20 files)
- TypeScript clean, ESLint clean, build successful

## Prerequisites for Signing (user action required)

**macOS:** Apple Developer Program ($99/yr), then configure GitHub secrets: APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD, APPLE_ID, APPLE_ID_PASSWORD, APPLE_TEAM_ID

**Windows:** Azure Trusted Signing ($9.99/mo), then configure GitHub secrets: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SIGNING_ACCOUNT, AZURE_CERTIFICATE_PROFILE

## Test plan

- [ ] Verify unsigned builds still work (no secrets configured)
- [ ] Verify docs site builds with Jekyll (faq, troubleshooting, sitemap render)
- [ ] Verify landing page shows Documentation links and Community section
- [ ] Verify robots.txt accessible at site root
- [ ] CI passes on all platforms