### PR TITLE
test: add assertions to debounced cancellation test (S2699)

### DIFF
--- a/app/renderer/utils/__tests__/asyncStateManagement.test.ts
+++ b/app/renderer/utils/__tests__/asyncStateManagement.test.ts
@@ -453,6 +453,11 @@ describe("Async State Management - Unit Tests", () => {
           // Expected cancellation error - do nothing
         }
       });
+
+      // The debounced operation fired exactly once, and cancelling during
+      // execution leaves the hook in a settled (not-loading) state.
+      expect(mockOperation).toHaveBeenCalledTimes(1);
+      expect(result.current.loading).toBe(false);
     });
   });
 });


### PR DESCRIPTION
The release quality-gate blocked on a single BLOCKER, `typescript:S2699` at `app/renderer/utils/__tests__/asyncStateManagement.test.ts:424` — the "should handle cancellation during execution" test ran cancel logic but asserted nothing.

It only surfaced now that the SonarCloud analysis job completes again (jasmin sensor disabled in #238 — before that, SonarCloud had been frozen since 2026-04-10).

Adds two meaningful assertions: the debounced operation fired exactly once, and the hook settles to not-loading after cancellation. Unblocks the v1.1.0 release gate.