### PR TITLE
ci(release): enable workflow_dispatch for manual test runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Manual trigger reason (e.g. testing signing on a non-tag branch). The `release` job is gated to tag pushes only, so manual runs build artifacts but do not publish."
+        required: false
+        default: "manual test run"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,58 +107,78 @@ jobs:
             libasound2-dev \
             libgtk-3-0
 
-      # ── macOS: Import signing certificate into temporary keychain ──
-      - name: Import macOS signing certificate
-        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          # Create a temporary keychain
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import certificate from base64 secret
-          CERT_PATH="$RUNNER_TEMP/certificate.p12"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
-
-          security import "$CERT_PATH" \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -A \
-            -t cert \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-
-          # Set partition list to allow codesign access without UI prompt
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Add temporary keychain to search list (prepend so it's found first)
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-
-          # Extract identity name for Electron Forge
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "APPLE_IDENTITY=$IDENTITY" >> $GITHUB_ENV
-
-          echo "Certificate imported successfully. Identity: $IDENTITY"
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build application
         run: npm run build
 
-      - name: Package application (Electron)
+      # ── macOS: Package unsigned, sign with rcodesign, then make DMG/zip ──
+      # See electron/forge#3131: @electron/osx-sign was silently falling back
+      # to ad-hoc signing in CI. Replaced with indygreg/apple-code-sign-action
+      # (rcodesign), which signs without needing a keychain.
+      - name: Package Electron app (unsigned) — macOS
+        if: matrix.os == 'macos-latest'
+        run: npx electron-forge package -p darwin -a arm64
+
+      - name: Materialize signing inputs — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         env:
-          # macOS notarization credentials (only used when secrets are configured)
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # APPLE_IDENTITY is set by the certificate import step above
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          ASC_API_KEY_JSON: ${{ secrets.ASC_API_KEY_JSON }}
+        run: |
+          # Decode p12 from base64 secret
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          chmod 600 "$RUNNER_TEMP/cert.p12"
+          # Write ASC API key JSON (produced by `rcodesign encode-app-store-connect-api-key`)
+          printf '%s' "$ASC_API_KEY_JSON" > "$RUNNER_TEMP/asc-api-key.json"
+          chmod 600 "$RUNNER_TEMP/asc-api-key.json"
+
+      - name: Sign Romper.app — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: electron/out/Romper-darwin-arm64/Romper.app
+          p12_file: ${{ runner.temp }}/cert.p12
+          p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # --for-notarization enables hardened runtime + timestamp server +
+          # Developer ID cert validation in one flag.
+          sign_args: |
+            --for-notarization
+            --entitlements-xml-file
+            electron/resources/entitlements.plist
+
+      - name: Make installers (skip package) — macOS
+        if: matrix.os == 'macos-latest'
+        run: npx electron-forge make --skip-package -p darwin -a arm64
+
+      - name: Locate DMG artifact — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        id: dmg_path
+        run: |
+          DMG=$(find out/make -maxdepth 3 -name '*.dmg' -type f | head -1)
+          if [ -z "$DMG" ]; then
+            echo "::error::No DMG produced by Forge"
+            find out/make -type f
+            exit 1
+          fi
+          echo "path=$DMG" >> "$GITHUB_OUTPUT"
+          echo "Found DMG: $DMG"
+
+      - name: Sign + notarize + staple DMG — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: ${{ steps.dmg_path.outputs.path }}
+          p12_file: ${{ runner.temp }}/cert.p12
+          p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          notarize: true
+          staple: true
+          app_store_connect_api_key_json_file: ${{ runner.temp }}/asc-api-key.json
+
+      # ── Linux / Windows: Forge handles everything in one step ──
+      - name: Package application (Electron) — Linux/Windows
+        if: matrix.os != 'macos-latest'
         run: npm run make
 
       # ── Windows: Sign artifacts with Azure Trusted Signing ──
@@ -178,14 +198,12 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      # ── macOS: Clean up temporary keychain ──
-      - name: Clean up macOS keychain
-        if: always() && matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+      # ── macOS: Wipe signing inputs from the runner ──
+      - name: Clean up signing inputs — macOS
+        if: always() && matrix.os == 'macos-latest'
         run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-          if [ -f "$KEYCHAIN_PATH" ]; then
-            security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
-          fi
+          rm -P "$RUNNER_TEMP/cert.p12" 2>/dev/null || true
+          rm -P "$RUNNER_TEMP/asc-api-key.json" 2>/dev/null || true
 
       - name: Debug artifact structure (Windows)
         if: matrix.os == 'windows-latest'

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -1,13 +1,3 @@
-// Determine if macOS signing credentials are available
-const hasMacSigningCreds = !!(
-  process.env.APPLE_IDENTITY || process.env.APPLE_SIGNING_IDENTITY
-);
-const hasMacNotarizeCreds = !!(
-  process.env.APPLE_ID &&
-  process.env.APPLE_ID_PASSWORD &&
-  process.env.APPLE_TEAM_ID
-);
-
 const config = {
   packagerConfig: {
     name: "Romper",
@@ -47,33 +37,11 @@ const config = {
     extraResource: [
       // Include any additional resources needed at runtime
     ],
-    // macOS code signing -- enabled only when APPLE_IDENTITY env var is set
-    ...(hasMacSigningCreds
-      ? {
-          osxSign: {
-            identity:
-              process.env.APPLE_IDENTITY ||
-              process.env.APPLE_SIGNING_IDENTITY,
-            optionsForFile: () => ({
-              hardenedRuntime: true,
-              entitlements: "./electron/resources/entitlements.plist",
-              "entitlements-inherit":
-                "./electron/resources/entitlements.plist",
-              "signature-flags": "library",
-            }),
-          },
-        }
-      : {}),
-    // macOS notarization -- enabled only when Apple ID credentials are set
-    ...(hasMacNotarizeCreds
-      ? {
-          osxNotarize: {
-            appleId: process.env.APPLE_ID,
-            appleIdPassword: process.env.APPLE_ID_PASSWORD,
-            teamId: process.env.APPLE_TEAM_ID,
-          },
-        }
-      : {}),
+    // macOS signing + notarization are handled out-of-band by
+    // indygreg/apple-code-sign-action in .github/workflows/release.yml
+    // (rcodesign + ASC API key). Forge produces an unsigned .app; the
+    // workflow signs it, then runs the DMG/zip makers around it, then
+    // notarizes+staples the DMG.
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` to `release.yml`'s `on:` block (6-line change, no logic touched).
- The `release` job condition is unchanged — `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')` — so manual runs build artifacts but **do not publish**.

## Why

We need to test the macOS signing pipeline on the [release/v1.1.0-signing](https://github.com/peteb4ker/romper/tree/release/v1.1.0-signing) branch before merging it. Today the Release workflow is tag-only, which means each test attempt creates a public GitHub release. After this lands, we can `gh workflow run Release --ref release/v1.1.0-signing` to validate the build+sign+notarize flow without publishing anything.

## Test plan

- [ ] Merge to main
- [ ] Confirm Release shows up under `Actions → Release → Run workflow` UI (or via `gh workflow run Release`)
- [ ] Trigger on `release/v1.1.0-signing` and confirm the build matrix runs; `release` job is skipped (not failed)