### PR TITLE
fix(ci): disable hanging SonarCloud jasmin security sensor

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,6 +32,15 @@ sonar.javascript.lcov.reportPaths=coverage/merged/lcov.info
 sonar.typescript.tsconfigPath=tsconfig.json
 sonar.verbose=false
 
+# Disable the JS/TS security (taint) sensor. JsSecuritySensorV2/jasmin hangs
+# indefinitely on this codebase (stalls mid-run and never completes), which
+# was killing the analysis job at its timeout and freezing all SonarCloud
+# analysis since 2026-04-10 (see issue #237). A known SonarCloud bug on
+# TypeScript projects. Standard JS/TS rules, security hotspots, and coverage
+# import are unaffected; only deep taint/SAST is skipped (N/A for an offline
+# desktop app with no server/injection attack surface).
+sonar.jasmin.internal.disabled=true
+
 # Exclude accessibility rules that require native HTML elements
 # These rules conflict with our use of custom components and virtualized lists
 sonar.issue.ignore.multicriteria=e1,e2,e3,e4


### PR DESCRIPTION
Fixes #237.

## Root cause (from the scanner log)
SonarCloud's `JsSecuritySensorV2 [jasmin]` (deep taint/SAST sensor) **hangs indefinitely**:
- JS/TS analysis: done in 55s ✓
- Coverage import: 137ms ✓
- `JsSecuritySensorV2` starts on 239 files → reaches **57% (138/239) at 05:38:47, then zero further output until the job is killed at the 25-min timeout (06:02:12)** — ~23 min stuck on one file.

That's why the `analysis` job kept getting cancelled (no timeout fixes an infinite hang) and **SonarCloud has been frozen since 2026-04-10** — `new_coverage` stuck at the stale 79.1% while the codebase is actually ~91% covered (per Codecov *and* SonarCloud's own overall `coverage` metric).

## Fix
`sonar.jasmin.internal.disabled=true` — the documented workaround for this [known SonarCloud bug](https://community.sonarsource.com/t/jasmin-jssecuritysensorv2-hangs-at-82-on-large-typescript-monorepo-cannot-be-skipped/181296) on TypeScript projects. Only the deep taint/SAST sensor is skipped; standard JS/TS rules, security hotspots, and coverage import are unaffected. Taint analysis (injection/XSS via server routes) is N/A for an offline Electron desktop app.

## Expected result after merge
The next main-push `analysis` job completes in ~1–2 min → SonarCloud finally re-analyzes → `new_coverage` updates from the stale 79.1% toward ~91%, clearing the 80% gate condition on its own.

Follow-up: the `analysis` job `timeout-minutes` (raised to 25 in #232) can be lowered again once we confirm scans complete quickly.