### PR TITLE
fix(ci): only auto-close the sonar gate tracker, not labeled issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,11 +224,14 @@ jobs:
           FAILED_CONDITIONS=$(echo "$GATE" | jq -r \
             '.projectStatus.conditions[] | select(.status == "ERROR") | "- **\(.metricKey)**: \(.actualValue) (required: \(.errorThreshold))"')
 
-          # Search for existing open sonarcloud issue
-          EXISTING=$(gh issue list --label "sonarcloud" --state open --json number,body --limit 1)
-          EXISTING_NUMBER=$(echo "$EXISTING" | jq -r '.[0].number // empty')
-
           ISSUE_TITLE="SonarCloud: quality gate failure on main"
+
+          # Find CI's own auto-managed gate tracker. Match the exact title — NOT
+          # just the shared "sonarcloud" label — so human-created issues that also
+          # carry the label are never auto-closed when the gate passes.
+          EXISTING=$(gh issue list --label "sonarcloud" --state open --json number,title,body --limit 30 \
+            | jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)][0:1]')
+          EXISTING_NUMBER=$(echo "$EXISTING" | jq -r '.[0].number // empty')
 
           if [ "$STATUS" != "OK" ]; then
             if [ -n "$EXISTING_NUMBER" ]; then


### PR DESCRIPTION
## Problem
The `test.yml` → **Check quality gate and manage issues** step (runs on every push to `main`) closes the first `sonarcloud`-labeled open issue when the quality gate is green:
```bash
EXISTING=$(gh issue list --label "sonarcloud" --state open --json number,body --limit 1)
...
gh issue close "$EXISTING_NUMBER" --comment "## Quality Gate Passed ... Auto-closing."
```
The `sonarcloud` label is also used by human-created burn-down issues (#241–#246), so as PRs merged and the gate stayed green, the workflow inadvertently closed several of them — including **#241** (0/203 done) and **#246** (7/15). Both have been manually reopened.

## Fix
Match CI's own tracker by its **exact title** (`"SonarCloud: quality gate failure on main"`, already defined as `ISSUE_TITLE`) instead of just the label, so human-created issues are never auto-closed even if they carry the `sonarcloud` label:
```bash
EXISTING=$(gh issue list --label "sonarcloud" --state open --json number,title,body --limit 30 \
  | jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)][0:1]')
```

## Verification
- YAML validated (js-yaml).
- jq filter verified: returns the tracker when present; returns empty (no close) when only human issues exist.
- The step only runs on `push` to `main`, so it isn't exercised by PR CI; behavior takes effect on merge.