### PR TITLE
fix(ci): disable hanging jasmin sensor via correct js.ts property

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      # TEMP: run the full analysis (incl. SonarCloud scan) on this diagnostics
+      # branch as a push event, so the jasmin hang can be diagnosed off main.
+      - chore/jasmin-stacktrace-diagnostics
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-      # TEMP: run the full analysis (incl. SonarCloud scan) on this diagnostics
-      # branch as a push event, so the jasmin hang can be diagnosed off main.
-      - chore/jasmin-stacktrace-diagnostics
   pull_request:
     branches:
       - "**"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,21 +30,19 @@ sonar.javascript.lcov.reportPaths=coverage/merged/lcov.info
 
 # Additional settings
 sonar.typescript.tsconfigPath=tsconfig.json
-# TEMP DIAGNOSTIC: verbose logs each file as jasmin processes it so we can
-# identify the file (position 139/239) where the security sensor deadlocks.
-sonar.verbose=true
+sonar.verbose=false
 
-# Disable the JS/TS security (taint) sensor. JsSecuritySensorV2/jasmin hangs
-# indefinitely on this codebase (stalls mid-run and never completes), which
-# was killing the analysis job at its timeout and freezing all SonarCloud
-# analysis since 2026-04-10 (see issue #237). A known SonarCloud bug on
-# TypeScript projects. Standard JS/TS rules, security hotspots, and coverage
-# import are unaffected; only deep taint/SAST is skipped (N/A for an offline
-# desktop app with no server/injection attack surface).
-sonar.jasmin.internal.disabled=true
-# TEMP DIAGNOSTIC: the disable flag above is a no-op (sensor still runs and
-# hangs). Enable jasmin stack tracing so it dumps where it deadlocks.
-sonar.jasmin.internal.enable.stacktracing=true
+# Disable the JS/TS security (taint) sensor. JsSecuritySensorV2/jasmin does a
+# cross-file taint path exploration that explodes combinatorially on this
+# codebase's React hook/component call graph (stack depth 45+), hanging until
+# the analysis job times out — which froze all SonarCloud analysis since
+# 2026-04-10 (see issue #237). The injection/XSS/SSRF rules it runs are N/A for
+# an offline Electron desktop app (no server/untrusted-network entry points).
+# NOTE: the generic `sonar.jasmin.internal.disabled` flag is a no-op for JS/TS;
+# the JS/TS-specific property below is the one that actually disables it
+# (confirmed on the SonarSource community forum) and works on the free tier
+# without Quality Profile changes.
+sonar.jasmin.internal.js.ts.disabled=true
 
 # Exclude accessibility rules that require native HTML elements
 # These rules conflict with our use of custom components and virtualized lists

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,7 +30,9 @@ sonar.javascript.lcov.reportPaths=coverage/merged/lcov.info
 
 # Additional settings
 sonar.typescript.tsconfigPath=tsconfig.json
-sonar.verbose=false
+# TEMP DIAGNOSTIC: verbose logs each file as jasmin processes it so we can
+# identify the file (position 139/239) where the security sensor deadlocks.
+sonar.verbose=true
 
 # Disable the JS/TS security (taint) sensor. JsSecuritySensorV2/jasmin hangs
 # indefinitely on this codebase (stalls mid-run and never completes), which
@@ -40,6 +42,9 @@ sonar.verbose=false
 # import are unaffected; only deep taint/SAST is skipped (N/A for an offline
 # desktop app with no server/injection attack surface).
 sonar.jasmin.internal.disabled=true
+# TEMP DIAGNOSTIC: the disable flag above is a no-op (sensor still runs and
+# hangs). Enable jasmin stack tracing so it dumps where it deadlocks.
+sonar.jasmin.internal.enable.stacktracing=true
 
 # Exclude accessibility rules that require native HTML elements
 # These rules conflict with our use of custom components and virtualized lists


### PR DESCRIPTION
Fixes the SonarCloud freeze (#237) for real.

## Root cause (diagnosed via verbose + jasmin stacktracing)
`JsSecuritySensorV2` (jasmin = JS/TS taint/SAST) loads all 239 files in ~0.2s, then does a cross-file taint **path exploration that explodes combinatorially** on this codebase's React hook/component call graph (stack depth 45+, `SampleWaveform.tsx`/`BankHeader.tsx` as hot nodes), hanging ~23 min until the analysis job times out — which froze all SonarCloud analysis since 2026-04-10. The injection/XSS/SSRF rules it runs are N/A for an offline Electron desktop app.

## Fix
The generic `sonar.jasmin.internal.disabled` (tried in #238) is a **no-op for JS/TS**. The JS/TS-specific property **`sonar.jasmin.internal.js.ts.disabled=true`** actually disables it ([confirmed on the SonarSource forum](https://community.sonarsource.com/t/jasmin-jssecuritysensorv2-hangs-at-82-on-large-typescript-monorepo-cannot-be-skipped/181296)) — scanner-side, works on the **free tier** without Quality Profile edits.

## Validated
Branch analysis run completed in **1m56s** (was timing out at 25 min). Standard JS/TS rules, security hotspots, and coverage import are unaffected; only the taint engine is skipped.

Reverts the temporary `sonar.verbose` / `sonar.jasmin.internal.enable.stacktracing` diagnostics and the branch push-trigger.