### PR TITLE
fix(ci): apply per-helper entitlements via rcodesign config (closes #260)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,10 +149,16 @@ jobs:
           p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           # --for-notarization enables hardened runtime + timestamp server +
           # Developer ID cert validation in one flag.
+          #
+          # --config-file points at electron/resources/rcodesign.toml, which
+          # declares per-helper entitlement scopes. v1.1.0 shipped with the
+          # top-level binary entitled but the Chromium helpers (Renderer/GPU/
+          # Plugin) unentitled, breaking V8 under hardened runtime and causing
+          # a renderer white-screen. See #260.
           sign_args: |
             --for-notarization
-            --entitlements-xml-file
-            electron/resources/entitlements.plist
+            --config-file
+            electron/resources/rcodesign.toml
 
       # ── Install rcodesign for the manual notarize+staple steps below.
       # The action hardcodes --max-wait-seconds 600 (10 min); Apple's notary

--- a/electron/resources/rcodesign.toml
+++ b/electron/resources/rcodesign.toml
@@ -1,0 +1,33 @@
+# rcodesign signing configuration for Romper.app
+#
+# Background: v1.1.0 shipped with hardened runtime applied to all binaries
+# (recursive default of `rcodesign sign --for-notarization`) but entitlements
+# applied ONLY to the top-level `Contents/MacOS/romper` binary. The Chromium
+# helpers (Renderer, GPU, Plugin) inherited hardened runtime but had NO
+# entitlements, so V8 couldn't JIT JavaScript -> renderer silently failed ->
+# white-screen on launch. See https://github.com/peteb4ker/romper/issues/260.
+#
+# `@electron/osx-sign` (the signer we migrated away from) applied per-helper
+# entitlements automatically because it knew the Electron bundle layout.
+# `rcodesign` doesn't, so we declare those scopes explicitly here.
+#
+# All four helpers use the same plist as the top-level binary: the three
+# entitlements it carries (allow-jit, allow-unsigned-executable-memory,
+# disable-library-validation) are exactly what each Chromium helper process
+# needs under hardened runtime. Splitting into per-helper plists would be
+# marginally tighter but offers no practical security gain for this app.
+
+[default.sign]
+entitlements_xml_file = "electron/resources/entitlements.plist"
+
+[default.sign.path."Contents/Frameworks/Romper Helper.app"]
+entitlements_xml_file = "electron/resources/entitlements.plist"
+
+[default.sign.path."Contents/Frameworks/Romper Helper (GPU).app"]
+entitlements_xml_file = "electron/resources/entitlements.plist"
+
+[default.sign.path."Contents/Frameworks/Romper Helper (Plugin).app"]
+entitlements_xml_file = "electron/resources/entitlements.plist"
+
+[default.sign.path."Contents/Frameworks/Romper Helper (Renderer).app"]
+entitlements_xml_file = "electron/resources/entitlements.plist"


### PR DESCRIPTION
## Summary
- Fixes the v1.1.0 white-screen on launch ([#260](https://github.com/peteb4ker/romper/issues/260)) by giving every Chromium helper inside `Romper.app` the JIT/unsigned-exec-memory entitlements it needs under hardened runtime.
- Adds `electron/resources/rcodesign.toml` declaring `[default.sign.path."Contents/Frameworks/Romper Helper(*).app"]` scopes that all reuse the existing `entitlements.plist`.
- Switches the release workflow's `rcodesign sign` step from inline `--entitlements-xml-file` to `--config-file electron/resources/rcodesign.toml` so the per-helper scopes are picked up.

## Why
`v1.1.0` installed bundle had hardened runtime on every binary but entitlements only on `Contents/MacOS/romper`. `codesign -d --entitlements -` on `Romper Helper (Renderer).app` returned empty, so V8 silently failed to JIT the renderer JS bundle → white window. `@electron/osx-sign` (the signer we migrated away from) applied per-helper entitlements implicitly; rcodesign requires explicit scopes. Full root-cause trace in [#260](https://github.com/peteb4ker/romper/issues/260#issuecomment-4613682691).

## Test plan
Signing requires the real Developer ID cert (CI only), so end-to-end validation has to happen on a release-workflow run:

- [ ] Trigger the **Release** workflow manually via `workflow_dispatch` on this branch
- [ ] Download the resulting macOS DMG artifact
- [ ] Mount it and run:
  ```
  codesign -d --entitlements - "/Volumes/Romper*/Romper.app/Contents/Frameworks/Romper Helper (Renderer).app"
  ```
  Expect the three entitlements (`com.apple.security.cs.allow-jit`, `…allow-unsigned-executable-memory`, `…disable-library-validation`) instead of empty output
- [ ] Install the DMG and launch Romper — confirm the kit browser renders (no white screen)
- [ ] Confirm `codesign --verify --deep --strict` still passes
- [ ] Confirm the notarize+staple step still succeeds for both .app and DMG
- [ ] Confirm the zip artifact's bundled .app is still Gatekeeper-clean offline (preserves the zip-safety work from b73d31d)

Local pre-commit checks all green: 3524 unit + 529 integration tests, typecheck, lint, full build.

## Out of scope
- Splitting helper entitlements into separate plists — same shared plist works for all four helpers (all need the same three grants) and Splitting them offers no practical security gain for this app.
- DevTools-in-prod ([#262](https://github.com/peteb4ker/romper/issues/262)) — the diagnostic gap that made #260 hard to triage; tracked separately.