### PR TITLE
chore(sonar): modernize JS/TS idioms (#244)

### DIFF
--- a/app/renderer/components/KitBankNav.tsx
+++ b/app/renderer/components/KitBankNav.tsx
@@ -9,7 +9,9 @@ interface KitBankNavProps {
   selectedBank?: string;
 }
 
-const banks = Array.from({ length: 26 }, (_, i) => String.fromCharCode(65 + i));
+const banks = Array.from({ length: 26 }, (_, i) =>
+  String.fromCodePoint(65 + i),
+);
 
 // Fisheye scale: closest letter scales to max, fades over `radius` neighbors
 const BASE_SCALE = 1;

--- a/app/renderer/components/SampleWaveform.tsx
+++ b/app/renderer/components/SampleWaveform.tsx
@@ -27,8 +27,8 @@ function buildEnvelope(
   const tops = new Float32Array(width);
   const bottoms = new Float32Array(width);
   for (let i = 0; i < width; i++) {
-    let max = -1.0,
-      min = 1.0;
+    let max = -1,
+      min = 1;
     for (let j = 0; j < step; j++) {
       const datum = data[i * step + j] || 0;
       if (datum < min) min = datum;
@@ -57,7 +57,7 @@ function computeRms(
 // string usable by canvas APIs. Falls back to accent-primary or a default blue.
 function resolveWaveformColor(voiceColor?: string): string {
   if (voiceColor) {
-    const varMatch = voiceColor.match(/^var\((.+)\)$/);
+    const varMatch = /^var\((.+)\)$/.exec(voiceColor);
     if (varMatch) {
       const resolved = getComputedStyle(document.documentElement)
         .getPropertyValue(varMatch[1])
@@ -208,7 +208,7 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
       tracePath(ctx, bottoms);
       ctx.stroke();
 
-      ctx.globalAlpha = 1.0;
+      ctx.globalAlpha = 1;
     },
     [voiceColor],
   );

--- a/app/renderer/components/dialogs/led-grid/ledConstants.ts
+++ b/app/renderer/components/dialogs/led-grid/ledConstants.ts
@@ -16,22 +16,22 @@ export type WaveType = "saw" | "sine" | "triangle";
 
 // Each row gets its own LFO config for varied wave patterns
 export const ROW_LFO_CONFIGS: RowLfoConfig[] = [
-  { frequency: 0.12, phase: 0.0, spatialFreq: 0.3, wave: "sine" },
+  { frequency: 0.12, phase: 0, spatialFreq: 0.3, wave: "sine" },
   { frequency: 0.18, phase: 0.4, spatialFreq: 0.25, wave: "triangle" },
   { frequency: 0.09, phase: 0.8, spatialFreq: 0.35, wave: "saw" },
   { frequency: 0.22, phase: 1.2, spatialFreq: 0.2, wave: "sine" },
   { frequency: 0.15, phase: 1.6, spatialFreq: 0.4, wave: "triangle" },
-  { frequency: 0.1, phase: 2.0, spatialFreq: 0.15, wave: "sine" },
+  { frequency: 0.1, phase: 2, spatialFreq: 0.15, wave: "sine" },
   { frequency: 0.25, phase: 2.4, spatialFreq: 0.3, wave: "saw" },
   { frequency: 0.08, phase: 2.8, spatialFreq: 0.28, wave: "triangle" },
   { frequency: 0.2, phase: 3.2, spatialFreq: 0.22, wave: "sine" },
   { frequency: 0.14, phase: 3.6, spatialFreq: 0.38, wave: "saw" },
-  { frequency: 0.3, phase: 4.0, spatialFreq: 0.18, wave: "triangle" },
+  { frequency: 0.3, phase: 4, spatialFreq: 0.18, wave: "triangle" },
   { frequency: 0.11, phase: 4.4, spatialFreq: 0.32, wave: "sine" },
   { frequency: 0.19, phase: 4.8, spatialFreq: 0.26, wave: "saw" },
   { frequency: 0.35, phase: 5.2, spatialFreq: 0.2, wave: "triangle" },
   { frequency: 0.13, phase: 5.6, spatialFreq: 0.35, wave: "sine" },
-  { frequency: 0.16, phase: 6.0, spatialFreq: 0.24, wave: "saw" },
+  { frequency: 0.16, phase: 6, spatialFreq: 0.24, wave: "saw" },
 ];
 
 // Interaction tuning

--- a/app/renderer/components/dialogs/led-grid/ledMath.ts
+++ b/app/renderer/components/dialogs/led-grid/ledMath.ts
@@ -88,7 +88,7 @@ export function computeRippleBoost(
     const radius = elapsed * speed;
     const dx = col - ripple.col;
     const dy = row - ripple.row;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+    const dist = Math.hypot(dx, dy);
     const ringDist = Math.abs(dist - radius);
     if (ringDist < width) {
       const ringIntensity = 1 - ringDist / width;

--- a/app/renderer/components/hooks/kit-management/useKitDataManager.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDataManager.ts
@@ -118,9 +118,7 @@ export function useKitDataManager({
           const sortedKitNames = loadedKits
             .map((k) => k.name)
             .sort(compareKitSlots);
-          const kitIndex = sortedKitNames.findIndex(
-            (name) => name === scrollToKit,
-          );
+          const kitIndex = sortedKitNames.indexOf(scrollToKit);
 
           if (kitIndex !== -1) {
             const kitEl = document.querySelector(`[data-kit='${scrollToKit}']`);

--- a/app/renderer/components/hooks/kit-management/useKitStepSequencer.ts
+++ b/app/renderer/components/hooks/kit-management/useKitStepSequencer.ts
@@ -8,7 +8,9 @@ export function useKitStepSequencer(initialPattern?: boolean[][]) {
   // pattern[voice][step] = boolean
   const [pattern, setPattern] = useState<boolean[][]>(
     initialPattern ||
-      Array.from({ length: NUM_VOICES }, () => Array(NUM_STEPS).fill(false)),
+      Array.from({ length: NUM_VOICES }, () =>
+        new Array(NUM_STEPS).fill(false),
+      ),
   );
 
   // Helper function to toggle a specific step in a voice row

--- a/app/renderer/components/hooks/shared/stepPatternConstants.ts
+++ b/app/renderer/components/hooks/shared/stepPatternConstants.ts
@@ -97,7 +97,7 @@ export const LED_GLOWS = [
  * Creates a default empty step pattern (4 voices x 16 steps, all velocity 0)
  */
 export function createDefaultStepPattern(): number[][] {
-  return Array.from({ length: NUM_VOICES }, () => Array(NUM_STEPS).fill(0));
+  return Array.from({ length: NUM_VOICES }, () => new Array(NUM_STEPS).fill(0));
 }
 
 /**

--- a/app/renderer/components/hooks/shared/useExternalDragHandlers.ts
+++ b/app/renderer/components/hooks/shared/useExternalDragHandlers.ts
@@ -79,7 +79,7 @@ export function useExternalDragHandlers({
         }
 
         // Determine if this is insert-before or append
-        const currentSampleCount = samples.filter((s) => s).length;
+        const currentSampleCount = samples.filter(Boolean).length;
         const isAppend = slotNumber === currentSampleCount;
         const mode = isAppend ? "append" : "insert";
 

--- a/app/renderer/components/hooks/shared/useInternalDragHandlers.ts
+++ b/app/renderer/components/hooks/shared/useInternalDragHandlers.ts
@@ -116,7 +116,7 @@ export function useInternalDragHandlers({
 
       // Determine drop mode for visual feedback
       // All moves are insert-only, but we need to distinguish insert vs append
-      const currentSampleCount = samples.filter((s) => s).length;
+      const currentSampleCount = samples.filter(Boolean).length;
       const isAppend = slotNumber === currentSampleCount;
       const mode = isAppend ? "append" : "insert";
 

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
@@ -272,7 +272,7 @@ export function useVoicePanelSlotRendering({
   // Helper function to render single drop zone per voice (append-only)
   const renderSingleDropZone = React.useCallback(() => {
     const { nextAvailableSlot } = slotRenderingHook.calculateRenderSlots();
-    const sampleCount = samples.filter((s) => s).length;
+    const sampleCount = samples.filter(Boolean).length;
 
     // Only show drop zone if editable and voice isn't full
     if (!isEditable || sampleCount >= MAX_SLOTS_PER_VOICE) {
@@ -341,7 +341,7 @@ export function useVoicePanelSlotRendering({
   // Main render function for all sample slots (always render exactly MAX_SLOTS_PER_VOICE for consistent height)
   const renderSampleSlots = React.useCallback(() => {
     const renderedSlots = [];
-    const sampleCount = samples.filter((s) => s).length;
+    const sampleCount = samples.filter(Boolean).length;
 
     // Always render exactly MAX_SLOTS_PER_VOICE slot positions
     for (let i = 0; i < MAX_SLOTS_PER_VOICE; i++) {

--- a/app/renderer/components/hooks/wizard/useLocalStoreWizardFileOps.ts
+++ b/app/renderer/components/hooks/wizard/useLocalStoreWizardFileOps.ts
@@ -56,7 +56,7 @@ export function useLocalStoreWizardFileOps({
   // --- SD Card validation and copy combined ---
   const validateAndCopySdCardKits = useCallback(
     async (sdCardSourcePath: string, targetPath: string) => {
-      if (!sdCardSourcePath) throw new Error();
+      if (!sdCardSourcePath) throw new Error("SD card source path is required");
       const validationError = await validateSdCardFolder(sdCardSourcePath);
       if (validationError) {
         setWizardState({

--- a/app/renderer/components/led-icon/ledIconConstants.ts
+++ b/app/renderer/components/led-icon/ledIconConstants.ts
@@ -8,7 +8,7 @@ export const ICON_LED_COUNT = ICON_COLS * ICON_ROWS;
 
 // Each row gets its own LFO config for varied wave patterns
 export const ICON_ROW_LFO_CONFIGS: RowLfoConfig[] = [
-  { frequency: 0.12, phase: 0.0, spatialFreq: 0.3, wave: "sine" },
+  { frequency: 0.12, phase: 0, spatialFreq: 0.3, wave: "sine" },
   { frequency: 0.18, phase: 0.8, spatialFreq: 0.25, wave: "triangle" },
   { frequency: 0.09, phase: 1.6, spatialFreq: 0.35, wave: "saw" },
   { frequency: 0.22, phase: 2.4, spatialFreq: 0.2, wave: "sine" },
@@ -17,13 +17,13 @@ export const ICON_ROW_LFO_CONFIGS: RowLfoConfig[] = [
 
 // Time multipliers for idle vs hover state
 export const ICON_TIME_IDLE = 0.6; // gentle ambient drift at rest
-export const ICON_TIME_HOVER = 1.0; // full speed on hover
+export const ICON_TIME_HOVER = 1; // full speed on hover
 
 // Interaction tuning (smaller grid = tighter values)
 export const ICON_PROXIMITY_RADIUS_SQ = 8;
 export const ICON_PROXIMITY_INTENSITY = 0.5;
 export const ICON_RIPPLE_SPEED = 4;
-export const ICON_RIPPLE_WIDTH = 1.0;
+export const ICON_RIPPLE_WIDTH = 1;
 export const ICON_RIPPLE_DURATION = 0.8;
 export const ICON_MAX_RIPPLES = 3;
 

--- a/app/renderer/components/led-icon/vuMeterConstants.ts
+++ b/app/renderer/components/led-icon/vuMeterConstants.ts
@@ -24,7 +24,7 @@ export const VU_NOISE_FLOOR = 0.02; // RMS below this reads as silence
 
 // Brightness values
 export const VU_LIT_MIN_BRIGHTNESS = 0.6;
-export const VU_LIT_MAX_BRIGHTNESS = 1.0;
-export const VU_PEAK_BRIGHTNESS = 1.0;
+export const VU_LIT_MAX_BRIGHTNESS = 1;
+export const VU_PEAK_BRIGHTNESS = 1;
 export const VU_UNLIT_BRIGHTNESS = 0.03;
 export const VU_BORDER_BRIGHTNESS = 0.02;

--- a/app/renderer/components/utils/scanners/voiceInferenceScanner.ts
+++ b/app/renderer/components/utils/scanners/voiceInferenceScanner.ts
@@ -22,7 +22,7 @@ export function scanVoiceInference(
 
     // Process each voice
     for (const [voiceNumber, files] of Object.entries(samples)) {
-      const voiceNum = parseInt(voiceNumber, 10);
+      const voiceNum = Number.parseInt(voiceNumber, 10);
 
       if (!files || files.length === 0) {
         continue;

--- a/app/renderer/utils/hmrStateManager.ts
+++ b/app/renderer/utils/hmrStateManager.ts
@@ -49,7 +49,7 @@ export function getSavedSelectedKit(): null | string {
  */
 export function isHmrAvailable(): boolean {
   return (
-    typeof (import.meta as ImportMeta).hot !== "undefined" &&
+    (import.meta as ImportMeta).hot !== undefined &&
     (import.meta as ImportMeta).hot !== null
   );
 }

--- a/app/renderer/utils/sampleGroupingUtils.ts
+++ b/app/renderer/utils/sampleGroupingUtils.ts
@@ -44,7 +44,7 @@ export function groupDbSamplesByVoice(dbSamples: Sample[]): VoiceSamples {
       }
     }
     // Remove trailing empty slots
-    while (voice.length > 0 && voice[voice.length - 1] === "") {
+    while (voice.length > 0 && voice.at(-1) === "") {
       voice.pop();
     }
   });

--- a/electron/main/db/stepPatternUtils.ts
+++ b/electron/main/db/stepPatternUtils.ts
@@ -13,9 +13,9 @@ export function decodeStepPatternFromBlob(
   }
 
   // Create 4 voices x 16 steps pattern
-  const stepPattern: number[][] = Array(STEP_PATTERN_VOICES)
+  const stepPattern: number[][] = new Array(STEP_PATTERN_VOICES)
     .fill(0)
-    .map(() => Array(STEP_PATTERN_STEPS));
+    .map(() => new Array(STEP_PATTERN_STEPS));
 
   for (let step = 0; step < STEP_PATTERN_STEPS; step++) {
     for (let voice = 0; voice < STEP_PATTERN_VOICES; voice++) {

--- a/electron/main/formatConverter.ts
+++ b/electron/main/formatConverter.ts
@@ -249,7 +249,7 @@ function applyGain(
   return channelData.map((channel) => {
     const output = new Float32Array(channel.length);
     for (let i = 0; i < channel.length; i++) {
-      output[i] = Math.max(-1.0, Math.min(1.0, channel[i] * linearGain));
+      output[i] = Math.max(-1, Math.min(1, channel[i] * linearGain));
     }
     return output;
   });

--- a/electron/main/services/rtfFileService.ts
+++ b/electron/main/services/rtfFileService.ts
@@ -15,7 +15,7 @@ class RtfFileService {
    */
   removeRtfFile(dirPath: string, bankLetter: string): void {
     const files = fs.readdirSync(dirPath);
-    const pattern = new RegExp(`^${bankLetter} - .+\\.rtf$`, "iu");
+    const pattern = new RegExp(String.raw`^${bankLetter} - .+\.rtf$`, "iu");
     for (const file of files) {
       if (pattern.test(file)) {
         fs.unlinkSync(path.join(dirPath, file));
@@ -49,7 +49,7 @@ class RtfFileService {
 
     const filename = `${bankLetter} - ${artistName}.rtf`;
     const filePath = path.join(dirPath, filename);
-    fs.writeFileSync(filePath, "{\\rtf1}", "utf-8");
+    fs.writeFileSync(filePath, String.raw`{\rtf1}`, "utf-8");
   }
 }
 

--- a/electron/main/services/syncService.ts
+++ b/electron/main/services/syncService.ts
@@ -221,7 +221,7 @@ class SyncService {
     // Base time per file (seconds)
     const baseTimePerFile = 0.5;
     // Additional time per conversion
-    const timePerConversion = 2.0;
+    const timePerConversion = 2;
 
     return Math.ceil(
       totalFiles * baseTimePerFile + conversions * timePerConversion,

--- a/shared/kitUtilsShared.ts
+++ b/shared/kitUtilsShared.ts
@@ -8,7 +8,7 @@ export function groupSamplesByVoice(files: string[]): {
   files.forEach((f) => {
     const match = /^([1-4])./.exec(f);
     if (match) {
-      const voice = parseInt(match[1], 10);
+      const voice = Number.parseInt(match[1], 10);
       if (voices[voice]) voices[voice].push(f);
     }
   });
@@ -199,7 +199,7 @@ function checkWordBoundaryKeywords(name: string): null | string {
     if (!Array.isArray(keywords)) continue;
     for (const keyword of keywords) {
       if (!keyword.includes(" ")) {
-        if (new RegExp(`(^|\\W)${keyword}(?=\\W|$)`, "i").test(name)) {
+        if (new RegExp(String.raw`(^|\W)${keyword}(?=\W|$)`, "i").test(name)) {
           return toCapitalCase(type);
         }
       }


### PR DESCRIPTION
## Summary
Burn-down of SonarCloud issue category [#244](https://github.com/peteb4ker/romper/issues/244) — **35 maintainability issues** across 21 files. All changes are mechanical idiom modernizations with **no behavior or UI change**.

| Rule | Fix |
|------|-----|
| S7748 | Drop zero fractions in numeric literals (`1.0` → `1`) |
| S7723 | `Array(n)` → `new Array(n)` |
| S7770 | `filter((s) => s)` → `filter(Boolean)` |
| S7780 | Regex/RTF strings → `String.raw` (no `\\` escaping) |
| S7773 | `parseInt` → `Number.parseInt` |
| S6594 | `String.match()` → `RegExp.exec()` |
| S7769 | `Math.sqrt(dx*dx+dy*dy)` → `Math.hypot(dx, dy)` |
| S7758 | `String.fromCharCode` → `String.fromCodePoint` |
| S7755 | `arr[arr.length-1]` → `arr.at(-1)` |
| S7753 | `findIndex(n => n === x)` → `indexOf(x)` |
| S7741 | `typeof x !== "undefined"` → `x !== undefined` |
| S7722 | Add a message to the `Error` constructor |

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] Unit tests — 3524 passed
- [x] Integration tests — 529 passed
- [x] Pre-commit hook (lint + typecheck + unit + integration) — passed

Closes #244