### PR TITLE
fix(e2e): pass Windows E2E tests (tmpdir + sqlite3)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,15 @@ jobs:
           echo "Current directory: $(pwd)"
         shell: bash
 
+      # Ubuntu/macOS runners ship the sqlite3 CLI; Windows does not. The sync
+      # E2E tests shell out to `sqlite3` to fix fixture source paths.
+      - name: Install sqlite3 CLI (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install sqlite --no-progress -y
+          sqlite3 -version
+        shell: pwsh
+
       - name: Install system dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/app/renderer/components/hooks/wizard/__tests__/localStoreWizard.e2e.test.ts
+++ b/app/renderer/components/hooks/wizard/__tests__/localStoreWizard.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { _electron as electron, expect, test } from "@playwright/test";
 import fs from "fs-extra";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -144,7 +145,10 @@ async function runWizardTest(
   }
 
   // 2. target - generate dynamic path since ROMPER_LOCAL_PATH is empty
-  const targetPath = path.join("/tmp", `romper-e2e-${source}-${Date.now()}`);
+  const targetPath = path.join(
+    os.tmpdir(),
+    `romper-e2e-${source}-${Date.now()}`,
+  );
   await window.waitForSelector("#local-store-path-input", { state: "visible" });
   await window.fill("#local-store-path-input", targetPath);
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "@playwright/test";
+import os from "node:os";
+import path from "node:path";
 
 export default defineConfig({
   expect: {
@@ -33,7 +35,8 @@ export default defineConfig({
           env: {
             ...process.env,
             ROMPER_SDCARD_PATH:
-              process.env.ROMPER_SDCARD_PATH || "/tmp/e2e-sdcard",
+              process.env.ROMPER_SDCARD_PATH ||
+              path.join(os.tmpdir(), "e2e-sdcard"),
             // Ensure display is set for headless environments
             ...(process.env.CI && !process.env.DISPLAY
               ? { DISPLAY: ":99" }

--- a/tests/utils/e2e-fixture-extractor.ts
+++ b/tests/utils/e2e-fixture-extractor.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from "fs-extra";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as tar from "tar";
@@ -116,8 +117,8 @@ export async function extractE2EFixture(): Promise<E2ETestEnvironment> {
 
   // Create temporary directories
   const testId = Date.now();
-  const localStorePath = path.join("/tmp", `romper-e2e-local-${testId}`);
-  const tempSdcardPath = path.join("/tmp", `romper-e2e-sdcard-${testId}`);
+  const localStorePath = path.join(os.tmpdir(), `romper-e2e-local-${testId}`);
+  const tempSdcardPath = path.join(os.tmpdir(), `romper-e2e-sdcard-${testId}`);
 
   await fs.ensureDir(localStorePath);
   await fs.ensureDir(tempSdcardPath);


### PR DESCRIPTION
Fixes #233.

Five E2E tests failed deterministically on `windows-latest` (test-code/infra bugs, not the product).

## Changes
**Hardcoded `/tmp` → `os.tmpdir()`** (resolved to `\tmp` on Windows, which the wizard's write-permission pre-check correctly rejected):
- `tests/utils/e2e-fixture-extractor.ts` — local + sdcard fixture dirs
- `app/renderer/components/hooks/wizard/__tests__/localStoreWizard.e2e.test.ts` — wizard target path
- `playwright.config.ts` — `ROMPER_SDCARD_PATH` local-dev fallback (CI always sets this env explicitly, so no CI behavior change)

**Install `sqlite3` CLI on the Windows runner** (`e2e.yml`):
- The sync E2E tests shell out to `sqlite3` to rewrite fixture `source_path`s. Ubuntu/macOS runners ship it; Windows doesn't.

## Validation
- [x] `os.tmpdir()` matches the already-passing pattern in `onboarding-errors.e2e.test.ts`
- [x] Pre-commit gate green (typecheck, lint, unit + integration, build)
- [ ] **Windows E2E only runs the full OS matrix on push to `main`** (the `e2e.yml` matrix is ubuntu-only on PRs), so the Windows result is verified post-merge.

## Scope note
Independent of the release pipeline — does not block the `v1.1.0` tag.