### PR TITLE
chore(sonar): prefer globalThis over window (#241)

### DIFF
--- a/app/renderer/components/GainKnob.tsx
+++ b/app/renderer/components/GainKnob.tsx
@@ -124,11 +124,11 @@ const GainKnob: React.FC<GainKnobProps> = ({ disabled, onChange, value }) => {
       setIsDragging(false);
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
+    globalThis.addEventListener("mousemove", handleMouseMove);
+    globalThis.addEventListener("mouseup", handleMouseUp);
     return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+      globalThis.removeEventListener("mousemove", handleMouseMove);
+      globalThis.removeEventListener("mouseup", handleMouseUp);
     };
   }, [isDragging, updateGain]);
 

--- a/app/renderer/components/KitStepSequencer.tsx
+++ b/app/renderer/components/KitStepSequencer.tsx
@@ -118,7 +118,7 @@ const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
   const handleVolumeChange = React.useCallback(
     (voiceNumber: number, volume: number) => {
       setVoiceVolumes((prev) => ({ ...prev, [voiceNumber]: volume }));
-      window.electronAPI?.updateVoiceVolume?.(kitName, voiceNumber, volume);
+      globalThis.electronAPI?.updateVoiceVolume?.(kitName, voiceNumber, volume);
       debouncedRefresh();
     },
     [kitName, debouncedRefresh],
@@ -128,7 +128,11 @@ const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
   const handleSampleModeChange = React.useCallback(
     (voiceNumber: number, mode: SampleMode) => {
       setSampleModes((prev) => ({ ...prev, [voiceNumber]: mode }));
-      window.electronAPI?.updateVoiceSampleMode?.(kitName, voiceNumber, mode);
+      globalThis.electronAPI?.updateVoiceSampleMode?.(
+        kitName,
+        voiceNumber,
+        mode,
+      );
       onVoiceSettingChanged?.();
     },
     [kitName, onVoiceSettingChanged],

--- a/app/renderer/components/KitVoicePanels.tsx
+++ b/app/renderer/components/KitVoicePanels.tsx
@@ -166,8 +166,8 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
         voiceData,
         sampleData,
         async (voiceNumber, updates) => {
-          if (window.electronAPI?.updateVoiceStereoMode) {
-            await window.electronAPI.updateVoiceStereoMode(
+          if (globalThis.electronAPI?.updateVoiceStereoMode) {
+            await globalThis.electronAPI.updateVoiceStereoMode(
               hookProps.kitName,
               voiceNumber,
               updates.stereo_mode ?? false,
@@ -194,8 +194,8 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
         voiceData,
         sampleData,
         async (voiceNumber, updates) => {
-          if (window.electronAPI?.updateVoiceStereoMode) {
-            await window.electronAPI.updateVoiceStereoMode(
+          if (globalThis.electronAPI?.updateVoiceStereoMode) {
+            await globalThis.electronAPI.updateVoiceStereoMode(
               hookProps.kitName,
               voiceNumber,
               updates.stereo_mode ?? false,
@@ -225,13 +225,13 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
   // Load sample metadata when kit changes
   React.useEffect(() => {
     const loadSampleMetadata = async () => {
-      if (!hookProps.kitName || !window.electronAPI?.getAllSamplesForKit) {
+      if (!hookProps.kitName || !globalThis.electronAPI?.getAllSamplesForKit) {
         setSampleMetadata({});
         return;
       }
 
       try {
-        const samplesResult = await window.electronAPI.getAllSamplesForKit(
+        const samplesResult = await globalThis.electronAPI.getAllSamplesForKit(
           hookProps.kitName,
         );
         if (samplesResult?.success && samplesResult.data) {

--- a/app/renderer/components/LocalStoreWizardUI.tsx
+++ b/app/renderer/components/LocalStoreWizardUI.tsx
@@ -67,8 +67,8 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
     }, [state.isInitializing, onInitializationChange]);
 
     const safeSelectLocalStorePath = useCallback(async () => {
-      if (window.electronAPI?.selectLocalStorePath) {
-        return await window.electronAPI.selectLocalStorePath();
+      if (globalThis.electronAPI?.selectLocalStorePath) {
+        return await globalThis.electronAPI.selectLocalStorePath();
       }
       return undefined;
     }, []);
@@ -122,18 +122,18 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
 
     // Helper function to validate electronAPI availability
     const validateElectronAPI = useCallback(() => {
-      if (!window.electronAPI?.selectExistingLocalStore) {
-        const errorMsg = window.electronAPI
+      if (!globalThis.electronAPI?.selectExistingLocalStore) {
+        const errorMsg = globalThis.electronAPI
           ? "selectExistingLocalStore method not found (preload issue)"
           : "electronAPI not available (app may need restart)";
 
         console.error("Debug info:", {
-          availableMethods: window.electronAPI
-            ? Object.keys(window.electronAPI)
+          availableMethods: globalThis.electronAPI
+            ? Object.keys(globalThis.electronAPI)
             : "none",
-          electronAPI: !!window.electronAPI,
+          electronAPI: !!globalThis.electronAPI,
           selectExistingLocalStore:
-            !!window.electronAPI?.selectExistingLocalStore,
+            !!globalThis.electronAPI?.selectExistingLocalStore,
         });
 
         return { error: errorMsg, isValid: false };
@@ -153,11 +153,12 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
     );
 
     const handleChooseExistingStore = useCallback(async () => {
-      isDev && console.debug("electronAPI available:", !!window.electronAPI);
+      isDev &&
+        console.debug("electronAPI available:", !!globalThis.electronAPI);
       isDev &&
         console.debug(
           "selectExistingLocalStore method available:",
-          !!window.electronAPI?.selectExistingLocalStore,
+          !!globalThis.electronAPI?.selectExistingLocalStore,
         );
 
       const validation = validateElectronAPI();
@@ -171,7 +172,8 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
 
       try {
         isDev && console.debug("Calling selectExistingLocalStore...");
-        const result = await window.electronAPI.selectExistingLocalStore?.();
+        const result =
+          await globalThis.electronAPI.selectExistingLocalStore?.();
         isDev && console.debug("selectExistingLocalStore result:", result);
 
         if (result?.success && result.path) {
@@ -325,7 +327,7 @@ const LocalStoreWizardUI: React.FC<LocalStoreWizardUIProps> = React.memo(
                   className="bg-surface-4 text-text-primary px-4 py-2 rounded"
                   onClick={() => {
                     if (state.isInitializing) {
-                      const confirmed = window.confirm(
+                      const confirmed = globalThis.confirm(
                         "Initialization is in progress. Closing now may leave an incomplete database. Are you sure?",
                       );
                       if (!confirmed) return;

--- a/app/renderer/components/SampleWaveform.tsx
+++ b/app/renderer/components/SampleWaveform.tsx
@@ -111,12 +111,12 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
     let cancelled = false;
 
     // Use secure API with kit/voice/slot identifiers
-    if (!window.electronAPI?.getSampleAudioBuffer) {
+    if (!globalThis.electronAPI?.getSampleAudioBuffer) {
       if (onError) onError("Sample audio buffer API not available");
       return;
     }
 
-    window.electronAPI
+    globalThis.electronAPI
       .getSampleAudioBuffer(kitName, voiceNumber, slotNumber)
       .then(async (arrayBuffer: ArrayBuffer | null) => {
         if (cancelled) return;
@@ -135,7 +135,7 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
             // Ignore close errors
           }
         }
-        const ctx = new window.AudioContext();
+        const ctx = new globalThis.AudioContext();
         audioCtxRef.current = ctx;
         ctx.decodeAudioData(arrayBuffer.slice(0), (buf) => {
           setAudioBuffer(buf);

--- a/app/renderer/components/dialogs/AboutDialog.tsx
+++ b/app/renderer/components/dialogs/AboutDialog.tsx
@@ -4,7 +4,8 @@ import React, { useEffect } from "react";
 import LedPixelGrid from "./led-grid/LedPixelGrid";
 
 const openExternal = (url: string) => {
-  if (window.electronAPI?.openExternal) window.electronAPI.openExternal(url);
+  if (globalThis.electronAPI?.openExternal)
+    globalThis.electronAPI.openExternal(url);
   else window.open(url, "_blank", "noopener,noreferrer");
 };
 

--- a/app/renderer/components/dialogs/ChangeLocalStoreDirectoryDialog.tsx
+++ b/app/renderer/components/dialogs/ChangeLocalStoreDirectoryDialog.tsx
@@ -42,11 +42,11 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
   const handleSelectDirectory = async () => {
     setIsSelecting(true);
     try {
-      if (!window.electronAPI?.selectLocalStorePath) {
+      if (!globalThis.electronAPI?.selectLocalStorePath) {
         throw new Error("Directory selection not available");
       }
 
-      const path = await window.electronAPI.selectLocalStorePath();
+      const path = await globalThis.electronAPI.selectLocalStorePath();
       if (path && isMountedRef.current) {
         setSelectedPath(path);
         setValidationResult(null);
@@ -80,12 +80,12 @@ const ChangeLocalStoreDirectoryDialog: React.FC<
         return;
       }
 
-      if (!window.electronAPI?.validateLocalStoreBasic) {
+      if (!globalThis.electronAPI?.validateLocalStoreBasic) {
         throw new Error("Directory validation not available");
       }
 
       const result =
-        await window.electronAPI.validateLocalStoreBasic(pathToUse);
+        await globalThis.electronAPI.validateLocalStoreBasic(pathToUse);
       if (isMountedRef.current) {
         setValidationResult({
           error: result.error,

--- a/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
+++ b/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
@@ -84,11 +84,11 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
   const handleSelectDirectory = async () => {
     setIsSelecting(true);
     try {
-      if (!window.electronAPI?.selectLocalStorePath) {
+      if (!globalThis.electronAPI?.selectLocalStorePath) {
         throw new Error("Directory selection not available");
       }
 
-      const path = await window.electronAPI.selectLocalStorePath();
+      const path = await globalThis.electronAPI.selectLocalStorePath();
       if (path && isMountedRef.current) {
         setSelectedPath(path);
         await validatePath(path);
@@ -108,11 +108,11 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
   const validatePath = async (path: string) => {
     setIsValidating(true);
     try {
-      if (!window.electronAPI?.validateLocalStore) {
+      if (!globalThis.electronAPI?.validateLocalStore) {
         throw new Error("Validation API not available");
       }
 
-      const result = await window.electronAPI.validateLocalStore(path);
+      const result = await globalThis.electronAPI.validateLocalStore(path);
       if (isMountedRef.current) {
         setValidationResult({
           error: result.error || undefined,
@@ -162,8 +162,8 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
   };
 
   const handleExitApp = () => {
-    if (window.electronAPI?.closeApp) {
-      window.electronAPI.closeApp();
+    if (globalThis.electronAPI?.closeApp) {
+      globalThis.electronAPI.closeApp();
     } else {
       // Fallback for development or if API is not available
       window.close();

--- a/app/renderer/components/dialogs/PreferencesDialog.tsx
+++ b/app/renderer/components/dialogs/PreferencesDialog.tsx
@@ -54,7 +54,7 @@ const PreferencesDialog: React.FC<PreferencesDialogProps> = ({
 
   const handleChangeLocalStore = async () => {
     try {
-      const result = await window.electronAPI.selectExistingLocalStore?.();
+      const result = await globalThis.electronAPI.selectExistingLocalStore?.();
       if (result?.success && result.path) {
         await setLocalStorePath(result.path);
       }

--- a/app/renderer/components/dialogs/SyncUpdateDialog.tsx
+++ b/app/renderer/components/dialogs/SyncUpdateDialog.tsx
@@ -69,9 +69,9 @@ const SyncUpdateDialog: React.FC<SyncUpdateDialogProps> = ({
   }, [isOpen, sdCardPath, localChangeSummary, onGenerateChangeSummary]);
 
   const handleSdCardSelect = async () => {
-    if (!window.electronAPI?.selectSdCard) return;
+    if (!globalThis.electronAPI?.selectSdCard) return;
 
-    const selectedPath = await window.electronAPI.selectSdCard();
+    const selectedPath = await globalThis.electronAPI.selectSdCard();
     if (!selectedPath) return;
 
     setLocalSdCardPath(selectedPath);

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
@@ -306,13 +306,10 @@ describe("useKitDataManager", () => {
       success: true,
     });
 
-    globalThis.window = {
-      ...globalThis.window,
-      electronAPI: {
-        getAllSamplesForKit: freshMock,
-        getKits: vi.fn().mockResolvedValue({ data: mockKits, success: true }),
-      },
-    };
+    globalThis.electronAPI = {
+      getAllSamplesForKit: freshMock,
+      getKits: vi.fn().mockResolvedValue({ data: mockKits, success: true }),
+    } as unknown as typeof globalThis.electronAPI;
 
     const { result } = renderHook(() =>
       useKitDataManager({
@@ -337,13 +334,10 @@ describe("useKitDataManager", () => {
       success: true,
     });
 
-    globalThis.window = {
-      ...globalThis.window,
-      electronAPI: {
-        getAllSamplesForKit: freshMock,
-        getKits: vi.fn().mockResolvedValue({ data: mockKits, success: true }),
-      },
-    };
+    globalThis.electronAPI = {
+      getAllSamplesForKit: freshMock,
+      getKits: vi.fn().mockResolvedValue({ data: mockKits, success: true }),
+    } as unknown as typeof globalThis.electronAPI;
 
     const { result } = renderHook(() =>
       useKitDataManager({

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitFilters.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitFilters.test.ts
@@ -9,19 +9,11 @@ import { useKitFilters } from "../useKitFilters";
 const mockToggleKitFavorite = vi.fn();
 const mockGetFavoriteKitsCount = vi.fn();
 
-// Ensure window.electronAPI is properly mocked
-Object.defineProperty(globalThis, "window", {
-  value: {
-    electronAPI: {
-      getFavoriteKitsCount: mockGetFavoriteKitsCount,
-      toggleKitFavorite: mockToggleKitFavorite,
-    },
-  },
-  writable: true,
-});
-
-// Ensure global window is also set
-global.window = globalThis.window as unknown;
+// Ensure electronAPI is properly mocked (code reads globalThis.electronAPI)
+globalThis.electronAPI = {
+  getFavoriteKitsCount: mockGetFavoriteKitsCount,
+  toggleKitFavorite: mockToggleKitFavorite,
+} as unknown as typeof globalThis.electronAPI;
 
 describe("useKitFilters", () => {
   const mockOnMessage = vi.fn();

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitSync.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitSync.test.ts
@@ -244,9 +244,8 @@ describe("useKitSync", () => {
       const mockElectronAPI = {
         writeSettings: mockWriteSettings,
       };
-      global.window = {
-        electronAPI: mockElectronAPI,
-      } as unknown;
+      globalThis.electronAPI =
+        mockElectronAPI as unknown as typeof globalThis.electronAPI;
 
       const { result } = renderHook(() => useKitSync(defaultProps));
 
@@ -265,9 +264,8 @@ describe("useKitSync", () => {
       const mockElectronAPI = {
         writeSettings: mockWriteSettings,
       };
-      global.window = {
-        electronAPI: mockElectronAPI,
-      } as unknown;
+      globalThis.electronAPI =
+        mockElectronAPI as unknown as typeof globalThis.electronAPI;
 
       const { result } = renderHook(() => useKitSync(defaultProps));
 
@@ -286,9 +284,8 @@ describe("useKitSync", () => {
       const mockElectronAPI = {
         writeSettings: mockWriteSettings,
       };
-      global.window = {
-        electronAPI: mockElectronAPI,
-      } as unknown;
+      globalThis.electronAPI =
+        mockElectronAPI as unknown as typeof globalThis.electronAPI;
 
       const { result } = renderHook(() => useKitSync(defaultProps));
 
@@ -307,7 +304,8 @@ describe("useKitSync", () => {
     });
 
     it("works when electronAPI is not available", async () => {
-      global.window = {} as unknown;
+      globalThis.electronAPI =
+        undefined as unknown as typeof globalThis.electronAPI;
 
       const { result } = renderHook(() => useKitSync(defaultProps));
 

--- a/app/renderer/components/hooks/kit-management/useKit.ts
+++ b/app/renderer/components/hooks/kit-management/useKit.ts
@@ -25,13 +25,13 @@ export function useKit({ kitName, onKitUpdated }: UseKitParams) {
   const [error, setError] = useState<null | string>(null);
 
   const loadKit = useCallback(async () => {
-    if (!window.electronAPI?.getKit || !kitName) return;
+    if (!globalThis.electronAPI?.getKit || !kitName) return;
 
     setLoading(true);
     setError(null);
 
     try {
-      const result = await window.electronAPI.getKit(kitName);
+      const result = await globalThis.electronAPI.getKit(kitName);
       if (result.success && result.data) {
         setKit(result.data);
       } else {
@@ -50,10 +50,10 @@ export function useKit({ kitName, onKitUpdated }: UseKitParams) {
   }, [kitName, loadKit]);
 
   const updateKitAlias = async (alias: string) => {
-    if (!window.electronAPI?.updateKit || !kitName) return;
+    if (!globalThis.electronAPI?.updateKit || !kitName) return;
 
     try {
-      const result = await window.electronAPI.updateKit(kitName, { alias });
+      const result = await globalThis.electronAPI.updateKit(kitName, { alias });
       if (result.success) {
         await loadKit();
         // Refresh the kit browser's data after updating alias
@@ -69,12 +69,12 @@ export function useKit({ kitName, onKitUpdated }: UseKitParams) {
   };
 
   const toggleEditableMode = async () => {
-    if (!window.electronAPI?.updateKit || !kitName || !kit) return;
+    if (!globalThis.electronAPI?.updateKit || !kitName || !kit) return;
 
     const newEditableState = !kit.editable;
 
     try {
-      const result = await window.electronAPI.updateKit(kitName, {
+      const result = await globalThis.electronAPI.updateKit(kitName, {
         editable: newEditableState,
       });
       if (result.success) {

--- a/app/renderer/components/hooks/kit-management/useKitBankNavigation.ts
+++ b/app/renderer/components/hooks/kit-management/useKitBankNavigation.ts
@@ -175,7 +175,7 @@ export function useKitBankNavigation({
       const artist = newName || null;
       const rtfFilename = newName ? `${bank} - ${newName}.rtf` : null;
 
-      const result = await window.electronAPI.updateBank?.(bank, {
+      const result = await globalThis.electronAPI.updateBank?.(bank, {
         artist,
         rtf_filename: rtfFilename,
       });

--- a/app/renderer/components/hooks/kit-management/useKitDataManager.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDataManager.ts
@@ -48,7 +48,7 @@ export function useKitDataManager({
     async (kit: string): Promise<VoiceSamples> => {
       try {
         const samplesResult =
-          await window.electronAPI?.getAllSamplesForKit?.(kit);
+          await globalThis.electronAPI?.getAllSamplesForKit?.(kit);
 
         if (samplesResult?.success && samplesResult.data) {
           const grouped = groupDbSamplesByVoice(samplesResult.data);
@@ -75,7 +75,7 @@ export function useKitDataManager({
       let kitNames: string[] = [];
       let loadedKits: KitWithRelations[] = [];
       try {
-        const kitsResult = await window.electronAPI?.getKits?.();
+        const kitsResult = await globalThis.electronAPI?.getKits?.();
         if (kitsResult?.success && kitsResult.data) {
           const kitsWithBanks =
             kitsResult.data as unknown as KitWithRelations[];
@@ -151,7 +151,7 @@ export function useKitDataManager({
   // Refresh metadata for a single kit (voice aliases, etc.) without reloading all samples
   const refreshSingleKitMetadata = useCallback(async (kitName: string) => {
     try {
-      const kitResult = await window.electronAPI?.getKit?.(kitName);
+      const kitResult = await globalThis.electronAPI?.getKit?.(kitName);
       if (kitResult?.success && kitResult.data) {
         const updatedKit = kitResult.data;
         setKits((prevKits) =>
@@ -166,7 +166,7 @@ export function useKitDataManager({
   // Helper function to load all kits and samples from database
   const refreshAllKitsAndSamples = useCallback(async () => {
     try {
-      const kitsResult = await window.electronAPI?.getKits?.();
+      const kitsResult = await globalThis.electronAPI?.getKits?.();
       if (kitsResult?.success && kitsResult.data) {
         const kitsWithBanks = kitsResult.data as unknown as KitWithRelations[];
         setKits(kitsWithBanks);
@@ -221,7 +221,8 @@ export function useKitDataManager({
   const toggleKitFavorite = useCallback(
     async (kitName: string) => {
       try {
-        const result = await window.electronAPI?.toggleKitFavorite?.(kitName);
+        const result =
+          await globalThis.electronAPI?.toggleKitFavorite?.(kitName);
         if (result?.success) {
           // Update local state immediately for optimistic UI update
           const newFavoriteState = result.data?.isFavorite ?? false;
@@ -247,12 +248,12 @@ export function useKitDataManager({
       },
       errorContext: string,
     ) => {
-      if (!window.electronAPI?.updateKit) {
+      if (!globalThis.electronAPI?.updateKit) {
         throw new Error("Update kit API not available");
       }
 
       try {
-        const result = await window.electronAPI.updateKit(kitName, updates);
+        const result = await globalThis.electronAPI.updateKit(kitName, updates);
         if (result.success) {
           // Update local state with properly typed updates
           const stateUpdates: Partial<KitWithRelations> = {};

--- a/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
+++ b/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
@@ -161,11 +161,11 @@ export function useKitEditorLogic(props: UseKitEditorLogicParams) {
     setScanStatus({ status: "scanning" });
 
     try {
-      if (!window.electronAPI?.rescanKit) {
+      if (!globalThis.electronAPI?.rescanKit) {
         throw new Error("Rescan API not available");
       }
 
-      const result = await window.electronAPI.rescanKit(kitName);
+      const result = await globalThis.electronAPI.rescanKit(kitName);
 
       if (result.success) {
         const sampleCount = result.data?.scannedSamples || 0;
@@ -224,8 +224,8 @@ export function useKitEditorLogic(props: UseKitEditorLogicParams) {
         if (!voiceSamples || voiceSamples.length === 0) continue;
 
         const inferredType = inferVoiceTypeFromFilename(voiceSamples[0]);
-        if (inferredType && window.electronAPI?.updateVoiceAlias) {
-          await window.electronAPI.updateVoiceAlias(
+        if (inferredType && globalThis.electronAPI?.updateVoiceAlias) {
+          await globalThis.electronAPI.updateVoiceAlias(
             kitName,
             voice,
             inferredType,
@@ -321,9 +321,12 @@ export function useKitEditorLogic(props: UseKitEditorLogicParams) {
     const handler = (e: CustomEvent) => {
       onMessage(e.detail, "error");
     };
-    window.addEventListener("SampleWaveformError", handler as EventListener);
+    globalThis.addEventListener(
+      "SampleWaveformError",
+      handler as EventListener,
+    );
     return () => {
-      window.removeEventListener(
+      globalThis.removeEventListener(
         "SampleWaveformError",
         handler as EventListener,
       );
@@ -400,8 +403,8 @@ export function useKitEditorLogic(props: UseKitEditorLogicParams) {
         }
       }
     }
-    window.addEventListener("keydown", handleGlobalKeyDown);
-    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+    globalThis.addEventListener("keydown", handleGlobalKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleGlobalKeyDown);
   }, [
     sequencerOpen,
     selectedVoice,

--- a/app/renderer/components/hooks/kit-management/useKitFilters.ts
+++ b/app/renderer/components/hooks/kit-management/useKitFilters.ts
@@ -65,7 +65,8 @@ export function useKitFilters({ kits, onMessage }: UseKitFiltersOptions) {
   const handleToggleFavorite = useCallback(
     async (kitName: string) => {
       try {
-        const result = await window.electronAPI.toggleKitFavorite?.(kitName);
+        const result =
+          await globalThis.electronAPI.toggleKitFavorite?.(kitName);
         if (result?.success) {
           // Update individual kit favorite state immediately (for instant UI update)
           const newFavoriteState = result.data?.isFavorite ?? false;
@@ -75,7 +76,8 @@ export function useKitFilters({ kits, onMessage }: UseKitFiltersOptions) {
           }));
 
           // Update favorites count for filter badge (lightweight)
-          const countResult = await window.electronAPI.getFavoriteKitsCount?.();
+          const countResult =
+            await globalThis.electronAPI.getFavoriteKitsCount?.();
           if (countResult?.success && typeof countResult.data === "number") {
             setFavoritesCount(countResult.data);
           }
@@ -118,7 +120,7 @@ export function useKitFilters({ kits, onMessage }: UseKitFiltersOptions) {
       }
 
       try {
-        const result = await window.electronAPI.getFavoriteKitsCount?.();
+        const result = await globalThis.electronAPI.getFavoriteKitsCount?.();
         if (result?.success && typeof result.data === "number") {
           setFavoritesCount(result.data);
         } else {

--- a/app/renderer/components/hooks/kit-management/useKitKeyboardNav.ts
+++ b/app/renderer/components/hooks/kit-management/useKitKeyboardNav.ts
@@ -36,12 +36,12 @@ export function useKitKeyboardNav({
 
   // Register global A-Z navigation for bank selection and kit focus
   useEffect(() => {
-    window.addEventListener("keydown", globalBankHotkeyHandler);
-    window.addEventListener("keydown", favoritesKeyboardHandler);
+    globalThis.addEventListener("keydown", globalBankHotkeyHandler);
+    globalThis.addEventListener("keydown", favoritesKeyboardHandler);
 
     return () => {
-      window.removeEventListener("keydown", globalBankHotkeyHandler);
-      window.removeEventListener("keydown", favoritesKeyboardHandler);
+      globalThis.removeEventListener("keydown", globalBankHotkeyHandler);
+      globalThis.removeEventListener("keydown", favoritesKeyboardHandler);
     };
   }, [globalBankHotkeyHandler, favoritesKeyboardHandler]);
 

--- a/app/renderer/components/hooks/kit-management/useKitPlayback.ts
+++ b/app/renderer/components/hooks/kit-management/useKitPlayback.ts
@@ -95,11 +95,11 @@ export function useKitPlayback(samples: null | undefined | VoiceSamples) {
     const handleError = (errMsg: string) => {
       setPlaybackError(errMsg || "Playback failed");
     };
-    window.electronAPI.onSamplePlaybackEnded?.(handleEnded);
-    window.electronAPI.onSamplePlaybackError?.(handleError);
+    globalThis.electronAPI.onSamplePlaybackEnded?.(handleEnded);
+    globalThis.electronAPI.onSamplePlaybackError?.(handleError);
     return () => {
-      window.electronAPI.onSamplePlaybackEnded?.(() => {});
-      window.electronAPI.onSamplePlaybackError?.(() => {});
+      globalThis.electronAPI.onSamplePlaybackEnded?.(() => {});
+      globalThis.electronAPI.onSamplePlaybackError?.(() => {});
     };
   }, []);
 

--- a/app/renderer/components/hooks/kit-management/useKitScan.ts
+++ b/app/renderer/components/hooks/kit-management/useKitScan.ts
@@ -23,10 +23,10 @@ export type BulkScanProgress =
 const BULK_SCAN_COMPLETE_CLEAR_MS = 5000;
 
 export async function fileReader(filePath: string): Promise<ArrayBuffer> {
-  if (!window.electronAPI?.readFile) {
+  if (!globalThis.electronAPI?.readFile) {
     throw new Error("File reader not available");
   }
-  const result = await window.electronAPI.readFile(filePath);
+  const result = await globalThis.electronAPI.readFile(filePath);
   if (!result.success || !result.data) {
     throw new Error(result.error || "Failed to read file");
   }

--- a/app/renderer/components/hooks/kit-management/useKitSync.ts
+++ b/app/renderer/components/hooks/kit-management/useKitSync.ts
@@ -26,9 +26,9 @@ export function useKitSync({ onMessage, onRefreshKits }: UseKitSyncOptions) {
   // Get SD card path from settings (includes environment overrides)
   useEffect(() => {
     const getSettings = async () => {
-      if (window.electronAPI?.readSettings) {
+      if (globalThis.electronAPI?.readSettings) {
         try {
-          const settings = await window.electronAPI.readSettings();
+          const settings = await globalThis.electronAPI.readSettings();
           log.debug("Settings loaded:", settings);
           if (settings?.sdCardPath) {
             log.debug(
@@ -118,9 +118,9 @@ export function useKitSync({ onMessage, onRefreshKits }: UseKitSyncOptions) {
       setSdCardPath(path);
 
       // Save to settings if electronAPI is available
-      if (window.electronAPI?.writeSettings) {
+      if (globalThis.electronAPI?.writeSettings) {
         try {
-          await window.electronAPI.writeSettings("sdCardPath", path);
+          await globalThis.electronAPI.writeSettings("sdCardPath", path);
           log.debug("SD card path saved to settings:", path);
         } catch (error) {
           log.error("Failed to save SD card path to settings:", error);

--- a/app/renderer/components/hooks/sample-management/useSampleActions.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleActions.ts
@@ -37,8 +37,8 @@ export function useSampleActions({
   const handleSampleContextMenu = useCallback(
     (e: React.MouseEvent, sampleData: SampleData | undefined) => {
       e.preventDefault();
-      if (sampleData?.source_path && window.electronAPI?.showItemInFolder) {
-        window.electronAPI.showItemInFolder(sampleData.source_path);
+      if (sampleData?.source_path && globalThis.electronAPI?.showItemInFolder) {
+        globalThis.electronAPI.showItemInFolder(sampleData.source_path);
       }
     },
     [],

--- a/app/renderer/components/hooks/sample-management/useSampleManagementMoveOps.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleManagementMoveOps.ts
@@ -35,11 +35,11 @@ export function useSampleManagementMoveOps({
   const validateMoveAPI = useCallback(
     (isCrossKit: boolean) => {
       if (isCrossKit) {
-        if (!window.electronAPI?.moveSampleBetweenKits) {
+        if (!globalThis.electronAPI?.moveSampleBetweenKits) {
           onMessage?.("Cross-kit sample move not available", "error");
           return false;
         }
-      } else if (!window.electronAPI?.moveSampleInKit) {
+      } else if (!globalThis.electronAPI?.moveSampleInKit) {
         onMessage?.("Sample move not available", "error");
         return false;
       }
@@ -53,7 +53,7 @@ export function useSampleManagementMoveOps({
       if (skipUndoRecording || !onAddUndoAction) return [];
 
       const samplesResult =
-        await window.electronAPI?.getAllSamplesForKit?.(kitName);
+        await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
       if (!samplesResult?.success || !samplesResult.data) return [];
 
       const affectedVoices = new Set([fromVoice, toVoice]);
@@ -108,7 +108,7 @@ export function useSampleManagementMoveOps({
         let result;
 
         if (isCrossKit) {
-          result = await window.electronAPI.moveSampleBetweenKits?.(
+          result = await globalThis.electronAPI.moveSampleBetweenKits?.(
             kitName,
             fromVoice,
             fromSlot,
@@ -119,7 +119,7 @@ export function useSampleManagementMoveOps({
           );
         } else {
           const stateSnapshot = await captureStateSnapshot(fromVoice, toVoice);
-          result = await window.electronAPI.moveSampleInKit?.(
+          result = await globalThis.electronAPI.moveSampleInKit?.(
             kitName,
             fromVoice,
             fromSlot,

--- a/app/renderer/components/hooks/sample-management/useSampleManagementOperations.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleManagementOperations.ts
@@ -35,13 +35,13 @@ export function useSampleManagementOperations({
 
   const handleSampleAdd = useCallback(
     async (voice: number, slotNumber: number, filePath: string) => {
-      if (!window.electronAPI?.addSampleToSlot) {
+      if (!globalThis.electronAPI?.addSampleToSlot) {
         onMessage?.("Sample management not available", "error");
         return;
       }
 
       try {
-        const result = await window.electronAPI.addSampleToSlot(
+        const result = await globalThis.electronAPI.addSampleToSlot(
           kitName,
           voice,
           slotNumber,
@@ -100,7 +100,7 @@ export function useSampleManagementOperations({
 
   const handleSampleReplace = useCallback(
     async (voice: number, slotNumber: number, filePath: string) => {
-      if (!window.electronAPI?.replaceSampleInSlot) {
+      if (!globalThis.electronAPI?.replaceSampleInSlot) {
         onMessage?.("Sample management not available", "error");
         return;
       }
@@ -111,7 +111,7 @@ export function useSampleManagementOperations({
           slotNumber,
         );
 
-        const result = await window.electronAPI.replaceSampleInSlot(
+        const result = await globalThis.electronAPI.replaceSampleInSlot(
           kitName,
           voice,
           slotNumber,
@@ -155,7 +155,7 @@ export function useSampleManagementOperations({
 
   const handleSampleDelete = useCallback(
     async (voice: number, slotNumber: number) => {
-      if (!window.electronAPI?.deleteSampleFromSlot) {
+      if (!globalThis.electronAPI?.deleteSampleFromSlot) {
         onMessage?.("Sample management not available", "error");
         return;
       }
@@ -166,7 +166,7 @@ export function useSampleManagementOperations({
           slotNumber,
         );
 
-        const result = await window.electronAPI.deleteSampleFromSlot(
+        const result = await globalThis.electronAPI.deleteSampleFromSlot(
           kitName,
           voice,
           slotNumber,

--- a/app/renderer/components/hooks/sample-management/useSampleManagementUndoActions.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleManagementUndoActions.ts
@@ -48,7 +48,7 @@ export function useSampleManagementUndoActions({
       if (skipUndoRecording) return null;
 
       const samplesResult =
-        await window.electronAPI?.getAllSamplesForKit?.(kitName);
+        await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
       if (samplesResult?.success && samplesResult.data) {
         return (
           samplesResult.data.find(
@@ -68,7 +68,7 @@ export function useSampleManagementUndoActions({
 
       try {
         const samplesResult =
-          await window.electronAPI?.getAllSamplesForKit?.(kitName);
+          await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
         if (samplesResult?.success && samplesResult.data) {
           return (
             samplesResult.data.find(

--- a/app/renderer/components/hooks/sample-management/useSampleProcessing.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleProcessing.ts
@@ -30,12 +30,12 @@ export function useSampleProcessing({
   voice,
 }: UseSampleProcessingOptions) {
   const getCurrentKitSamples = useCallback(async () => {
-    if (!window.electronAPI?.getAllSamplesForKit) {
+    if (!globalThis.electronAPI?.getAllSamplesForKit) {
       console.error("Sample management not available");
       return null;
     }
 
-    const result = await window.electronAPI.getAllSamplesForKit(kitName);
+    const result = await globalThis.electronAPI.getAllSamplesForKit(kitName);
     if (!result.success) {
       console.error(`Failed to get samples: ${result.error}`);
       return null;

--- a/app/renderer/components/hooks/shared/useBankScanning.ts
+++ b/app/renderer/components/hooks/shared/useBankScanning.ts
@@ -10,7 +10,7 @@ interface UseBankScanningProps {
 export function useBankScanning({ onMessage }: UseBankScanningProps) {
   const scanBanks = useCallback(async () => {
     try {
-      const result = await window.electronAPI.scanBanks?.();
+      const result = await globalThis.electronAPI.scanBanks?.();
       if (result?.success) {
         onMessage?.(
           `Bank scanning complete. Updated ${result.data?.updatedBanks} banks.`,

--- a/app/renderer/components/hooks/shared/useBpm.ts
+++ b/app/renderer/components/hooks/shared/useBpm.ts
@@ -25,9 +25,9 @@ export function useBpm({ initialBpm = 120, kitName }: UseBpmParams) {
       setBpmState(clampedBpm);
 
       // Persist to database
-      if (kitName && window.electronAPI?.updateKitBpm) {
+      if (kitName && globalThis.electronAPI?.updateKitBpm) {
         try {
-          await window.electronAPI.updateKitBpm(kitName, clampedBpm);
+          await globalThis.electronAPI.updateKitBpm(kitName, clampedBpm);
         } catch (error) {
           console.error("Failed to update BPM:", error);
           // Revert on error

--- a/app/renderer/components/hooks/shared/useFileValidation.ts
+++ b/app/renderer/components/hooks/shared/useFileValidation.ts
@@ -38,8 +38,8 @@ interface FormatValidationResult {
 export function useFileValidation() {
   const getFilePathFromDrop = useCallback(
     async (file: File): Promise<string> => {
-      if (window.electronFileAPI?.getDroppedFilePath) {
-        return await window.electronFileAPI.getDroppedFilePath(file);
+      if (globalThis.electronFileAPI?.getDroppedFilePath) {
+        return await globalThis.electronFileAPI.getDroppedFilePath(file);
       }
       return (file as ElectronFile).path || file.name;
     },
@@ -77,12 +77,13 @@ export function useFileValidation() {
 
   const validateDroppedFile = useCallback(
     async (filePath: string) => {
-      if (!window.electronAPI?.validateSampleFormat) {
+      if (!globalThis.electronAPI?.validateSampleFormat) {
         console.error("Format validation not available");
         return null;
       }
 
-      const result = await window.electronAPI.validateSampleFormat(filePath);
+      const result =
+        await globalThis.electronAPI.validateSampleFormat(filePath);
       if (!result.success || !result.data) {
         console.error("Format validation failed:", result.error);
         return null;

--- a/app/renderer/components/hooks/shared/useMenuEvents.ts
+++ b/app/renderer/components/hooks/shared/useMenuEvents.ts
@@ -52,29 +52,29 @@ export function useMenuEvents(handlers: MenuEventHandlers) {
     };
 
     // Register electron event listeners
-    if (window.electronAPI) {
-      window.addEventListener("menu-scan-all-kits", handleScanAll);
-      window.addEventListener(
+    if (globalThis.electronAPI) {
+      globalThis.addEventListener("menu-scan-all-kits", handleScanAll);
+      globalThis.addEventListener(
         "menu-change-local-store-directory",
         handleChangeLocalStoreDirectory,
       );
-      window.addEventListener("menu-preferences", handlePreferences);
-      window.addEventListener("menu-about", handleAbout);
-      window.addEventListener("menu-undo", handleUndo);
-      window.addEventListener("menu-redo", handleRedo);
+      globalThis.addEventListener("menu-preferences", handlePreferences);
+      globalThis.addEventListener("menu-about", handleAbout);
+      globalThis.addEventListener("menu-undo", handleUndo);
+      globalThis.addEventListener("menu-redo", handleRedo);
     }
 
     // Cleanup event listeners
     return () => {
-      window.removeEventListener("menu-scan-all-kits", handleScanAll);
-      window.removeEventListener(
+      globalThis.removeEventListener("menu-scan-all-kits", handleScanAll);
+      globalThis.removeEventListener(
         "menu-change-local-store-directory",
         handleChangeLocalStoreDirectory,
       );
-      window.removeEventListener("menu-preferences", handlePreferences);
-      window.removeEventListener("menu-about", handleAbout);
-      window.removeEventListener("menu-undo", handleUndo);
-      window.removeEventListener("menu-redo", handleRedo);
+      globalThis.removeEventListener("menu-preferences", handlePreferences);
+      globalThis.removeEventListener("menu-about", handleAbout);
+      globalThis.removeEventListener("menu-undo", handleUndo);
+      globalThis.removeEventListener("menu-redo", handleRedo);
     };
   }, [handlers]);
 }

--- a/app/renderer/components/hooks/shared/useRedoActionHandlers.ts
+++ b/app/renderer/components/hooks/shared/useRedoActionHandlers.ts
@@ -15,20 +15,20 @@ export function useRedoActionHandlers({
   const executeRedoAction = async (action: AnyUndoAction) => {
     switch (action.type) {
       case "ADD_SAMPLE":
-        return window.electronAPI?.addSampleToSlot?.(
+        return globalThis.electronAPI?.addSampleToSlot?.(
           kitName,
           action.data.voice,
           action.data.slot,
           action.data.addedSample.source_path,
         );
       case "DELETE_SAMPLE":
-        return window.electronAPI?.deleteSampleFromSlot?.(
+        return globalThis.electronAPI?.deleteSampleFromSlot?.(
           kitName,
           action.data.voice,
           action.data.slot,
         );
       case "MOVE_SAMPLE":
-        return window.electronAPI?.moveSampleInKit?.(
+        return globalThis.electronAPI?.moveSampleInKit?.(
           kitName,
           action.data.fromVoice,
           action.data.fromSlot,
@@ -36,7 +36,7 @@ export function useRedoActionHandlers({
           action.data.toSlot,
         );
       case "MOVE_SAMPLE_BETWEEN_KITS":
-        return window.electronAPI?.moveSampleBetweenKits?.(
+        return globalThis.electronAPI?.moveSampleBetweenKits?.(
           action.data.fromKit,
           action.data.fromVoice,
           action.data.fromSlot,
@@ -46,13 +46,13 @@ export function useRedoActionHandlers({
           action.data.mode,
         );
       case "REINDEX_SAMPLES":
-        return window.electronAPI?.deleteSampleFromSlot?.(
+        return globalThis.electronAPI?.deleteSampleFromSlot?.(
           kitName,
           action.data.voice,
           action.data.deletedSlot,
         );
       case "REPLACE_SAMPLE":
-        return window.electronAPI?.replaceSampleInSlot?.(
+        return globalThis.electronAPI?.replaceSampleInSlot?.(
           kitName,
           action.data.voice,
           action.data.slot,

--- a/app/renderer/components/hooks/shared/useStartupActions.ts
+++ b/app/renderer/components/hooks/shared/useStartupActions.ts
@@ -20,7 +20,7 @@ export function useStartupActions({
       // Run bank scanning on startup (after migrations)
       try {
         console.info("[Startup] Running bank scanning...");
-        const bankScanResult = await window.electronAPI.scanBanks?.();
+        const bankScanResult = await globalThis.electronAPI.scanBanks?.();
         if (bankScanResult?.success) {
           console.info(
             `[Startup] Bank scanning complete. Updated ${bankScanResult.data?.updatedBanks} banks.`,

--- a/app/renderer/components/hooks/shared/useStepPattern.ts
+++ b/app/renderer/components/hooks/shared/useStepPattern.ts
@@ -26,13 +26,13 @@ export function useStepPattern({
 
   const updateStepPattern = useCallback(
     async (pattern: number[][]) => {
-      if (!window.electronAPI?.updateStepPattern || !kitName) return;
+      if (!globalThis.electronAPI?.updateStepPattern || !kitName) return;
 
       // Update UI state immediately for responsive feedback
       setStepPatternState(pattern);
 
       try {
-        const result = await window.electronAPI.updateStepPattern(
+        const result = await globalThis.electronAPI.updateStepPattern(
           kitName,
           pattern,
         );

--- a/app/renderer/components/hooks/shared/useSyncUpdate.ts
+++ b/app/renderer/components/hooks/shared/useSyncUpdate.ts
@@ -31,7 +31,7 @@ interface SyncProgress {
 }
 
 interface SyncUpdateDependencies {
-  electronAPI?: typeof window.electronAPI;
+  electronAPI?: typeof globalThis.electronAPI;
 }
 
 interface UseSyncUpdateResult {
@@ -52,7 +52,7 @@ interface UseSyncUpdateResult {
 export function useSyncUpdate(
   deps: SyncUpdateDependencies = {},
 ): UseSyncUpdateResult {
-  const electronAPI = deps.electronAPI || window.electronAPI;
+  const electronAPI = deps.electronAPI || globalThis.electronAPI;
 
   const [syncProgress, setSyncProgress] = useState<null | SyncProgress>(null);
   const [isLoading, setIsLoading] = useState(false);

--- a/app/renderer/components/hooks/shared/useTriggerConditions.ts
+++ b/app/renderer/components/hooks/shared/useTriggerConditions.ts
@@ -39,13 +39,13 @@ export function useTriggerConditions({
 
   const updateTriggerConditions = useCallback(
     async (conditions: (null | string)[][]) => {
-      if (!window.electronAPI?.updateTriggerConditions || !kitName) return;
+      if (!globalThis.electronAPI?.updateTriggerConditions || !kitName) return;
 
       // Update UI state immediately for responsive feedback
       setTriggerConditionsState(conditions);
 
       try {
-        const result = await window.electronAPI.updateTriggerConditions(
+        const result = await globalThis.electronAPI.updateTriggerConditions(
           kitName,
           conditions,
         );

--- a/app/renderer/components/hooks/shared/useUndoActionHandlers.ts
+++ b/app/renderer/components/hooks/shared/useUndoActionHandlers.ts
@@ -50,7 +50,7 @@ export function useUndoActionHandlers({
   const clearAffectedVoices = async (fromVoice: number, toVoice: number) => {
     const affectedVoices = new Set([fromVoice, toVoice]);
     const currentSamplesResult =
-      await window.electronAPI?.getAllSamplesForKit?.(kitName);
+      await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
 
     if (currentSamplesResult?.success && currentSamplesResult.data) {
       const currentSamples = currentSamplesResult.data.filter((s) =>
@@ -58,7 +58,7 @@ export function useUndoActionHandlers({
       );
 
       for (const sample of currentSamples) {
-        await window.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
+        await globalThis.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
           kitName,
           sample.voice_number,
           dbSlotToUiSlot(sample.slot_number) - 1,
@@ -71,7 +71,7 @@ export function useUndoActionHandlers({
     for (const { sample, slot, voice } of stateSnapshot) {
       // Convert database slot to 0-based slot number for API call
       const apiSlotNumber = dbSlotToUiSlot(slot) - 1;
-      await window.electronAPI?.addSampleToSlot?.(
+      await globalThis.electronAPI?.addSampleToSlot?.(
         kitName,
         voice,
         apiSlotNumber,
@@ -82,7 +82,7 @@ export function useUndoActionHandlers({
 
   const clearCurrentVoiceSamples = async (voice: number) => {
     const currentSamplesResult =
-      await window.electronAPI?.getAllSamplesForKit?.(kitName);
+      await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
 
     if (currentSamplesResult?.success && currentSamplesResult.data) {
       const currentSamples = currentSamplesResult.data.filter(
@@ -90,7 +90,7 @@ export function useUndoActionHandlers({
       );
 
       for (const sample of currentSamples) {
-        await window.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
+        await globalThis.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
           kitName,
           sample.voice_number,
           dbSlotToUiSlot(sample.slot_number) - 1,
@@ -102,7 +102,7 @@ export function useUndoActionHandlers({
   const cleanSlots = async (slotsToClean: Set<string>) => {
     for (const slotKey of slotsToClean) {
       const [voice, slot] = slotKey.split("-").map(Number);
-      await window.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
+      await globalThis.electronAPI?.deleteSampleFromSlotWithoutReindexing?.(
         kitName,
         voice,
         slot,
@@ -114,7 +114,7 @@ export function useUndoActionHandlers({
     const sortedSamples = [...samplesToRestore].sort((a, b) => a.slot - b.slot);
 
     for (const { sample, slot, voice } of sortedSamples) {
-      await window.electronAPI?.addSampleToSlot?.(
+      await globalThis.electronAPI?.addSampleToSlot?.(
         kitName,
         voice,
         slot,
@@ -126,7 +126,7 @@ export function useUndoActionHandlers({
   // Individual undo action handlers
   const undoDeleteSample = async (action: DeleteSampleAction) => {
     log.debug(" Undoing DELETE_SAMPLE - adding sample back");
-    const result = await window.electronAPI?.addSampleToSlot?.(
+    const result = await globalThis.electronAPI?.addSampleToSlot?.(
       kitName,
       action.data.voice,
       action.data.slot,
@@ -138,7 +138,7 @@ export function useUndoActionHandlers({
 
   const undoAddSample = async (action: AddSampleAction) => {
     log.debug(" Undoing ADD_SAMPLE - deleting sample");
-    const result = await window.electronAPI?.deleteSampleFromSlot?.(
+    const result = await globalThis.electronAPI?.deleteSampleFromSlot?.(
       kitName,
       action.data.voice,
       action.data.slot,
@@ -149,7 +149,7 @@ export function useUndoActionHandlers({
 
   const undoReplaceSample = async (action: ReplaceSampleAction) => {
     log.debug(" Undoing REPLACE_SAMPLE - restoring old sample");
-    const result = await window.electronAPI?.replaceSampleInSlot?.(
+    const result = await globalThis.electronAPI?.replaceSampleInSlot?.(
       kitName,
       action.data.voice,
       action.data.slot,
@@ -245,7 +245,7 @@ export function useUndoActionHandlers({
     action: MoveSampleBetweenKitsAction,
   ) => {
     try {
-      const result = await window.electronAPI?.moveSampleBetweenKits?.(
+      const result = await globalThis.electronAPI?.moveSampleBetweenKits?.(
         action.data.toKit,
         action.data.toVoice,
         action.data.toSlot,
@@ -257,7 +257,7 @@ export function useUndoActionHandlers({
 
       // Restore replaced sample if any
       if (action.data.replacedSample && result?.success) {
-        await window.electronAPI?.addSampleToSlot?.(
+        await globalThis.electronAPI?.addSampleToSlot?.(
           action.data.toKit,
           action.data.toVoice,
           action.data.toSlot,
@@ -277,7 +277,7 @@ export function useUndoActionHandlers({
   const restoreDeletedSample = async (
     actionData: ReindexSamplesAction["data"],
   ) => {
-    await window.electronAPI?.addSampleToSlot?.(
+    await globalThis.electronAPI?.addSampleToSlot?.(
       kitName,
       actionData.voice,
       actionData.deletedSlot,
@@ -289,7 +289,7 @@ export function useUndoActionHandlers({
     affectedSamples: ReindexSamplesAction["data"]["affectedSamples"],
   ) => {
     for (const affectedSample of affectedSamples) {
-      await window.electronAPI?.addSampleToSlot?.(
+      await globalThis.electronAPI?.addSampleToSlot?.(
         kitName,
         affectedSample.voice,
         affectedSample.newSlot,

--- a/app/renderer/components/hooks/shared/useValidationResults.ts
+++ b/app/renderer/components/hooks/shared/useValidationResults.ts
@@ -45,7 +45,7 @@ export function useValidationResults({
     setIsLoading(true);
     try {
       const result =
-        await window.electronAPI.validateLocalStore(localStorePath);
+        await globalThis.electronAPI.validateLocalStore(localStorePath);
       setValidationResult(result);
 
       if (!result.isValid && onMessage) {
@@ -97,7 +97,7 @@ export function useValidationResults({
   // Helper function to rescan a single kit
   const rescanSingleKit = useCallback(async (kitName: string) => {
     try {
-      const result = await window.electronAPI.rescanKit(kitName);
+      const result = await globalThis.electronAPI.rescanKit(kitName);
 
       if (result.success && result.data) {
         return {
@@ -185,7 +185,7 @@ export function useValidationResults({
 
       // Re-validate to show updated results
       const updatedValidation =
-        await window.electronAPI.validateLocalStore(localStorePath);
+        await globalThis.electronAPI.validateLocalStore(localStorePath);
       setValidationResult(updatedValidation);
 
       // Close dialog if successful and valid

--- a/app/renderer/components/hooks/voice-panels/useVoiceAlias.ts
+++ b/app/renderer/components/hooks/voice-panels/useVoiceAlias.ts
@@ -11,10 +11,10 @@ export interface UseVoiceAliasParams {
 export function useVoiceAlias({ kitName, onUpdate }: UseVoiceAliasParams) {
   const updateVoiceAlias = useCallback(
     async (voiceNumber: number, voiceAlias: string) => {
-      if (!window.electronAPI?.updateVoiceAlias || !kitName) return;
+      if (!globalThis.electronAPI?.updateVoiceAlias || !kitName) return;
 
       try {
-        const result = await window.electronAPI.updateVoiceAlias(
+        const result = await globalThis.electronAPI.updateVoiceAlias(
           kitName,
           voiceNumber,
           voiceAlias,

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
@@ -207,7 +207,7 @@ export function useVoicePanelSlotRendering({
           {isEditable && (
             <GainKnob
               onChange={(db) => {
-                window.electronAPI?.updateSampleGain?.(
+                globalThis.electronAPI?.updateSampleGain?.(
                   kitName,
                   voice,
                   slotNumber,
@@ -224,8 +224,11 @@ export function useVoicePanelSlotRendering({
             key={`${kitName}-${voice}-${uiSlotNumber}-${sampleName}`}
             kitName={kitName}
             onError={(err) => {
-              if (typeof window !== "undefined" && window.dispatchEvent) {
-                window.dispatchEvent(
+              if (
+                typeof globalThis !== "undefined" &&
+                globalThis.dispatchEvent
+              ) {
+                globalThis.dispatchEvent(
                   new CustomEvent("SampleWaveformError", { detail: err }),
                 );
               }

--- a/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
+++ b/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
@@ -294,8 +294,8 @@ export function useLocalStoreWizard(
 
 function getElectronAPI(): ElectronAPI {
   // Use type assertion to avoid type conflict with window.electronAPI
-  return typeof window !== "undefined" && window.electronAPI
-    ? window.electronAPI
+  return typeof globalThis !== "undefined" && globalThis.electronAPI
+    ? globalThis.electronAPI
     : ({} as ElectronAPI);
 }
 

--- a/app/renderer/components/utils/__tests__/kitOperations.test.ts
+++ b/app/renderer/components/utils/__tests__/kitOperations.test.ts
@@ -22,10 +22,8 @@ const mockElectronAPI = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  global.window = {
-    ...global.window,
-    electronAPI: mockElectronAPI,
-  } as unknown;
+  globalThis.electronAPI =
+    mockElectronAPI as unknown as typeof globalThis.electronAPI;
 });
 
 describe("validateKitSlot", () => {
@@ -68,7 +66,7 @@ describe("createKit", () => {
   });
 
   it("throws error when Electron API is not available", async () => {
-    global.window = { electronAPI: {} } as unknown;
+    globalThis.electronAPI = {} as unknown as typeof globalThis.electronAPI;
 
     await expect(createKit("A1")).rejects.toThrow("Electron API not available");
   });
@@ -98,7 +96,7 @@ describe("duplicateKit", () => {
   });
 
   it("throws error when Electron API is not available", async () => {
-    global.window = { electronAPI: {} } as unknown;
+    globalThis.electronAPI = {} as unknown as typeof globalThis.electronAPI;
 
     await expect(duplicateKit("A1", "B2")).rejects.toThrow(
       "Electron API not available",
@@ -139,7 +137,7 @@ describe("deleteKit", () => {
   });
 
   it("throws error when Electron API is not available", async () => {
-    global.window = { electronAPI: {} } as unknown;
+    globalThis.electronAPI = {} as unknown as typeof globalThis.electronAPI;
 
     await expect(deleteKit("A5")).rejects.toThrow("Electron API not available");
   });
@@ -178,7 +176,7 @@ describe("getKitDeleteSummary", () => {
   });
 
   it("throws error when Electron API is not available", async () => {
-    global.window = { electronAPI: {} } as unknown;
+    globalThis.electronAPI = {} as unknown as typeof globalThis.electronAPI;
 
     await expect(getKitDeleteSummary("A5")).rejects.toThrow(
       "Electron API not available",

--- a/app/renderer/components/utils/databaseScanning.ts
+++ b/app/renderer/components/utils/databaseScanning.ts
@@ -287,7 +287,7 @@ async function processSingleWAVAnalysis(
   kitName: string,
   result: DatabaseScanResult,
 ): Promise<void> {
-  const samples = await window.electronAPI?.getAllSamplesForKit?.(kitName);
+  const samples = await globalThis.electronAPI?.getAllSamplesForKit?.(kitName);
   if (!samples?.success || !samples.data) {
     result.errors.push({
       error: `Could not retrieve samples for kit ${kitName}`,
@@ -307,7 +307,7 @@ async function processSingleWAVAnalysis(
     return;
   }
 
-  const updateResult = await window.electronAPI?.updateSampleMetadata?.(
+  const updateResult = await globalThis.electronAPI?.updateSampleMetadata?.(
     matchingSample.id,
     {
       wav_bit_depth: analysis.bitDepth,

--- a/app/renderer/components/utils/kitOperations.ts
+++ b/app/renderer/components/utils/kitOperations.ts
@@ -17,23 +17,23 @@ export async function createKit(kitSlot: string): Promise<void> {
     throw new Error("Invalid kit slot. Use format A0-Z99.");
   }
 
-  if (!window.electronAPI?.createKit) {
+  if (!globalThis.electronAPI?.createKit) {
     throw new Error("Electron API not available");
   }
 
-  await window.electronAPI.createKit(kitSlot);
+  await globalThis.electronAPI.createKit(kitSlot);
 }
 
 /**
  * Deletes a kit and all its child records (samples, voices) from the database
  */
 export async function deleteKit(kitName: string): Promise<void> {
-  if (!window.electronAPI?.deleteKit) {
+  if (!globalThis.electronAPI?.deleteKit) {
     throw new Error("Electron API not available");
   }
 
   try {
-    await window.electronAPI.deleteKit(kitName);
+    await globalThis.electronAPI.deleteKit(kitName);
   } catch (err) {
     let msg = String(err instanceof Error ? err.message : err);
     msg = msg
@@ -54,12 +54,12 @@ export async function duplicateKit(
     throw new Error("Invalid destination slot. Use format A0-Z99.");
   }
 
-  if (!window.electronAPI?.copyKit) {
+  if (!globalThis.electronAPI?.copyKit) {
     throw new Error("Electron API not available");
   }
 
   try {
-    await window.electronAPI.copyKit(sourceSlot, destSlot);
+    await globalThis.electronAPI.copyKit(sourceSlot, destSlot);
   } catch (err) {
     // Clean up error message
     let msg = String(err instanceof Error ? err.message : err);
@@ -113,12 +113,12 @@ export async function getKitDeleteSummary(kitName: string): Promise<{
   sampleCount: number;
   voiceCount: number;
 }> {
-  if (!window.electronAPI?.getKitDeleteSummary) {
+  if (!globalThis.electronAPI?.getKitDeleteSummary) {
     throw new Error("Electron API not available");
   }
 
   try {
-    return await window.electronAPI.getKitDeleteSummary(kitName);
+    return await globalThis.electronAPI.getKitDeleteSummary(kitName);
   } catch (err) {
     let msg = String(err instanceof Error ? err.message : err);
     msg = msg

--- a/app/renderer/components/utils/romperDb.ts
+++ b/app/renderer/components/utils/romperDb.ts
@@ -8,11 +8,11 @@ import { createLogger } from "../../utils/logger";
 const log = createLogger("Renderer");
 
 export async function createRomperDb(dbDir: string) {
-  if (!window.electronAPI?.createRomperDb) {
+  if (!globalThis.electronAPI?.createRomperDb) {
     log.error("Romper DB creation not available");
     throw new Error("Romper DB creation not available");
   }
-  const result = await window.electronAPI.createRomperDb(dbDir);
+  const result = await globalThis.electronAPI.createRomperDb(dbDir);
   if (!result.success) {
     log.error("Failed to create Romper DB:", result.error);
     throw new Error(result.error || "Failed to create Romper DB");
@@ -22,9 +22,9 @@ export async function createRomperDb(dbDir: string) {
 }
 
 export async function insertKit(dbDir: string, kit: NewKit) {
-  if (!window.electronAPI?.insertKit) throw new Error("IPC not available");
+  if (!globalThis.electronAPI?.insertKit) throw new Error("IPC not available");
 
-  const result = await window.electronAPI.insertKit(dbDir, kit);
+  const result = await globalThis.electronAPI.insertKit(dbDir, kit);
   if (!result.success) throw new Error(result.error || "Failed to insert kit");
   return kit.name; // Return the kit name instead of an ID
 }
@@ -44,7 +44,8 @@ export async function insertSample(
     wav_sample_rate?: number;
   },
 ) {
-  if (!window.electronAPI?.insertSample) throw new Error("IPC not available");
+  if (!globalThis.electronAPI?.insertSample)
+    throw new Error("IPC not available");
 
   // Provide default values for required fields
   const sampleWithDefaults = {
@@ -56,7 +57,7 @@ export async function insertSample(
     wav_sample_rate: sample.wav_sample_rate || null,
   };
 
-  const result = await window.electronAPI.insertSample(
+  const result = await globalThis.electronAPI.insertSample(
     dbDir,
     sampleWithDefaults,
   );

--- a/app/renderer/components/wizard/WizardSourceStep.tsx
+++ b/app/renderer/components/wizard/WizardSourceStep.tsx
@@ -38,8 +38,8 @@ const WizardSourceStep: React.FC<WizardSourceStepProps> = ({
       if (setSdCardPath) setSdCardPath(config.sdCardPath!);
       return;
     }
-    if (window.electronAPI?.selectSdCard) {
-      const pickedPath = await window.electronAPI.selectSdCard();
+    if (globalThis.electronAPI?.selectSdCard) {
+      const pickedPath = await globalThis.electronAPI.selectSdCard();
       if (pickedPath && setSdCardPath) {
         setSdCardPath(pickedPath);
         setSourceConfirmed?.(true);

--- a/app/renderer/electron.d.ts
+++ b/app/renderer/electron.d.ts
@@ -407,4 +407,16 @@ declare global {
       getDroppedFilePath: (file: File) => Promise<string>;
     };
   }
+
+  // In the renderer `globalThis === window`, so the preload-injected bridges
+  // are also reachable as `globalThis.electronAPI` / `globalThis.electronFileAPI`.
+  // Declared as globals so code can prefer `globalThis` over `window` (S7764).
+
+  var electronAPI: ElectronAPI;
+
+  var electronFileAPI:
+    | {
+        getDroppedFilePath: (file: File) => Promise<string>;
+      }
+    | undefined;
 }

--- a/app/renderer/main.tsx
+++ b/app/renderer/main.tsx
@@ -30,8 +30,8 @@ const AppContent = () => {
   // Listen for menu-about custom event (from LED icon click and native menu)
   useEffect(() => {
     const handler = () => setShowAboutModal(true);
-    window.addEventListener("menu-about", handler);
-    return () => window.removeEventListener("menu-about", handler);
+    globalThis.addEventListener("menu-about", handler);
+    return () => globalThis.removeEventListener("menu-about", handler);
   }, []);
 
   return (

--- a/app/renderer/utils/SettingsContext.tsx
+++ b/app/renderer/utils/SettingsContext.tsx
@@ -74,8 +74,8 @@ const initialState: SettingsState = {
 
 // Helper function to detect system theme preference
 function getSystemThemePreference(): boolean {
-  if (typeof window !== "undefined" && window.matchMedia) {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (typeof globalThis !== "undefined" && globalThis.matchMedia) {
+    return globalThis.matchMedia("(prefers-color-scheme: dark)").matches;
   }
   return false;
 }
@@ -168,7 +168,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   // Refresh local store status
   const refreshLocalStoreStatus = useCallback(async () => {
     try {
-      const status = await window.electronAPI.getLocalStoreStatus();
+      const status = await globalThis.electronAPI.getLocalStoreStatus();
       dispatch({ payload: status, type: "UPDATE_LOCAL_STORE_STATUS" });
     } catch (error) {
       console.error("Failed to refresh local store status:", error);
@@ -181,7 +181,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
     dispatch({ type: "INIT_START" });
 
     try {
-      const loadedSettings = await window.electronAPI.readSettings();
+      const loadedSettings = await globalThis.electronAPI.readSettings();
 
       const settings: Settings = {
         confirmDestructiveActions:
@@ -210,7 +210,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   const setLocalStorePath = useCallback(
     async (path: string) => {
       try {
-        await window.electronAPI.setSetting("localStorePath", path);
+        await globalThis.electronAPI.setSetting("localStorePath", path);
         dispatch({ payload: path, type: "UPDATE_LOCAL_STORE_PATH" });
         await refreshLocalStoreStatus();
       } catch (error) {
@@ -224,7 +224,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   const setThemeMode = useCallback(
     async (mode: ThemeMode) => {
       try {
-        await window.electronAPI.setSetting("themeMode", mode);
+        await globalThis.electronAPI.setSetting("themeMode", mode);
         dispatch({ payload: mode, type: "UPDATE_THEME_MODE" });
         applyTheme(shouldUseDarkMode(mode));
       } catch (error) {
@@ -237,7 +237,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   // Update confirm destructive actions setting
   const setConfirmDestructiveActions = useCallback(async (enabled: boolean) => {
     try {
-      await window.electronAPI.setSetting("confirmDestructiveActions", enabled);
+      await globalThis.electronAPI.setSetting(
+        "confirmDestructiveActions",
+        enabled,
+      );
       dispatch({
         payload: enabled,
         type: "UPDATE_CONFIRM_DESTRUCTIVE_ACTIONS",
@@ -264,10 +267,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (
       state.settings.themeMode === "system" &&
-      typeof window !== "undefined" &&
-      window.matchMedia
+      typeof globalThis !== "undefined" &&
+      globalThis.matchMedia
     ) {
-      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      const mediaQuery = globalThis.matchMedia("(prefers-color-scheme: dark)");
 
       const handleSystemThemeChange = () => {
         if (state.settings.themeMode === "system") {

--- a/app/renderer/utils/hmrStateManager.ts
+++ b/app/renderer/utils/hmrStateManager.ts
@@ -76,8 +76,8 @@ export function markExplicitNavigation(): void {
  */
 export function restoreRouteState(): void {
   const savedRoute = sessionStorage.getItem(HMR_ROUTE_KEY);
-  if (savedRoute && savedRoute !== window.location.hash) {
-    window.location.hash = savedRoute;
+  if (savedRoute && savedRoute !== globalThis.location.hash) {
+    globalThis.location.hash = savedRoute;
   }
 }
 
@@ -108,7 +108,7 @@ export function restoreSelectedKitIfExists(
  * Save the current route to session storage
  */
 export function saveRouteState(): void {
-  const currentPath = window.location.hash;
+  const currentPath = globalThis.location.hash;
   sessionStorage.setItem(HMR_ROUTE_KEY, currentPath);
 }
 

--- a/app/renderer/views/AboutView.tsx
+++ b/app/renderer/views/AboutView.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 const openExternal = (url: string) => {
-  if (window.electronAPI?.openExternal) {
-    window.electronAPI.openExternal(url);
+  if (globalThis.electronAPI?.openExternal) {
+    globalThis.electronAPI.openExternal(url);
   } else {
     window.open(url, "_blank", "noopener,noreferrer");
   }
@@ -29,9 +29,9 @@ const AboutView: React.FC<AboutViewProps> = ({ navigate }) => {
     if (navigate) {
       navigate("/kits");
     } else {
-      window.history.length > 1
-        ? window.history.back()
-        : window.location.assign("/kits");
+      globalThis.history.length > 1
+        ? globalThis.history.back()
+        : globalThis.location.assign("/kits");
     }
   };
   return (

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -252,8 +252,8 @@ const KitsView: React.FC = () => {
 
   // Critical error handler
   const handleCriticalError = useCallback(() => {
-    if (window.electronAPI?.closeApp) {
-      window.electronAPI.closeApp();
+    if (globalThis.electronAPI?.closeApp) {
+      globalThis.electronAPI.closeApp();
     } else {
       // Fallback for development or if API is not available
       window.close();
@@ -320,7 +320,7 @@ const KitsView: React.FC = () => {
           localStorePath={localStorePath}
           modifiedCount={kitFilters.modifiedCount}
           onAboutClick={() =>
-            window.dispatchEvent(new CustomEvent("menu-about"))
+            globalThis.dispatchEvent(new CustomEvent("menu-about"))
           }
           onMessage={showMessage}
           onRefreshKits={refreshAllKitsAndSamples}
@@ -345,7 +345,7 @@ const KitsView: React.FC = () => {
         onClose={dialogState.closeWizard}
         onCloseApp={
           needsLocalStoreSetup
-            ? () => window.electronAPI?.closeApp?.()
+            ? () => globalThis.electronAPI?.closeApp?.()
             : undefined
         }
         onInitializationChange={setIsWizardInitializing}

--- a/electron/preload/__tests__/index.test.tsx
+++ b/electron/preload/__tests__/index.test.tsx
@@ -46,10 +46,9 @@ describe("preload/index.tsx", () => {
       return originalRequire.apply(this, arguments);
     };
 
-    // Mock global window for menuEventForwarder
-    global.window = {
-      dispatchEvent: vi.fn(),
-    } as unknown;
+    // Mock dispatchEvent for menuEventForwarder (code uses globalThis.dispatchEvent)
+    globalThis.dispatchEvent =
+      vi.fn() as unknown as typeof globalThis.dispatchEvent;
   });
 
   it("exposes romperEnv in main world", async () => {
@@ -391,7 +390,7 @@ describe("preload/index.tsx", () => {
       callback();
 
       // Check that a DOM event was dispatched
-      expect(global.window.dispatchEvent).toHaveBeenCalledWith(
+      expect(globalThis.dispatchEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "menu-scan-all-kits",
         }),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -109,7 +109,7 @@ class MenuEventForwarder {
   initialize(): void {
     this.eventMappings.forEach(({ domEvent, ipcEvent }) => {
       ipcRenderer.on(ipcEvent, () => {
-        window.dispatchEvent(new CustomEvent(domEvent));
+        globalThis.dispatchEvent(new CustomEvent(domEvent));
       });
     });
   }


### PR DESCRIPTION
## Summary
Burn-down of SonarCloud issue category [#241](https://github.com/peteb4ker/romper/issues/241) — **~200/203 `S7764`** (`globalThis` over `window`) across 49 files. No behavior change (in the renderer `globalThis === window`).

Breakdown of the 203: 152 `window.electronAPI`, 13 `addEventListener`, 13 `removeEventListener`, 9 bare `window` (`typeof` guards), 4 `location`, 3 `dispatchEvent`, 3 `matchMedia`, 2 `electronFileAPI`, 2 `history`, 1 each `confirm`/`AudioContext`.

### How the tricky cases were handled
- **`window.electronAPI` / `electronFileAPI` (154):** `globalThis.electronAPI` didn't typecheck because the `Window` interface augmentation doesn't reach `typeof globalThis` (TS7017). Added `var electronAPI` / `var electronFileAPI` global declarations in `electron.d.ts` (the preload bridges are genuinely globals — `contextBridge.exposeInMainWorld` puts them on the renderer global).
- **`typeof window !== "undefined"` guards (9):** safe — each pairs with a real property check (`&& globalThis.matchMedia` / `.electronAPI` / `.dispatchEvent` / `.romperEnv?.[]`), and `globalThis.<browserProp>` is `undefined` in non-browser envs, so gating is preserved.
- **Test harness (5 files):** several tests reassigned `global.window`/`globalThis.window` to a fresh object, which breaks the `globalThis === window` identity and left `globalThis.electronAPI` stale (also polluting later tests). Updated them to mutate `globalThis.electronAPI`/`dispatchEvent` directly.

### Deferred
`config.ts`'s 3 `(window as WindowWithRomperEnv)` casts — `window` is used as a `Window` object there; `typeof globalThis` isn't a `Window` subtype, so converting needs an ugly double-cast. Left as `window`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] Unit tests — 3524 passed
- [x] Integration tests — 529 passed
- [x] Pre-commit hook — passed

Closes #241