### PR TITLE
fix(ci): notarize+staple .app so the zip is offline-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,42 @@ jobs:
             --entitlements-xml-file
             electron/resources/entitlements.plist
 
+      # ── Install rcodesign for the manual notarize+staple steps below.
+      # The action hardcodes --max-wait-seconds 600 (10 min); Apple's notary
+      # service occasionally exceeds that (sub 8b66b65c-3708-41dd-bf4a-…
+      # took ~16h during a 2026-06-02 outage). Bumped to 30 min here.
+      - name: Install rcodesign for notarization
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        run: |
+          set -euo pipefail
+          VERSION="0.29.0"
+          ASSET="apple-codesign-${VERSION}-macos-universal.tar.gz"
+          EXPECTED_SHA="d98372d5524226ccf9dc0eda03d4e4f5826182dabb2fc3f2bd303ed9113a748d"
+          curl -fsSL -o "$RUNNER_TEMP/$ASSET" \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${VERSION}/${ASSET}"
+          ACTUAL_SHA=$(shasum -a 256 "$RUNNER_TEMP/$ASSET" | awk '{print $1}')
+          if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+            echo "::error::rcodesign tarball SHA mismatch (expected $EXPECTED_SHA, got $ACTUAL_SHA)"
+            exit 1
+          fi
+          tar -xzf "$RUNNER_TEMP/$ASSET" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/apple-codesign-${VERSION}-macos-universal" >> "$GITHUB_PATH"
+
+      # ── Notarize + staple the .app BEFORE Forge wraps it.
+      # This makes the .app self-contained: the ticket is embedded inside
+      # the bundle, so any container we put it in (DMG, zip, future tar)
+      # is Gatekeeper-clean offline. Without this step, the zip artifact
+      # carries a signed-but-not-stapled .app and offline macOS shows the
+      # "cannot verify developer" warning until first online launch.
+      - name: Notarize + staple Romper.app — macOS
+        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        run: |
+          rcodesign notary-submit \
+            --staple \
+            --max-wait-seconds 1800 \
+            --api-key-file "$RUNNER_TEMP/asc-api-key.json" \
+            out/Romper-darwin-arm64/Romper.app
+
       - name: Make installers (skip package) — macOS
         if: matrix.os == 'macos-latest'
         run: npx electron-forge make --skip-package -p darwin -a arm64
@@ -179,28 +215,9 @@ jobs:
           p12_file: ${{ runner.temp }}/cert.p12
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
-      # ── Notarize + staple manually so we control the Apple poll timeout.
-      # The action hardcodes --max-wait-seconds 600 (10 min); Apple's notary
-      # service has been taking 12+ min lately (Romper.dmg submission
-      # 8b66b65c-3708-41dd-bf4a-908d4cbee272 was still InProgress after the
-      # action gave up). Bumped to 30 min here.
-      - name: Install rcodesign for notarization
-        if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
-        run: |
-          set -euo pipefail
-          VERSION="0.29.0"
-          ASSET="apple-codesign-${VERSION}-macos-universal.tar.gz"
-          EXPECTED_SHA="d98372d5524226ccf9dc0eda03d4e4f5826182dabb2fc3f2bd303ed9113a748d"
-          curl -fsSL -o "$RUNNER_TEMP/$ASSET" \
-            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${VERSION}/${ASSET}"
-          ACTUAL_SHA=$(shasum -a 256 "$RUNNER_TEMP/$ASSET" | awk '{print $1}')
-          if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
-            echo "::error::rcodesign tarball SHA mismatch (expected $EXPECTED_SHA, got $ACTUAL_SHA)"
-            exit 1
-          fi
-          tar -xzf "$RUNNER_TEMP/$ASSET" -C "$RUNNER_TEMP"
-          echo "$RUNNER_TEMP/apple-codesign-${VERSION}-macos-universal" >> "$GITHUB_PATH"
-
+      # Notarize + staple the DMG too so the DMG itself (not just the .app
+      # inside) carries a ticket — needed for offline Gatekeeper checks
+      # during DMG mount.
       - name: Notarize + staple DMG — macOS
         if: matrix.os == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         run: |


### PR DESCRIPTION
## Summary

[v1.1.0](https://github.com/peteb4ker/romper/releases/tag/v1.1.0) ships a fully signed/notarized/stapled DMG — perfect for users who go through the DMG. The accompanying \`Romper-darwin-arm64-1.1.0.zip\` contains a signed \`.app\` but the \`.app\` itself isn't stapled. Offline macOS shows the "cannot verify developer" warning until first online launch.

## Fix

Move the notarize+staple to **before** \`electron-forge make\`, applied directly to the \`.app\`. Forge then wraps a stapled \`.app\` into both the DMG and the zip. The DMG itself is still separately notarized+stapled so it's also clean on offline DMG mount.

## Change

\`\`\`
Before:                       After:
  sign .app                     sign .app
  make → DMG + zip              install rcodesign
  sign DMG                      notarize + staple .app    ← NEW
  install rcodesign             make → DMG + zip (wraps stapled .app)
  notarize + staple DMG         locate DMG
                                sign DMG
                                notarize + staple DMG
\`\`\`

Adds one extra Apple round-trip per macOS build (~2.5 min when their queue is healthy).

## Test plan

- [x] YAML parses, step order correct
- [ ] After merge: dispatch on main → confirm both notarize submissions succeed
- [ ] Verify zip artifact's .app shows a stapled ticket: \`xcrun stapler validate Romper.app\`