### PR TITLE
fix(ci): correct macOS .app path for rcodesign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         uses: indygreg/apple-code-sign-action@v1
         with:
-          input_path: electron/out/Romper-darwin-arm64/Romper.app
+          input_path: out/Romper-darwin-arm64/Romper.app
           p12_file: ${{ runner.temp }}/cert.p12
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           # --for-notarization enables hardened runtime + timestamp server +

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -5,7 +5,6 @@ const config = {
     appBundleId: "com.romper.samplemanager",
     appCategoryType: "public.app-category.music",
     icon: "./electron/resources/app-icon", // Don't include extension, Forge handles it
-    out: "./electron/out",
     ignore: [
       // Ignore source files and dev dependencies
       "^/src",


### PR DESCRIPTION
## Summary

The first dispatch test of the new rcodesign signing pipeline ([run 26798083005](https://github.com/peteb4ker/romper/actions/runs/26798083005)) failed at the sign step. Two bugs were found:

1. **Forge silently ignores `packagerConfig.out`** — despite `out: "./electron/out"` in [forge.config.cjs](forge.config.cjs), `electron-forge package` writes to its own default `./out/` instead. Reproduced locally.
2. **rcodesign's "not of a recognized type" error is misleading for missing paths** — when given a path that doesn't exist, it prints `signing X in place` then errors with `specified path is not of a recognized type` (rather than "no such file"). Verified locally.

## Changes

- `.github/workflows/release.yml`: point `input_path` at the actual Forge output (`out/Romper-darwin-arm64/Romper.app`).
- `forge.config.cjs`: drop the dead `out: "./electron/out"` config so there's one source of truth.

## Test plan

- [x] Reproduce Forge package locally and confirm `.app` is at `out/Romper-darwin-arm64/Romper.app`
- [x] Run `rcodesign sign out/Romper-darwin-arm64/Romper.app` locally and confirm it recursively signs nested Mach-Os
- [ ] After merge: dispatch Release workflow on main → confirm sign + notarize + staple succeed