### PR TITLE
chore(sonar): React hook/prop cleanups (#246, partial)

### DIFF
--- a/app/renderer/components/KitBrowserContainer.tsx
+++ b/app/renderer/components/KitBrowserContainer.tsx
@@ -25,7 +25,6 @@ interface KitBrowserContainerProps {
   onSearchClear?: () => void;
   onSelectKit: (kitName: string) => void;
   onShowSettings: () => void;
-  ref?: React.Ref<KitBrowserHandle>;
   sampleCounts: Record<string, [number, number, number, number]>;
   // Search functionality
   searchQuery?: string;

--- a/app/renderer/components/KitBrowserHeader.tsx
+++ b/app/renderer/components/KitBrowserHeader.tsx
@@ -25,7 +25,9 @@ interface KitBrowserHeaderProps {
   showModifiedOnly?: boolean;
 }
 
-function BulkScanStatus({ progress }: { progress: BulkScanProgress }) {
+function BulkScanStatus({
+  progress,
+}: Readonly<{ progress: BulkScanProgress }>) {
   if (progress.status === "idle") return null;
 
   if (progress.status === "scanning") {

--- a/app/renderer/components/SampleWaveform.tsx
+++ b/app/renderer/components/SampleWaveform.tsx
@@ -94,7 +94,6 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [playhead, setPlayhead] = useState(0);
-  const [, setError] = useState<null | string>(null);
   const sourceRef = useRef<AudioBufferSourceNode | null>(null);
   const animationRef = useRef<null | number>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
@@ -110,11 +109,9 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
   // Load audio file and decode
   useEffect(() => {
     let cancelled = false;
-    setError(null);
 
     // Use secure API with kit/voice/slot identifiers
     if (!window.electronAPI?.getSampleAudioBuffer) {
-      setError("Sample audio buffer API not available");
       if (onError) onError("Sample audio buffer API not available");
       return;
     }
@@ -127,7 +124,6 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
         // Handle null response for missing samples (empty slots)
         if (!arrayBuffer) {
           setAudioBuffer(null);
-          setError(null);
           return;
         }
 
@@ -153,7 +149,6 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
             `[SampleWaveform] Sample not found: kit=${kitName}, voice=${voiceNumber}, slot=${slotNumber}:`,
             err,
           );
-          setError(null); // Don't show error to user for missing samples
         }
         setAudioBuffer(null);
       });

--- a/app/renderer/components/hooks/shared/useBpm.ts
+++ b/app/renderer/components/hooks/shared/useBpm.ts
@@ -10,7 +10,7 @@ interface UseBpmParams {
  * Provides BPM state, validation, and persistence functionality
  */
 export function useBpm({ initialBpm = 120, kitName }: UseBpmParams) {
-  const [bpm, setBpmState] = React.useState(initialBpm);
+  const [bpmState, setBpmState] = React.useState(initialBpm);
   const [isEditing, setIsEditing] = React.useState(false);
 
   // Update local state when initial BPM changes (kit switching)
@@ -43,7 +43,7 @@ export function useBpm({ initialBpm = 120, kitName }: UseBpmParams) {
   }, []);
 
   return {
-    bpm,
+    bpm: bpmState,
     isEditing,
     setBpm,
     setIsEditing,

--- a/app/renderer/components/hooks/shared/useStepPattern.ts
+++ b/app/renderer/components/hooks/shared/useStepPattern.ts
@@ -16,7 +16,9 @@ export function useStepPattern({
   kitName,
   onSaved,
 }: UseStepPatternParams) {
-  const [stepPattern, setStepPatternState] = useState<null | number[][]>(null);
+  const [stepPatternState, setStepPatternState] = useState<null | number[][]>(
+    null,
+  );
 
   useEffect(() => {
     setStepPatternState(ensureValidStepPattern(initialPattern));
@@ -52,6 +54,6 @@ export function useStepPattern({
 
   return {
     setStepPattern: updateStepPattern,
-    stepPattern,
+    stepPattern: stepPatternState,
   };
 }

--- a/app/renderer/components/hooks/shared/useTriggerConditions.ts
+++ b/app/renderer/components/hooks/shared/useTriggerConditions.ts
@@ -19,7 +19,7 @@ export function useTriggerConditions({
   kitName,
   onSaved,
 }: UseTriggerConditionsParams) {
-  const [triggerConditions, setTriggerConditionsState] = useState<
+  const [triggerConditionsState, setTriggerConditionsState] = useState<
     (null | string)[][]
   >(() => ensureValidTriggerConditions(initialConditions));
 
@@ -69,6 +69,6 @@ export function useTriggerConditions({
 
   return {
     setTriggerConditions: updateTriggerConditions,
-    triggerConditions,
+    triggerConditions: triggerConditionsState,
   };
 }

--- a/app/renderer/components/wizard/WizardPostInitGuidance.tsx
+++ b/app/renderer/components/wizard/WizardPostInitGuidance.tsx
@@ -27,8 +27,8 @@ const WizardPostInitGuidance: React.FC<WizardPostInitGuidanceProps> =
               Some samples were skipped (max 12 per voice):
             </p>
             <ul className="text-sm space-y-1">
-              {truncationWarnings.map((w, i) => (
-                <li key={i}>
+              {truncationWarnings.map((w) => (
+                <li key={`${w.kitName}-${w.voiceNumber}`}>
                   Kit <strong>{w.kitName}</strong>, Voice {w.voiceNumber}:{" "}
                   {w.skipped} of {w.total} samples skipped (kept first {w.kept})
                 </li>


### PR DESCRIPTION
## Summary
Partial burn-down of SonarCloud issue category [#246](https://github.com/peteb4ker/romper/issues/246) — the **7 safe, contained fixes**. No behavior change. Does **not** close #246 (see "Remaining" below).

- **S6754 (×4) — destructure `useState` symmetrically.** The three hooks (`useBpm`, `useStepPattern`, `useTriggerConditions`) use a private `setXState` paired with a public wrapper (`setBpm`/`updateStepPattern`/…), so the value is renamed to `<name>State` to pair symmetrically; the returned key (`bpm`/`stepPattern`/`triggerConditions`) is unchanged, so consumers are unaffected. `SampleWaveform` had a write-only `error` state — removed it and its no-op `setError` calls (errors already surface via the `onError` prop + `MessageDisplay`; see the line-385 comment).
- **S6759 (×1)** — `BulkScanStatus` props marked `Readonly<>`.
- **S6479 (×1)** — `WizardPostInitGuidance` uses a stable key (`kitName`+`voiceNumber`) instead of the array index.
- **S6767 (×1)** — removed the misplaced `ref` from `KitBrowserContainerProps`; `forwardRef` supplies `ref`, and it was never read from props.

## Remaining on #246 (8 issues — deliberately not in this PR)
**4 false positives (S6767 on `KitGridItem`):** `isNew`, `onDeleteKit`, `onDuplicateKit`, `onRequestDeleteSummary` are **actually used** (e.g. `isNew` at line 308, `onDeleteKit` at 255/263/303). The rule misfires on the `React.memo(forwardRef<…, PropsA & PropsB>)` pattern. These need to be marked **"False Positive"** in the SonarCloud UI; removing them would break the component.

**3 dead-prop threads + 1 a11y rule (need a focused follow-up):**
- `onShowLocalStoreWizard` (KitBrowserHeader) — passed by `KitBrowser` but unused by the header; removal touches the header, `KitBrowser`, its handler wiring, and a test.
- `searchResultCount` (KitBrowserHeader) — computed in `useKitSearch` and threaded through `KitsView → KitBrowserContainer → KitBrowser → KitBrowserHeader` but never rendered; clean removal cascades across 5 files + a test (looks like an unfinished "result count" feature).
- `onSampleKeyNav` (leaf `KitVoicePanel`) — handled by the parent now; removal touches `KitVoicePanels` + a test.
- `S6848` (GainKnob) — on a hover-only `<div>` (`onMouseEnter`/`onMouseLeave`); the correct remediation is ambiguous.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] Unit tests — 3524 passed
- [x] Integration tests — 529 passed
- [x] Pre-commit hook — passed

Part of #246