### PR TITLE
fix(ci): unblock release workflow and SonarCloud scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # The `secrets` context cannot be used in step `if:` conditions, so surface
+    # the gating secrets as job-level env and gate steps on `env.*` instead.
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
 
     steps:
       - name: Checkout code
@@ -104,7 +109,7 @@ jobs:
 
       # ── macOS: Import signing certificate into temporary keychain ──
       - name: Import macOS signing certificate
-        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -158,7 +163,7 @@ jobs:
 
       # ── Windows: Sign artifacts with Azure Trusted Signing ──
       - name: Sign Windows artifacts with Azure Trusted Signing
-        if: matrix.os == 'windows-latest' && secrets.AZURE_CLIENT_ID != ''
+        if: matrix.os == 'windows-latest' && env.AZURE_CLIENT_ID != ''
         uses: azure/trusted-signing-action@v0.5.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -175,7 +180,7 @@ jobs:
 
       # ── macOS: Clean up temporary keychain ──
       - name: Clean up macOS keychain
-        if: always() && matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
+        if: always() && matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           if [ -f "$KEYCHAIN_PATH" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,10 @@ jobs:
     needs: [unit-tests, integration-tests]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # The SonarCloud Scan step exceeded the previous 8-minute limit and was
+    # killed mid-scan on every main push, so SonarCloud had not re-analyzed
+    # since 2026-04-10. Give the scan room to complete.
+    timeout-minutes: 25
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Two CI bugs that block the v1.1.0 release, found while investigating the failed release run on the #231 merge.

## 1. `release.yml` was an invalid workflow file
The macOS/Windows signing steps gated on the **`secrets` context inside `if:`** (`secrets.APPLE_CERTIFICATE != ''`, `secrets.AZURE_CLIENT_ID != ''`). GitHub Actions does not allow `secrets` in `if:`, so the whole file failed to parse — it logged a 0s failure on every push and would fail identically on a `v*` tag. The signed release pipeline has never been runnable since signing was added (#219).

**Fix:** surface the two gating secrets as job-level `env` on the `build` job and gate the steps on `env.*` (allowed in step `if:`).

## 2. SonarCloud has not analyzed `main` in ~7 weeks
The `analysis` job (`test.yml`) runs the SonarCloud Scan as its final step under `timeout-minutes: 8`. The scan exceeded it and the job was killed mid-scan on every main push — last successful analysis was **2026-04-10 (v1.0.1)**. Codecov stayed current only because its upload runs earlier in the same job. This is why SonarCloud `new_coverage` (79.1%, new-code metric) never moved while Codecov/overall coverage sits at ~91%.

**Fix:** raise the `analysis` job `timeout-minutes` 8 → 25 so the scan can finish.

## Effect
After merge, SonarCloud re-analyzes `main` for the first time since April — producing accurate `new_coverage` and issue counts — and `release.yml` becomes a valid, runnable workflow.

## Test plan
- [x] No `secrets.` references remain in any `if:` (`grep` clean)
- [x] `release.yml` and `test.yml` parse as valid YAML
- [x] Pre-commit gate green (typecheck, lint, unit + integration tests, build)
- [ ] Post-merge: confirm the `analysis` job completes and SonarCloud shows a fresh analysis timestamp