### PR TITLE
fix(menu): macOS About opens custom AboutDialog (#263)

### DIFF
--- a/electron/main/__tests__/applicationMenu.integration.test.ts
+++ b/electron/main/__tests__/applicationMenu.integration.test.ts
@@ -43,8 +43,10 @@ const mockNativeImage = {
 vi.mock("electron", () => ({
   app: {
     getName: vi.fn().mockReturnValue("Romper"),
+    getVersion: vi.fn().mockReturnValue("1.1.0"),
     isPackaged: false,
     quit: vi.fn(),
+    setAboutPanelOptions: vi.fn(),
   },
   BrowserWindow: mockBrowserWindow,
   ipcMain: mockIpcMain,
@@ -244,6 +246,52 @@ describe("Menu IPC Integration Tests", () => {
     expect(viewRoles).toContain("reload");
     expect(viewRoles).toContain("forceReload");
     expect(viewRoles).toContain("toggleDevTools");
+  });
+
+  it("should route the macOS app-menu About entry to the custom AboutDialog IPC", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const mockWindow = {
+      webContents: {
+        send: vi.fn(),
+      },
+    };
+    mockBrowserWindow.getFocusedWindow.mockReturnValue(mockWindow);
+
+    try {
+      const { createApplicationMenu } = await import("../applicationMenu");
+
+      createApplicationMenu();
+
+      const menuTemplate = mockMenu.buildFromTemplate.mock.calls[0][0];
+      const appMenu = menuTemplate.find(
+        (item: unknown) => item.label === "Romper",
+      );
+      expect(appMenu).toBeDefined();
+
+      const aboutItem = appMenu.submenu.find(
+        (item: unknown) => item.label === "About Romper",
+      );
+      expect(aboutItem).toBeDefined();
+      // It must be a click handler, not the generic native { role: "about" }
+      expect(aboutItem.role).toBeUndefined();
+      expect(aboutItem.click).toBeDefined();
+
+      aboutItem.click();
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith("menu-about");
+
+      // No duplicate About entry should leak into the Help menu on macOS
+      const helpMenu = menuTemplate.find(
+        (item: unknown) => item.label === "Help",
+      );
+      const helpAbout = helpMenu.submenu.find(
+        (item: unknown) => item.label === "About Romper",
+      );
+      expect(helpAbout).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
   });
 
   it("should handle missing browser windows gracefully", async () => {

--- a/electron/main/applicationMenu.ts
+++ b/electron/main/applicationMenu.ts
@@ -9,6 +9,15 @@ const isDev = !app.isPackaged;
  * Creates and sets the application menu with streamlined structure
  */
 export function createApplicationMenu() {
+  // Brand the native About panel in case any other code path triggers it
+  // directly; the menu entry below routes to the custom AboutDialog instead.
+  if (process.platform === "darwin") {
+    app.setAboutPanelOptions({
+      applicationName: app.getName(),
+      applicationVersion: app.getVersion(),
+    });
+  }
+
   const template: Electron.MenuItemConstructorOptions[] = [
     // Application menu (macOS only)
     ...(process.platform === "darwin"
@@ -16,7 +25,15 @@ export function createApplicationMenu() {
           {
             label: app.getName(),
             submenu: [
-              { role: "about" as const },
+              {
+                click: () => {
+                  const focusedWindow = BrowserWindow.getFocusedWindow();
+                  if (focusedWindow) {
+                    focusedWindow.webContents.send("menu-about");
+                  }
+                },
+                label: `About ${app.getName()}`,
+              },
               { type: "separator" as const },
               {
                 accelerator: "Cmd+,",


### PR DESCRIPTION
## Summary
Fixes #263 — on macOS, **Romper → About Romper** used Electron's native `role: "about"`, rendering a tiny generic system dialog. Linux/Windows already send a `menu-about` IPC event that triggers the custom animated `AboutDialog`. macOS now routes through the same handler so all platforms show the custom dialog.

Also calls `app.setAboutPanelOptions({...})` on macOS so any other code path that hits the native panel shows real Romper name/version instead of the Electron default.

## Changes
- `electron/main/applicationMenu.ts` — replace macOS `{ role: "about" }` with the `menu-about` IPC click handler; add `setAboutPanelOptions` branding for macOS.
- `electron/main/__tests__/applicationMenu.integration.test.ts` — extend the mocked `app`; add a regression test that stubs `process.platform = "darwin"` and asserts the About entry dispatches `menu-about`, is a click handler (not `role: "about"`), and doesn't duplicate into the Help menu.

## Acceptance
- [x] macOS **Romper → About Romper** opens the custom animated `AboutDialog`
- [x] Linux/Windows behavior unchanged (Help → About Romper still works)
- [x] In-window LED icon About trigger still works (same `menu-about` channel)
- [x] No duplicate About entries in the macOS Help menu

## Verification
- `tsc --noEmit`: clean
- ESLint on changed files: clean
- Integration tests: 8/8 in the menu suite, 530/530 full suite (pre-commit)

Closes #263