### PR TITLE
fix(ci): manual notarize step with extended timeout (30 min)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,16 +171,44 @@ jobs:
           echo "path=$DMG" >> "$GITHUB_OUTPUT"
           echo "Found DMG: $DMG"
 
-      - name: Sign + notarize + staple DMG — macOS
+      - name: Sign DMG — macOS
         if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: ${{ steps.dmg_path.outputs.path }}
           p12_file: ${{ runner.temp }}/cert.p12
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          notarize: true
-          staple: true
-          app_store_connect_api_key_json_file: ${{ runner.temp }}/asc-api-key.json
+
+      # ── Notarize + staple manually so we control the Apple poll timeout.
+      # The action hardcodes --max-wait-seconds 600 (10 min); Apple's notary
+      # service has been taking 12+ min lately (Romper.dmg submission
+      # 8b66b65c-3708-41dd-bf4a-908d4cbee272 was still InProgress after the
+      # action gave up). Bumped to 30 min here.
+      - name: Install rcodesign for notarization
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        run: |
+          set -euo pipefail
+          VERSION="0.29.0"
+          ASSET="apple-codesign-${VERSION}-macos-universal.tar.gz"
+          EXPECTED_SHA="d98372d5524226ccf9dc0eda03d4e4f5826182dabb2fc3f2bd303ed9113a748d"
+          curl -fsSL -o "$RUNNER_TEMP/$ASSET" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${VERSION}/${ASSET}"
+          ACTUAL_SHA=$(shasum -a 256 "$RUNNER_TEMP/$ASSET" | awk '{print $1}')
+          if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+            echo "::error::rcodesign tarball SHA mismatch (expected $EXPECTED_SHA, got $ACTUAL_SHA)"
+            exit 1
+          fi
+          tar -xzf "$RUNNER_TEMP/$ASSET" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/apple-codesign-${VERSION}-macos-universal" >> "$GITHUB_PATH"
+
+      - name: Notarize + staple DMG — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        run: |
+          rcodesign notary-submit \
+            --staple \
+            --max-wait-seconds 1800 \
+            --api-key-file "$RUNNER_TEMP/asc-api-key.json" \
+            "${{ steps.dmg_path.outputs.path }}"
 
       # ── Linux / Windows: Forge handles everything in one step ──
       - name: Package application (Electron) — Linux/Windows


### PR DESCRIPTION
## Summary

The dispatch test on main after [#257](https://github.com/peteb4ker/romper/pull/257) ([run 26798487001](https://github.com/peteb4ker/romper/actions/runs/26798487001)) reached the notarize step before failing:

\`\`\`
poll state after 600s: InProgress
reached wait limit after 600s
Error: reached time limit waiting for notarization to complete
\`\`\`

Verified via \`rcodesign notary-list\` that submission \`8b66b65c-3708-41dd-bf4a-908d4cbee272\` is still **in progress** on Apple's side — not a failure, just a slow queue.

The action hardcodes \`--max-wait-seconds 600\` and has no input to override it; rcodesign's TOML config has no notary section.

## Changes

Split the previous "Sign + notarize + staple DMG" action call into:
- **Sign DMG** — still uses the action (sign only)
- **Install rcodesign for notarization** — pin 0.29.0, verify SHA-256
- **Notarize + staple DMG** — manual \`rcodesign notary-submit --max-wait-seconds 1800\` (30 min)

The action remains the source of rcodesign for sign operations (works fine); the manual step only handles notarization where we need timeout control.

## Test plan

- [x] YAML parses
- [x] Step list looks right (13 build steps for macOS, vs 11 before — adds Install rcodesign + splits notarize from sign)
- [ ] After merge: dispatch Release workflow on main → confirm full sign + make + sign DMG + notarize + staple succeeds