### PR TITLE
chore(sonar): replace deprecated phosphor icons & MutableRefObject (#242)

### DIFF
--- a/app/renderer/components/AddKitCard.tsx
+++ b/app/renderer/components/AddKitCard.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "@phosphor-icons/react";
+import { PlusIcon } from "@phosphor-icons/react";
 import React from "react";
 
 interface AddKitCardProps {
@@ -23,7 +23,7 @@ const AddKitCard: React.FC<AddKitCardProps> = ({
         disabled={isCreating}
         onClick={() => onClick(bankLetter)}
       >
-        <Plus size={20} weight="bold" />
+        <PlusIcon size={20} weight="bold" />
         <span className="text-xs font-medium">
           {isCreating ? "Creating..." : "Add Kit"}
         </span>

--- a/app/renderer/components/BankHeader.tsx
+++ b/app/renderer/components/BankHeader.tsx
@@ -1,4 +1,4 @@
-import { Pencil, VinylRecord } from "@phosphor-icons/react";
+import { PencilIcon, VinylRecordIcon } from "@phosphor-icons/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 export interface BankHeaderProps {
@@ -86,7 +86,7 @@ const BankHeader: React.FC<BankHeaderProps> = ({
     return (
       <div className="mt-2 first:mt-0" id={`bank-${bank}`} ref={headerRef}>
         <div className="flex items-center gap-2 px-2 py-1 rounded bg-surface-3 border-l-4 border-l-accent-primary">
-          <VinylRecord
+          <VinylRecordIcon
             className="text-accent-primary/50 shrink-0"
             size={14}
             weight="duotone"
@@ -137,7 +137,7 @@ const BankHeader: React.FC<BankHeaderProps> = ({
                   title={bankName ? "Edit bank name" : "Add bank name"}
                   type="button"
                 >
-                  <Pencil size={12} weight="bold" />
+                  <PencilIcon size={12} weight="bold" />
                 </button>
               )}
             </>
@@ -196,7 +196,7 @@ const BankHeader: React.FC<BankHeaderProps> = ({
                 title={bankName ? "Edit bank name" : "Add bank name"}
                 type="button"
               >
-                <Pencil size={14} weight="bold" />
+                <PencilIcon size={14} weight="bold" />
               </button>
             )}
           </>

--- a/app/renderer/components/KitBrowserHeader.tsx
+++ b/app/renderer/components/KitBrowserHeader.tsx
@@ -1,4 +1,8 @@
-import { BookmarkSimple, DownloadSimple, GearSix } from "@phosphor-icons/react";
+import {
+  BookmarkSimpleIcon,
+  DownloadSimpleIcon,
+  GearSixIcon,
+} from "@phosphor-icons/react";
 import React from "react";
 
 import type { BulkScanProgress } from "./hooks/kit-management/useKitScan";
@@ -118,7 +122,7 @@ const KitBrowserHeader: React.FC<KitBrowserHeaderProps> = (props) => {
                 : "Show only favorite kits"
             }
           >
-            <BookmarkSimple size={14} weight="fill" />
+            <BookmarkSimpleIcon size={14} weight="fill" />
             Favorites
             {typeof props.favoritesCount === "number" &&
               props.favoritesCount > 0 && (
@@ -182,7 +186,7 @@ const KitBrowserHeader: React.FC<KitBrowserHeaderProps> = (props) => {
             onClick={props.onSyncToSdCard}
             title="Write kits to SD card"
           >
-            <DownloadSimple size={12} />
+            <DownloadSimpleIcon size={12} />
             Write
           </button>
         )}
@@ -194,7 +198,7 @@ const KitBrowserHeader: React.FC<KitBrowserHeaderProps> = (props) => {
           onClick={props.onShowSettings}
           title="Configure settings and preferences"
         >
-          <GearSix size={16} />
+          <GearSixIcon size={16} />
         </button>
       </div>
 

--- a/app/renderer/components/KitGridItem.tsx
+++ b/app/renderer/components/KitGridItem.tsx
@@ -1,8 +1,8 @@
 import {
-  BookmarkSimple,
-  Copy,
-  LockSimple,
-  MusicNote,
+  BookmarkSimpleIcon,
+  CopyIcon,
+  LockSimpleIcon,
+  MusicNoteIcon,
   TrashIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
@@ -345,7 +345,7 @@ const KitGridItem = React.memo(
                     data-testid="lock-icon"
                     title="Factory kit (read-only)"
                   >
-                    <LockSimple
+                    <LockSimpleIcon
                       className="text-text-secondary"
                       size={15}
                       weight="bold"
@@ -388,7 +388,7 @@ const KitGridItem = React.memo(
                   className="px-1 py-0.5 text-xs bg-voice-3-muted text-voice-3 rounded border border-voice-3/30 font-mono truncate inline-flex items-center gap-0.5"
                   title={`Artist: ${kitData.searchMatch.matchedArtist}`}
                 >
-                  <MusicNote data-testid="icon-music-note" size={13} />{" "}
+                  <MusicNoteIcon data-testid="icon-music-note" size={13} />{" "}
                   {kitData.searchMatch.matchedArtist}
                 </span>
               </div>
@@ -417,7 +417,7 @@ const KitGridItem = React.memo(
                     isFavorite ? "Remove from favorites" : "Add to favorites"
                   }
                 >
-                  <BookmarkSimple
+                  <BookmarkSimpleIcon
                     className={`${isFavorite ? "" : "opacity-30"} ${isPulsing ? "animate-favorite-pulse" : ""}`}
                     size={17}
                     weight="fill"
@@ -431,7 +431,7 @@ const KitGridItem = React.memo(
                   ref={duplicateButtonRef}
                   title="Duplicate kit"
                 >
-                  <Copy size={15} />
+                  <CopyIcon size={15} />
                 </button>
               )}
               {canDelete && (

--- a/app/renderer/components/KitHeader.tsx
+++ b/app/renderer/components/KitHeader.tsx
@@ -1,14 +1,14 @@
 import type { Kit, KitWithRelations } from "@romper/shared/db/schema";
 
 import {
-  ArrowLeft,
-  ArrowsClockwise,
-  BookmarkSimple,
-  CaretLeft,
-  CaretRight,
-  Circle,
-  Lock,
-  PencilSimple,
+  ArrowLeftIcon,
+  ArrowsClockwiseIcon,
+  BookmarkSimpleIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
+  CircleIcon,
+  LockIcon,
+  PencilSimpleIcon,
 } from "@phosphor-icons/react";
 import React, { useCallback } from "react";
 
@@ -178,7 +178,7 @@ const KitHeader: React.FC<KitHeaderProps> = ({
             onClick={handleBack}
             title="Back"
           >
-            <ArrowLeft className="inline-block mr-1" size={14} /> Back
+            <ArrowLeftIcon className="inline-block mr-1" size={14} /> Back
           </button>
         )}
         {onPrevKit && prevButtonState && (
@@ -189,7 +189,12 @@ const KitHeader: React.FC<KitHeaderProps> = ({
             style={prevButtonState.style}
             title={prevButtonState.title}
           >
-            {renderNavigationButtonContent(false, kitIndex!, kits!, CaretLeft)}
+            {renderNavigationButtonContent(
+              false,
+              kitIndex!,
+              kits!,
+              CaretLeftIcon,
+            )}
           </button>
         )}
         {onNextKit && nextButtonState && (
@@ -200,7 +205,12 @@ const KitHeader: React.FC<KitHeaderProps> = ({
             style={nextButtonState.style}
             title={nextButtonState.title}
           >
-            {renderNavigationButtonContent(true, kitIndex!, kits!, CaretRight)}
+            {renderNavigationButtonContent(
+              true,
+              kitIndex!,
+              kits!,
+              CaretRightIcon,
+            )}
           </button>
         )}
       </div>
@@ -240,7 +250,7 @@ const KitHeader: React.FC<KitHeaderProps> = ({
               kit?.is_favorite ? "Remove from favorites" : "Add to favorites"
             }
           >
-            <BookmarkSimple
+            <BookmarkSimpleIcon
               className={kit?.is_favorite ? "" : "opacity-30"}
               size={20}
               weight="fill"
@@ -258,7 +268,7 @@ const KitHeader: React.FC<KitHeaderProps> = ({
           <div className="flex items-center gap-2">
             {kit?.modified_since_sync && (
               <div className="flex items-center gap-1 mr-2">
-                <Circle
+                <CircleIcon
                   className="text-accent-warning"
                   size={12}
                   weight="fill"
@@ -288,9 +298,9 @@ const KitHeader: React.FC<KitHeaderProps> = ({
               </span>
             </button>
             {isEditable ? (
-              <PencilSimple className="text-accent-sync" size={16} />
+              <PencilSimpleIcon className="text-accent-sync" size={16} />
             ) : (
-              <Lock className="text-text-tertiary" size={16} />
+              <LockIcon className="text-text-tertiary" size={16} />
             )}
           </div>
         )}
@@ -301,7 +311,7 @@ const KitHeader: React.FC<KitHeaderProps> = ({
             onClick={onScanKit}
             title="Perform comprehensive kit scan (voice names, WAV analysis, artist metadata)"
           >
-            <ArrowsClockwise className="inline-block mr-1" size={14} />
+            <ArrowsClockwiseIcon className="inline-block mr-1" size={14} />
             Scan Kit
           </button>
         )}

--- a/app/renderer/components/KitItem.tsx
+++ b/app/renderer/components/KitItem.tsx
@@ -1,4 +1,4 @@
-import { Circle, Copy } from "@phosphor-icons/react";
+import { CircleIcon, CopyIcon } from "@phosphor-icons/react";
 import { toCapitalCase } from "@romper/shared/kitUtilsShared";
 import React from "react";
 
@@ -109,7 +109,7 @@ const KitItem = React.memo(
                 )}
                 {isValid && kitData?.modified_since_sync && (
                   <div className="flex items-center gap-1 ml-2">
-                    <Circle
+                    <CircleIcon
                       className="text-accent-warning"
                       size={12}
                       weight="fill"
@@ -156,7 +156,7 @@ const KitItem = React.memo(
                     }}
                     title="Duplicate kit"
                   >
-                    <Copy size={14} />
+                    <CopyIcon size={14} />
                   </button>
                 )}
               </div>

--- a/app/renderer/components/KitVoicePanels.tsx
+++ b/app/renderer/components/KitVoicePanels.tsx
@@ -1,6 +1,6 @@
 import type { KitWithRelations, Sample } from "@romper/shared/db/schema";
 
-import { Link } from "@phosphor-icons/react";
+import { LinkIcon } from "@phosphor-icons/react";
 import React, { useState } from "react";
 
 import type { SampleData, VoiceSamples } from "./kitTypes";
@@ -454,7 +454,7 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
                     }}
                     title="Stereo link"
                   >
-                    <Link size={14} />
+                    <LinkIcon size={14} />
                   </div>
                 )}
               {/* Chain icon — right edge of panel, always visible */}
@@ -470,7 +470,7 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
                     title="Click to link stereo channels"
                     type="button"
                   >
-                    <Link size={14} />
+                    <LinkIcon size={14} />
                   </button>
                 </div>
               )}

--- a/app/renderer/components/LocalStoreWizardUI.tsx
+++ b/app/renderer/components/LocalStoreWizardUI.tsx
@@ -1,8 +1,8 @@
 import {
-  Archive,
-  FolderOpen,
-  HardDrive,
-  MagnifyingGlass,
+  ArchiveIcon,
+  FolderOpenIcon,
+  HardDriveIcon,
+  MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -75,17 +75,17 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
 
     const sourceOptions = [
       {
-        icon: <HardDrive className="mx-auto mb-2" size={30} />,
+        icon: <HardDriveIcon className="mx-auto mb-2" size={30} />,
         label: "Rample SD Card",
         value: "sdcard",
       },
       {
-        icon: <Archive className="mx-auto mb-2" size={30} />,
+        icon: <ArchiveIcon className="mx-auto mb-2" size={30} />,
         label: "Squarp.net Factory Samples",
         value: "squarp",
       },
       {
-        icon: <FolderOpen className="mx-auto mb-2" size={30} />,
+        icon: <FolderOpenIcon className="mx-auto mb-2" size={30} />,
         label: "Blank Folder",
         value: "blank",
       },
@@ -228,7 +228,7 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
               <FilePickerButton
                 className="bg-accent-primary text-white px-4 py-2 rounded"
                 data-testid="browse-existing-store-btn"
-                icon={<MagnifyingGlass size={14} />}
+                icon={<MagnifyingGlassIcon size={14} />}
                 isSelecting={isSelectingExisting}
                 onClick={handleChooseExistingStore}
               >
@@ -343,7 +343,7 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
                 data-testid="choose-existing-store-btn"
                 onClick={() => setShowExistingStoreSelector(true)}
               >
-                <MagnifyingGlass size={14} /> Choose Existing Store
+                <MagnifyingGlassIcon size={14} /> Choose Existing Store
               </button>
             </div>
           </>

--- a/app/renderer/components/SearchInput.tsx
+++ b/app/renderer/components/SearchInput.tsx
@@ -1,4 +1,8 @@
-import { CircleNotch, MagnifyingGlass, X } from "@phosphor-icons/react";
+import {
+  CircleNotchIcon,
+  MagnifyingGlassIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import React, { useEffect, useRef } from "react";
 
 export interface SearchActions {
@@ -59,7 +63,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
     <div className={`relative ${className}`}>
       <div className="relative flex items-center">
         {/* Search Icon */}
-        <MagnifyingGlass
+        <MagnifyingGlassIcon
           aria-hidden="true"
           className="absolute left-3 text-text-tertiary pointer-events-none z-10"
           size={16}
@@ -89,7 +93,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
           {(() => {
             if (isSearching) {
               return (
-                <CircleNotch
+                <CircleNotchIcon
                   aria-label="Searching..."
                   className="text-accent-primary animate-spin"
                   size={16}
@@ -105,7 +109,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
                   title="Clear search (Esc)"
                   type="button"
                 >
-                  <X size={16} />
+                  <XIcon size={16} />
                 </button>
               );
             }

--- a/app/renderer/components/StatusBar.tsx
+++ b/app/renderer/components/StatusBar.tsx
@@ -1,4 +1,9 @@
-import { Database, Monitor, Moon, Sun } from "@phosphor-icons/react";
+import {
+  DatabaseIcon,
+  MonitorIcon,
+  MoonIcon,
+  SunIcon,
+} from "@phosphor-icons/react";
 import React from "react";
 
 import { useSettings } from "../utils/SettingsContext";
@@ -21,12 +26,12 @@ const StatusBar: React.FC<StatusBarProps> = ({ progress = null }) => {
 
   const getThemeIcon = () => {
     if (themeMode === "system") {
-      return <Monitor size={16} />;
+      return <MonitorIcon size={16} />;
     }
     if (isDarkMode) {
-      return <Sun size={16} />;
+      return <SunIcon size={16} />;
     }
-    return <Moon size={16} />;
+    return <MoonIcon size={16} />;
   };
   return (
     <div
@@ -35,7 +40,7 @@ const StatusBar: React.FC<StatusBarProps> = ({ progress = null }) => {
     >
       <div className="flex items-center gap-3">
         <span className="flex items-center gap-1">
-          <Database size={16} /> Local Store:{" "}
+          <DatabaseIcon size={16} /> Local Store:{" "}
           <span className="font-mono">
             {localStorePath || "Not configured"}
           </span>

--- a/app/renderer/components/StepSequencerGrid.tsx
+++ b/app/renderer/components/StepSequencerGrid.tsx
@@ -1,9 +1,9 @@
 import {
-  NumberCircleOne,
-  Repeat,
-  Shuffle,
-  SpeakerSimpleHigh,
-  SpeakerSimpleSlash,
+  NumberCircleOneIcon,
+  RepeatIcon,
+  ShuffleIcon,
+  SpeakerSimpleHighIcon,
+  SpeakerSimpleSlashIcon,
 } from "@phosphor-icons/react";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -20,9 +20,9 @@ import {
 import { usePopoverDismiss } from "./hooks/shared/usePopoverDismiss";
 
 const SAMPLE_MODE_ICONS: Record<SampleMode, React.ReactNode> = {
-  first: <NumberCircleOne size={14} weight="bold" />,
-  random: <Shuffle size={14} weight="bold" />,
-  "round-robin": <Repeat size={14} weight="bold" />,
+  first: <NumberCircleOneIcon size={14} weight="bold" />,
+  random: <ShuffleIcon size={14} weight="bold" />,
+  "round-robin": <RepeatIcon size={14} weight="bold" />,
 };
 
 const SAMPLE_MODE_CYCLE: SampleMode[] = ["first", "random", "round-robin"];
@@ -388,13 +388,16 @@ const StepSequencerGrid: React.FC<StepSequencerGridProps> = ({
                 type="button"
               >
                 {isMuted ? (
-                  <SpeakerSimpleSlash
+                  <SpeakerSimpleSlashIcon
                     className="text-amber-500"
                     size={14}
                     weight="bold"
                   />
                 ) : (
-                  <SpeakerSimpleHigh className="text-text-tertiary" size={14} />
+                  <SpeakerSimpleHighIcon
+                    className="text-text-tertiary"
+                    size={14}
+                  />
                 )}
               </button>
               <input

--- a/app/renderer/components/__tests__/StatusBar.test.tsx
+++ b/app/renderer/components/__tests__/StatusBar.test.tsx
@@ -19,10 +19,10 @@ vi.mock("../../utils/SettingsContext", () => ({
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  Database: () => <div data-testid="database-icon" />,
-  Monitor: () => <div data-testid="monitor-icon" />,
-  Moon: () => <div data-testid="moon-icon" />,
-  Sun: () => <div data-testid="sun-icon" />,
+  DatabaseIcon: () => <div data-testid="database-icon" />,
+  MonitorIcon: () => <div data-testid="monitor-icon" />,
+  MoonIcon: () => <div data-testid="moon-icon" />,
+  SunIcon: () => <div data-testid="sun-icon" />,
 }));
 
 describe("StatusBar", () => {

--- a/app/renderer/components/dialogs/AboutDialog.tsx
+++ b/app/renderer/components/dialogs/AboutDialog.tsx
@@ -1,4 +1,4 @@
-import { X } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 import React, { useEffect } from "react";
 
 import LedPixelGrid from "./led-grid/LedPixelGrid";
@@ -62,7 +62,7 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ isOpen, onClose }) => {
           onClick={onClose}
           type="button"
         >
-          <X size={20} />
+          <XIcon size={20} />
         </button>
 
         {/* Content overlay */}

--- a/app/renderer/components/dialogs/ChangeLocalStoreDirectoryDialog.tsx
+++ b/app/renderer/components/dialogs/ChangeLocalStoreDirectoryDialog.tsx
@@ -1,9 +1,9 @@
 import {
-  ArrowsClockwise,
-  CheckCircle,
-  Folder,
-  Warning,
-  X,
+  ArrowsClockwiseIcon,
+  CheckCircleIcon,
+  FolderIcon,
+  WarningIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import React, { useEffect, useRef, useState } from "react";
 
@@ -150,7 +150,7 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
       <div className="bg-surface-2 border border-border-subtle w-full max-w-2xl max-h-[80vh] overflow-y-auto rounded-lg shadow-[0_8px_40px_rgba(0,0,0,0.4)] p-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-bold flex items-center gap-2">
-            <Folder className="text-accent-primary" size={24} />
+            <FolderIcon className="text-accent-primary" size={24} />
             Change Local Store Directory
           </h2>
           <button
@@ -158,7 +158,7 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
             className="text-text-tertiary hover:text-text-primary"
             onClick={handleClose}
           >
-            <X size={24} />
+            <XIcon size={24} />
           </button>
         </div>
 
@@ -212,7 +212,7 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
               <FilePickerButton
                 className="px-4 py-3 bg-accent-primary text-white rounded-lg hover:bg-accent-primary/80 flex items-center gap-2 font-medium whitespace-nowrap"
                 disabled={isValidating || isUpdating}
-                icon={<Folder size={18} />}
+                icon={<FolderIcon size={18} />}
                 isSelecting={isSelecting}
                 onClick={handleSelectDirectory}
               >
@@ -223,7 +223,7 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
             {/* Validation Messages - Only show warnings/errors */}
             {validationResult && selectedPath === localStorePath && (
               <div className="flex items-center gap-2 p-3 rounded-lg border border-accent-warning/30 bg-accent-warning/10">
-                <Warning
+                <WarningIcon
                   className="text-accent-warning flex-shrink-0"
                   size={16}
                 />
@@ -238,7 +238,7 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
               selectedPath !== localStorePath &&
               !validationResult.isValid && (
                 <div className="flex items-center gap-2 p-3 rounded-lg border border-accent-danger/30 bg-accent-danger/10">
-                  <Warning
+                  <WarningIcon
                     className="text-accent-danger flex-shrink-0"
                     size={16}
                   />
@@ -272,9 +272,9 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
             onClick={handleUpdateDirectory}
           >
             {isUpdating ? (
-              <ArrowsClockwise className="animate-spin" size={16} />
+              <ArrowsClockwiseIcon className="animate-spin" size={16} />
             ) : (
-              <CheckCircle size={16} />
+              <CheckCircleIcon size={16} />
             )}
             {isUpdating ? "Updating..." : "Update Directory"}
           </button>

--- a/app/renderer/components/dialogs/CriticalErrorDialog.tsx
+++ b/app/renderer/components/dialogs/CriticalErrorDialog.tsx
@@ -1,4 +1,4 @@
-import { Warning } from "@phosphor-icons/react";
+import { WarningIcon } from "@phosphor-icons/react";
 import React from "react";
 
 interface CriticalErrorDialogProps {
@@ -24,7 +24,7 @@ const CriticalErrorDialog: React.FC<CriticalErrorDialogProps> = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
       <div className="mx-4 w-full max-w-md rounded-lg bg-surface-2 p-6 shadow-lg border-2 border-accent-danger">
         <div className="mb-4 flex items-center space-x-3">
-          <Warning className="text-accent-danger" size={32} />
+          <WarningIcon className="text-accent-danger" size={32} />
           <h2 className="text-xl font-bold text-accent-danger">{title}</h2>
         </div>
 

--- a/app/renderer/components/dialogs/DeleteKitDialog.tsx
+++ b/app/renderer/components/dialogs/DeleteKitDialog.tsx
@@ -1,4 +1,4 @@
-import { Info, Trash, Warning } from "@phosphor-icons/react";
+import { InfoIcon, TrashIcon, WarningIcon } from "@phosphor-icons/react";
 import React from "react";
 
 interface DeleteKitDialogProps {
@@ -24,13 +24,13 @@ const DeleteKitDialog: React.FC<DeleteKitDialogProps> = ({
     >
       <div className="flex items-center gap-1.5">
         {hasSamples ? (
-          <Warning
+          <WarningIcon
             className="text-accent-warning flex-shrink-0"
             size={14}
             weight="bold"
           />
         ) : (
-          <Info
+          <InfoIcon
             className="text-text-tertiary flex-shrink-0"
             size={14}
             weight="bold"
@@ -59,7 +59,7 @@ const DeleteKitDialog: React.FC<DeleteKitDialogProps> = ({
           disabled={isDeleting}
           onClick={onConfirm}
         >
-          <Trash size={13} />
+          <TrashIcon size={13} />
           {isDeleting ? "Deleting..." : "Delete"}
         </button>
         <button

--- a/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
+++ b/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
@@ -1,4 +1,8 @@
-import { ArrowsClockwise, Folder, Warning } from "@phosphor-icons/react";
+import {
+  ArrowsClockwiseIcon,
+  FolderIcon,
+  WarningIcon,
+} from "@phosphor-icons/react";
 import React, { useEffect, useRef, useState } from "react";
 
 import { useSettings } from "../../utils/SettingsContext";
@@ -170,7 +174,7 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
     if (isValidating) {
       return (
         <div className="flex items-center space-x-2 text-accent-primary">
-          <ArrowsClockwise className="animate-spin" size={16} />
+          <ArrowsClockwiseIcon className="animate-spin" size={16} />
           <span className="text-sm">Validating directory...</span>
         </div>
       );
@@ -201,7 +205,7 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/75">
       <div className="mx-4 w-full max-w-md rounded-lg bg-surface-2 border border-border-subtle p-6 shadow-[0_8px_40px_rgba(0,0,0,0.4)]">
         <div className="mb-4 flex items-center space-x-3">
-          <Warning className="text-accent-danger" size={24} />
+          <WarningIcon className="text-accent-danger" size={24} />
           <h2 className="text-lg font-semibold text-text-primary">
             Invalid Local Store
           </h2>
@@ -230,7 +234,7 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
         <div className="mb-4">
           <FilePickerButton
             disabled={isUpdating}
-            icon={<Folder size={16} />}
+            icon={<FolderIcon size={16} />}
             isSelecting={isSelecting}
             onClick={handleSelectDirectory}
           >

--- a/app/renderer/components/dialogs/PreferencesDialog.tsx
+++ b/app/renderer/components/dialogs/PreferencesDialog.tsx
@@ -1,4 +1,4 @@
-import { GearSix, X } from "@phosphor-icons/react";
+import { GearSixIcon, XIcon } from "@phosphor-icons/react";
 import React, { useEffect, useState } from "react";
 
 import { useSettings } from "../../utils/SettingsContext";
@@ -80,7 +80,7 @@ const PreferencesDialog: React.FC<PreferencesDialogProps> = ({
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border-subtle">
           <div className="flex items-center gap-2">
-            <GearSix size={18} />
+            <GearSixIcon size={18} />
             <h2
               className="text-lg font-semibold text-text-primary"
               id="preferences-title"
@@ -93,7 +93,7 @@ const PreferencesDialog: React.FC<PreferencesDialogProps> = ({
             className="p-1 rounded hover:bg-surface-3 text-text-tertiary"
             onClick={onClose}
           >
-            <X size={18} />
+            <XIcon size={18} />
           </button>
         </div>
 

--- a/app/renderer/components/dialogs/SyncUpdateDialog.tsx
+++ b/app/renderer/components/dialogs/SyncUpdateDialog.tsx
@@ -1,13 +1,13 @@
 import {
-  ArrowsClockwise,
-  Check,
-  CheckCircle,
-  DownloadSimple,
-  Folder,
-  HardDrive,
-  Spinner,
-  Trash,
-  X,
+  ArrowsClockwiseIcon,
+  CheckCircleIcon,
+  CheckIcon,
+  DownloadSimpleIcon,
+  FolderIcon,
+  HardDriveIcon,
+  SpinnerIcon,
+  TrashIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import React, { useEffect, useState } from "react";
 
@@ -113,7 +113,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
         }}
       >
         <div className="flex items-center gap-2">
-          <DownloadSimple
+          <DownloadSimpleIcon
             className="text-accent-primary"
             size={16}
             weight="bold"
@@ -128,7 +128,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
           disabled={isLoading}
           onClick={handleClose}
         >
-          <X size={16} />
+          <XIcon size={16} />
         </button>
       </div>
 
@@ -140,14 +140,14 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
               <span className="text-text-secondary font-medium">
                 {syncProgress.status === "preparing" && (
                   <span className="flex items-center gap-1">
-                    <Spinner className="animate-spin" size={12} />
+                    <SpinnerIcon className="animate-spin" size={12} />
                     Preparing...
                   </span>
                 )}
                 {(syncProgress.status === "copying" ||
                   syncProgress.status === "converting") && (
                   <span className="flex items-center gap-1">
-                    <Spinner className="animate-spin" size={12} />
+                    <SpinnerIcon className="animate-spin" size={12} />
                     Writing{" "}
                     {syncProgress.currentKitName && (
                       <span
@@ -162,7 +162,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
                 {syncProgress.status === "finalizing" && "Finalizing..."}
                 {syncProgress.status === "completed" && (
                   <span className="text-accent-success flex items-center gap-1">
-                    <CheckCircle size={12} weight="fill" />
+                    <CheckCircleIcon size={12} weight="fill" />
                     Write Complete
                   </span>
                 )}
@@ -242,7 +242,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
         {/* Loading State */}
         {isGeneratingSummary && (
           <div className="px-4 py-6 flex items-center justify-center gap-2 text-text-tertiary text-sm">
-            <Spinner className="animate-spin" size={16} />
+            <SpinnerIcon className="animate-spin" size={16} />
             <span>Scanning kits...</span>
           </div>
         )}
@@ -316,7 +316,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
                 : "border-accent-primary/30 bg-accent-primary/5"
             }`}
           >
-            <HardDrive
+            <HardDriveIcon
               className={
                 localSdCardPath ? "text-text-tertiary" : "text-accent-primary"
               }
@@ -342,7 +342,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
               disabled={isLoading}
               onClick={handleSdCardSelect}
             >
-              <Folder size={11} />
+              <FolderIcon size={11} />
               {localSdCardPath ? "Change" : "Select"}
             </button>
           </div>
@@ -363,11 +363,11 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
             />
             <div className="w-3.5 h-3.5 rounded-sm border border-border-default bg-surface-3 shrink-0 flex items-center justify-center peer-checked:bg-accent-danger peer-checked:border-accent-danger transition-colors">
               {wipeSdCard && (
-                <Check className="text-white" size={10} weight="bold" />
+                <CheckIcon className="text-white" size={10} weight="bold" />
               )}
             </div>
             <span className="text-[11px] text-text-tertiary flex items-center gap-1 group-hover:text-text-secondary transition-colors">
-              <Trash size={11} />
+              <TrashIcon size={11} />
               Clear SD card before writing
             </span>
           </label>
@@ -403,7 +403,7 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
                 disabled={isLoading}
                 onClick={handleConfirm}
               >
-                <ArrowsClockwise size={12} weight="bold" />
+                <ArrowsClockwiseIcon size={12} weight="bold" />
                 Retry
               </button>
             )}
@@ -426,12 +426,12 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
             >
               {isLoading ? (
                 <>
-                  <Spinner className="animate-spin" size={12} />
+                  <SpinnerIcon className="animate-spin" size={12} />
                   Writing...
                 </>
               ) : (
                 <>
-                  <DownloadSimple size={12} weight="bold" />
+                  <DownloadSimpleIcon size={12} weight="bold" />
                   {syncProgress?.status === "error"
                     ? "Start New Write"
                     : "Start Write"}

--- a/app/renderer/components/dialogs/ValidationResultsDialog.tsx
+++ b/app/renderer/components/dialogs/ValidationResultsDialog.tsx
@@ -1,8 +1,8 @@
 import {
-  ArrowsClockwise,
-  CheckCircle,
-  Warning,
-  X,
+  ArrowsClockwiseIcon,
+  CheckCircleIcon,
+  WarningIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import { KitValidationError } from "@romper/shared/db/schema.js";
 import React from "react";
@@ -97,9 +97,9 @@ const ValidationResultsDialog: React.FC<ValidationResultsDialogProps> = ({
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-bold flex items-center gap-2">
             {validationResult?.isValid ? (
-              <CheckCircle className="text-accent-success" size={24} />
+              <CheckCircleIcon className="text-accent-success" size={24} />
             ) : (
-              <Warning className="text-accent-warning" size={24} />
+              <WarningIcon className="text-accent-warning" size={24} />
             )}
             Local Store Validation Results
           </h2>
@@ -108,7 +108,7 @@ const ValidationResultsDialog: React.FC<ValidationResultsDialogProps> = ({
             className="text-text-tertiary hover:text-text-primary"
             onClick={onClose}
           >
-            <X size={24} />
+            <XIcon size={24} />
           </button>
         </div>
 
@@ -201,7 +201,7 @@ const ValidationResultsDialog: React.FC<ValidationResultsDialogProps> = ({
                         </>
                       ) : (
                         <>
-                          <ArrowsClockwise size={16} />
+                          <ArrowsClockwiseIcon size={16} />
                           Rescan Selected Kits
                         </>
                       )}

--- a/app/renderer/components/dialogs/__tests__/ChangeLocalStoreDirectoryDialog.test.tsx
+++ b/app/renderer/components/dialogs/__tests__/ChangeLocalStoreDirectoryDialog.test.tsx
@@ -33,11 +33,11 @@ vi.mock("../../utils/FilePickerButton", () => ({
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  ArrowsClockwise: vi.fn(() => <div data-testid="refresh">Refresh</div>),
-  CheckCircle: vi.fn(() => <div data-testid="check-circle">Check</div>),
-  Folder: vi.fn(() => <div data-testid="folder">Folder</div>),
-  Warning: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
-  X: vi.fn(() => <div data-testid="close-x">X</div>),
+  ArrowsClockwiseIcon: vi.fn(() => <div data-testid="refresh">Refresh</div>),
+  CheckCircleIcon: vi.fn(() => <div data-testid="check-circle">Check</div>),
+  FolderIcon: vi.fn(() => <div data-testid="folder">Folder</div>),
+  WarningIcon: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
+  XIcon: vi.fn(() => <div data-testid="close-x">X</div>),
 }));
 
 // Setup centralized electronAPI mock

--- a/app/renderer/components/dialogs/__tests__/CriticalErrorDialog.test.tsx
+++ b/app/renderer/components/dialogs/__tests__/CriticalErrorDialog.test.tsx
@@ -6,7 +6,7 @@ import CriticalErrorDialog from "../CriticalErrorDialog";
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  Warning: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
+  WarningIcon: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
 }));
 
 describe("CriticalErrorDialog", () => {

--- a/app/renderer/components/dialogs/__tests__/InvalidLocalStoreDialog.test.tsx
+++ b/app/renderer/components/dialogs/__tests__/InvalidLocalStoreDialog.test.tsx
@@ -33,9 +33,9 @@ vi.mock("../../utils/FilePickerButton", () => ({
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  ArrowsClockwise: vi.fn(() => <div data-testid="refresh">Refresh</div>),
-  Folder: vi.fn(() => <div data-testid="folder">Folder</div>),
-  Warning: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
+  ArrowsClockwiseIcon: vi.fn(() => <div data-testid="refresh">Refresh</div>),
+  FolderIcon: vi.fn(() => <div data-testid="folder">Folder</div>),
+  WarningIcon: vi.fn(() => <div data-testid="alert-triangle">Alert</div>),
 }));
 
 // Setup centralized electronAPI mock

--- a/app/renderer/components/dialogs/led-grid/useLedAnimation.ts
+++ b/app/renderer/components/dialogs/led-grid/useLedAnimation.ts
@@ -26,7 +26,7 @@ import {
 interface UseLedAnimationReturn {
   addRipple: (col: number, row: number) => void;
   clearMousePosition: () => void;
-  ledRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  ledRefs: React.RefObject<(HTMLDivElement | null)[]>;
   setMousePosition: (col: number, row: number) => void;
 }
 

--- a/app/renderer/components/hooks/voice-panels/__tests__/useVoicePanelButtons.test.tsx
+++ b/app/renderer/components/hooks/voice-panels/__tests__/useVoicePanelButtons.test.tsx
@@ -6,9 +6,9 @@ import { useVoicePanelButtons } from "../useVoicePanelButtons";
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  Play: () => <span data-testid="play-icon">Play</span>,
-  Stop: () => <span data-testid="square-icon">Square</span>,
-  Trash: () => <span data-testid="trash-icon">Trash</span>,
+  PlayIcon: () => <span data-testid="play-icon">Play</span>,
+  StopIcon: () => <span data-testid="square-icon">Square</span>,
+  TrashIcon: () => <span data-testid="trash-icon">Trash</span>,
 }));
 
 describe("useVoicePanelButtons", () => {

--- a/app/renderer/components/hooks/voice-panels/__tests__/useVoicePanelUI.test.tsx
+++ b/app/renderer/components/hooks/voice-panels/__tests__/useVoicePanelUI.test.tsx
@@ -7,9 +7,9 @@ import { useVoicePanelUI } from "../useVoicePanelUI";
 
 // Mock @phosphor-icons/react
 vi.mock("@phosphor-icons/react", () => ({
-  Check: () => <span data-testid="check-icon">Check</span>,
-  PencilSimple: () => <span data-testid="edit-icon">Edit</span>,
-  X: () => <span data-testid="x-icon">X</span>,
+  CheckIcon: () => <span data-testid="check-icon">Check</span>,
+  PencilSimpleIcon: () => <span data-testid="edit-icon">Edit</span>,
+  XIcon: () => <span data-testid="x-icon">X</span>,
 }));
 
 // Mock the shared utility

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelButtons.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelButtons.tsx
@@ -1,4 +1,4 @@
-import { Play, Stop, Trash } from "@phosphor-icons/react";
+import { PlayIcon, StopIcon, TrashIcon } from "@phosphor-icons/react";
 import React from "react";
 
 export interface UseVoicePanelButtonsOptions {
@@ -39,7 +39,7 @@ export function useVoicePanelButtons({
             onClick={() => onStop(voice, sampleName)}
             style={buttonStyle}
           >
-            <Stop size={14} />
+            <StopIcon size={14} />
           </button>
         );
       }
@@ -51,7 +51,7 @@ export function useVoicePanelButtons({
           onClick={() => onPlay(voice, sampleName)}
           style={buttonStyle}
         >
-          <Play size={14} />
+          <PlayIcon size={14} />
         </button>
       );
     },
@@ -77,7 +77,7 @@ export function useVoicePanelButtons({
         }}
         title="Delete sample"
       >
-        <Trash size={14} />
+        <TrashIcon size={14} />
       </button>
     ),
     [sampleActionsHook],

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelUI.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelUI.tsx
@@ -1,4 +1,4 @@
-import { Check, PencilSimple, X } from "@phosphor-icons/react";
+import { CheckIcon, PencilSimpleIcon, XIcon } from "@phosphor-icons/react";
 import { toCapitalCase } from "@romper/shared/kitUtilsShared";
 import React from "react";
 
@@ -56,14 +56,14 @@ export function useVoicePanelUI({
               onClick={voiceNameEditorHook.handleSave}
               title="Save"
             >
-              <Check size={16} />
+              <CheckIcon size={16} />
             </button>
             <button
               className="ml-1 text-accent-danger"
               onClick={voiceNameEditorHook.handleCancel}
               title="Cancel"
             >
-              <X size={16} />
+              <XIcon size={16} />
             </button>
           </>
         ) : (
@@ -84,7 +84,7 @@ export function useVoicePanelUI({
                 onClick={voiceNameEditorHook.startEditing}
                 title="Edit voice name"
               >
-                <PencilSimple size={16} />
+                <PencilSimpleIcon size={16} />
               </button>
             )}
           </>

--- a/app/renderer/components/led-icon/useLedVisualization.ts
+++ b/app/renderer/components/led-icon/useLedVisualization.ts
@@ -58,7 +58,7 @@ export interface VoiceVuState {
 interface UseLedVisualizationReturn {
   addRipple: (col: number, row: number) => void;
   clearMousePosition: () => void;
-  ledRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  ledRefs: React.RefObject<(HTMLDivElement | null)[]>;
   setMousePosition: (col: number, row: number) => void;
 }
 
@@ -233,7 +233,7 @@ export function updatePeakState(state: VoiceVuState, barHeight: number): void {
 }
 
 export function useLedVisualization(
-  isHoveredRef: React.MutableRefObject<boolean>,
+  isHoveredRef: React.RefObject<boolean>,
 ): UseLedVisualizationReturn {
   const ledRefs = useRef<(HTMLDivElement | null)[]>([]);
   const mouseRef = useRef<{ col: number; row: number } | null>(null);

--- a/app/renderer/components/preferences/AdvancedTab.tsx
+++ b/app/renderer/components/preferences/AdvancedTab.tsx
@@ -1,4 +1,4 @@
-import { Folder } from "@phosphor-icons/react";
+import { FolderIcon } from "@phosphor-icons/react";
 import React from "react";
 
 import { type LocalStoreValidationDetailedResult } from "../../utils/SettingsContext";
@@ -44,7 +44,7 @@ const AdvancedTab: React.FC<AdvancedTabProps> = ({
                 className="px-3 py-2 bg-accent-primary text-white rounded hover:bg-accent-primary/80 transition-colors flex items-center gap-2"
                 onClick={onChangeLocalStore}
               >
-                <Folder size={14} />
+                <FolderIcon size={14} />
                 Change...
               </button>
             </div>

--- a/app/renderer/components/preferences/AppearanceTab.tsx
+++ b/app/renderer/components/preferences/AppearanceTab.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Moon, Sun } from "@phosphor-icons/react";
+import { MonitorIcon, MoonIcon, SunIcon } from "@phosphor-icons/react";
 import React from "react";
 
 import { type ThemeMode } from "../../utils/SettingsContext";
@@ -17,13 +17,13 @@ const AppearanceTab: React.FC<AppearanceTabProps> = ({
     label: string;
     value: ThemeMode;
   }> = [
-    { icon: <Sun size={16} />, label: "Light", value: "light" },
+    { icon: <SunIcon size={16} />, label: "Light", value: "light" },
     {
-      icon: <Monitor size={16} />,
+      icon: <MonitorIcon size={16} />,
       label: "System",
       value: "system",
     },
-    { icon: <Moon size={16} />, label: "Dark", value: "dark" },
+    { icon: <MoonIcon size={16} />, label: "Dark", value: "dark" },
   ];
 
   return (
@@ -53,13 +53,13 @@ const AppearanceTab: React.FC<AppearanceTabProps> = ({
                     >
                       {option.value === "light" && (
                         <div className="w-full h-full bg-surface-1 flex items-center justify-center">
-                          <Sun className="text-accent-warning" size={24} />
+                          <SunIcon className="text-accent-warning" size={24} />
                         </div>
                       )}
 
                       {option.value === "dark" && (
                         <div className="w-full h-full bg-gray-900 flex items-center justify-center">
-                          <Moon className="text-accent-primary" size={24} />
+                          <MoonIcon className="text-accent-primary" size={24} />
                         </div>
                       )}
 
@@ -75,14 +75,14 @@ const AppearanceTab: React.FC<AppearanceTabProps> = ({
                             <div className="relative w-6 h-6">
                               {/* Left half - dark icon on light background */}
                               <div className="absolute inset-0 w-1/2 overflow-hidden">
-                                <Monitor
+                                <MonitorIcon
                                   className="text-text-primary"
                                   size={24}
                                 />
                               </div>
                               {/* Right half - light icon on dark background */}
                               <div className="absolute inset-0 w-1/2 left-1/2 overflow-hidden">
-                                <Monitor
+                                <MonitorIcon
                                   className="text-white -ml-3"
                                   size={24}
                                 />

--- a/app/renderer/components/shared/KitIconRenderer.tsx
+++ b/app/renderer/components/shared/KitIconRenderer.tsx
@@ -1,9 +1,9 @@
 import {
-  ArrowsCounterClockwise,
-  Folder,
-  MicrophoneStage,
-  PianoKeys,
-  Sparkle,
+  ArrowsCounterClockwiseIcon,
+  FolderIcon,
+  MicrophoneStageIcon,
+  PianoKeysIcon,
+  SparkleIcon,
 } from "@phosphor-icons/react";
 import React from "react";
 
@@ -51,7 +51,7 @@ export const KitIconRenderer: React.FC<KitIconRendererProps> = ({
       );
     case "fx":
       return (
-        <Sparkle
+        <SparkleIcon
           className={`text-text-secondary ${className}`}
           size={iconSize}
           weight="fill"
@@ -59,14 +59,14 @@ export const KitIconRenderer: React.FC<KitIconRendererProps> = ({
       );
     case "loop":
       return (
-        <ArrowsCounterClockwise
+        <ArrowsCounterClockwiseIcon
           className={`text-text-secondary ${className}`}
           size={iconSize}
         />
       );
     case "mic":
       return (
-        <MicrophoneStage
+        <MicrophoneStageIcon
           className={`text-text-secondary ${className}`}
           size={iconSize}
           weight="fill"
@@ -74,7 +74,7 @@ export const KitIconRenderer: React.FC<KitIconRendererProps> = ({
       );
     case "piano":
       return (
-        <PianoKeys
+        <PianoKeysIcon
           className={`text-text-secondary ${className}`}
           size={iconSize}
           weight="fill"
@@ -82,7 +82,7 @@ export const KitIconRenderer: React.FC<KitIconRendererProps> = ({
       );
     default:
       return (
-        <Folder
+        <FolderIcon
           className={`text-text-secondary ${className}`}
           size={iconSize}
         />

--- a/app/renderer/components/utils/__tests__/FilePickerButton.test.tsx
+++ b/app/renderer/components/utils/__tests__/FilePickerButton.test.tsx
@@ -1,4 +1,4 @@
-import { Folder } from "@phosphor-icons/react";
+import { FolderIcon } from "@phosphor-icons/react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -62,7 +62,7 @@ describe("FilePickerButton", () => {
     render(
       <FilePickerButton
         data-testid="file-picker-with-icon"
-        icon={<Folder data-testid="folder-icon" size={16} />}
+        icon={<FolderIcon data-testid="folder-icon" size={16} />}
         isSelecting={false}
         onClick={() => {}}
       >
@@ -77,7 +77,7 @@ describe("FilePickerButton", () => {
     render(
       <FilePickerButton
         data-testid="file-picker-selecting-no-icon"
-        icon={<Folder data-testid="folder-icon" size={16} />}
+        icon={<FolderIcon data-testid="folder-icon" size={16} />}
         isSelecting={true}
         onClick={() => {}}
       >

--- a/app/renderer/components/wizard/WizardTargetStep.tsx
+++ b/app/renderer/components/wizard/WizardTargetStep.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen } from "@phosphor-icons/react";
+import { FolderOpenIcon } from "@phosphor-icons/react";
 import React, { useState } from "react";
 
 import FilePickerButton from "../utils/FilePickerButton";
@@ -59,7 +59,7 @@ const WizardTargetStep: React.FC<WizardTargetStepProps> = ({
         <FilePickerButton
           className="bg-surface-3 text-text-primary px-2 py-1 rounded focus:outline-none focus:ring-2 focus:ring-accent-primary"
           data-testid="wizard-target-browse-btn"
-          icon={<FolderOpen size={14} />}
+          icon={<FolderOpenIcon size={14} />}
           isSelecting={isSelecting}
           onClick={handleChooseFolder}
         >


### PR DESCRIPTION
## Summary
Burn-down of SonarCloud issue category [#242](https://github.com/peteb4ker/romper/issues/242) — **178 `S1874` deprecated-API issues** across 34 files. **No behavior or visual change.**

- **175 phosphor icon renames** to the canonical `<Name>Icon` form (e.g. `Trash`→`TrashIcon`, `X`→`XIcon`, `ArrowsClockwise`→`ArrowsClockwiseIcon`). Verified safe: in `@phosphor-icons/react` each deprecated name and its `Icon`-suffixed name export the **same icon constant** (`export declare const Trash: Icon; export { I as TrashIcon }` with `/** @deprecated Use TrashIcon */`), so glyphs are identical. Covers import specifiers, JSX usages, and `vi.mock` keys in the affected tests.
- **3× `React.MutableRefObject<T>` → `React.RefObject<T>`** (React 19 deprecation; `RefObject` is mutable in v19).

## Verification
- The rename was scripted with whole-word + quote/comment-safe matching, then **typecheck** confirms every import↔usage pair is consistent (a missed rename would fail to compile).
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] Unit tests — 3524 passed
- [x] Integration tests — 529 passed
- [x] Pre-commit hook — passed

Closes #242