### PR TITLE
feat(devtools): expose DevTools in packaged builds via ROMPER_ENABLE_DEVTOOLS (closes #262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Romper can be configured using environment variables for advanced use cases:
 - **`ROMPER_SDCARD_PATH`** - Default SD card directory path
 - **`ROMPER_LOCAL_PATH`** - Default local sample library path  
 - **`ROMPER_SQUARP_ARCHIVE_URL`** - Custom factory samples archive URL
+- **`ROMPER_ENABLE_DEVTOOLS`** - Set to `1` to expose Reload / Toggle Developer Tools in the View menu of a packaged build (off by default; intended for diagnosing issues in installed releases)
 
 ## 🛠️ Development
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,6 +99,32 @@ If Romper reports that your local store is invalid or corrupted:
 - **Check disk health** -- Corrupted stores can indicate disk issues. Run your operating system's disk checking utility.
 - **Backup consideration** -- The local store is a working copy. Your definitive data lives on your SD card and in your original sample files. Losing the local store means rebuilding your kit configurations, but no samples are lost.
 
+---
+
+## Inspecting Romper with Developer Tools
+
+If something is misbehaving and you want to capture diagnostic output for a bug report -- or you simply want to inspect the running app -- you can enable the Chromium Developer Tools in an installed build by launching Romper with the `ROMPER_ENABLE_DEVTOOLS` environment variable set to `1`. By default this is off, so installed releases do not expose **Reload** / **Force Reload** / **Toggle Developer Tools** in the View menu.
+
+**macOS** (terminal):
+
+```sh
+ROMPER_ENABLE_DEVTOOLS=1 open -a Romper
+```
+
+**Linux** (terminal):
+
+```sh
+ROMPER_ENABLE_DEVTOOLS=1 romper
+```
+
+**Windows** (PowerShell):
+
+```powershell
+$env:ROMPER_ENABLE_DEVTOOLS = "1"; & "$env:LOCALAPPDATA\Programs\Romper\Romper.exe"
+```
+
+Once the app is running with the variable set, the View menu gains a separator followed by the standard DevTools entries. The default shortcut is `Cmd+Option+I` on macOS and `Ctrl+Shift+I` on Windows / Linux. Use the **Console** tab for renderer errors and the **Network** tab to see whether assets failed to load.
+
 </div>
 </div>
 </section>

--- a/electron/main/__tests__/applicationMenu.integration.test.ts
+++ b/electron/main/__tests__/applicationMenu.integration.test.ts
@@ -294,6 +294,63 @@ describe("Menu IPC Integration Tests", () => {
     }
   });
 
+  it("should omit dev tools from View menu when packaged and ROMPER_ENABLE_DEVTOOLS is unset", async () => {
+    vi.resetModules();
+    const electron = await import("electron");
+    // @ts-expect-error -- mock object, writable in test
+    electron.app.isPackaged = true;
+    delete process.env.ROMPER_ENABLE_DEVTOOLS;
+
+    try {
+      const { createApplicationMenu } = await import("../applicationMenu");
+      createApplicationMenu();
+
+      const menuTemplate = mockMenu.buildFromTemplate.mock.calls.at(-1)?.[0];
+      const viewMenu = menuTemplate.find(
+        (item: unknown) => item.label === "View",
+      );
+      const viewRoles = viewMenu.submenu
+        .filter((item: unknown) => item.role)
+        .map((item: unknown) => item.role);
+
+      expect(viewRoles).not.toContain("reload");
+      expect(viewRoles).not.toContain("forceReload");
+      expect(viewRoles).not.toContain("toggleDevTools");
+    } finally {
+      // @ts-expect-error -- restore mock state
+      electron.app.isPackaged = false;
+    }
+  });
+
+  it("should include dev tools in View menu when packaged but ROMPER_ENABLE_DEVTOOLS=1", async () => {
+    vi.resetModules();
+    const electron = await import("electron");
+    // @ts-expect-error -- mock object, writable in test
+    electron.app.isPackaged = true;
+    process.env.ROMPER_ENABLE_DEVTOOLS = "1";
+
+    try {
+      const { createApplicationMenu } = await import("../applicationMenu");
+      createApplicationMenu();
+
+      const menuTemplate = mockMenu.buildFromTemplate.mock.calls.at(-1)?.[0];
+      const viewMenu = menuTemplate.find(
+        (item: unknown) => item.label === "View",
+      );
+      const viewRoles = viewMenu.submenu
+        .filter((item: unknown) => item.role)
+        .map((item: unknown) => item.role);
+
+      expect(viewRoles).toContain("reload");
+      expect(viewRoles).toContain("forceReload");
+      expect(viewRoles).toContain("toggleDevTools");
+    } finally {
+      // @ts-expect-error -- restore mock state
+      electron.app.isPackaged = false;
+      delete process.env.ROMPER_ENABLE_DEVTOOLS;
+    }
+  });
+
   it("should handle missing browser windows gracefully", async () => {
     mockBrowserWindow.getAllWindows.mockReturnValue([]);
 

--- a/electron/main/applicationMenu.ts
+++ b/electron/main/applicationMenu.ts
@@ -4,6 +4,10 @@ import { menuIcons } from "./menuIcons";
 import { logger } from "./utils/logger.js";
 
 const isDev = !app.isPackaged;
+// Power-user escape hatch for inspecting a packaged build. Set
+// ROMPER_ENABLE_DEVTOOLS=1 in the launch env to expose View → Reload /
+// Force Reload / Toggle DevTools in production. See issue #262.
+const allowDevTools = isDev || process.env.ROMPER_ENABLE_DEVTOOLS === "1";
 
 /**
  * Creates and sets the application menu with streamlined structure
@@ -131,7 +135,7 @@ export function createApplicationMenu() {
         { role: "zoomOut" as const },
         { type: "separator" as const },
         { role: "togglefullscreen" as const },
-        ...(isDev
+        ...(allowDevTools
           ? [
               { type: "separator" as const },
               { role: "reload" as const },


### PR DESCRIPTION
## Summary
- Adds an env-var opt-in (`ROMPER_ENABLE_DEVTOOLS=1`) so installed Romper builds can be launched with the View → Reload / Force Reload / Toggle Developer Tools entries enabled. Default UX is unchanged — end users still see a tidy View menu in a packaged release.
- Closes the diagnostic gap that made [#260](https://github.com/peteb4ker/romper/issues/260) hard to triage in the field: once a reporter can open the renderer console we can read silent failures without spinning up a local `file://` build.
- Documents the new knob in `README.md` (Configuration section) and adds a per-OS "Inspecting Romper with Developer Tools" section to `docs/troubleshooting.md`.

## Implementation
[`electron/main/applicationMenu.ts`](https://github.com/peteb4ker/romper/blob/main/electron/main/applicationMenu.ts):
```ts
const isDev = !app.isPackaged;
const allowDevTools = isDev || process.env.ROMPER_ENABLE_DEVTOOLS === "1";
```
The View menu now toggles on `allowDevTools` instead of `isDev`. No other gating changed — preload, IPC handlers, and CSP are unaffected, so the production attack surface only grows when the user explicitly opts in.

## Test plan
- [x] `applicationMenu.integration.test.ts` — two new cases added:
  - `packaged + no env var` → no `reload` / `forceReload` / `toggleDevTools` roles in the View menu
  - `packaged + ROMPER_ENABLE_DEVTOOLS=1` → those three roles are present
  - Original `unpackaged` case unchanged
- [x] Local pre-commit suite green: typecheck, lint, build, 3526 unit + 531 integration tests
- [ ] Manual verification on a packaged build (post-merge, next release):
  ```sh
  ROMPER_ENABLE_DEVTOOLS=1 open -a Romper
  ```
  View menu shows DevTools entries; Cmd+Option+I toggles them.

## Docs
- `README.md` — appended `ROMPER_ENABLE_DEVTOOLS` to the existing `ROMPER_*` env var list with a one-line description.
- `docs/troubleshooting.md` — new section "Inspecting Romper with Developer Tools" with macOS / Linux / Windows launch commands. Linked from the existing troubleshooting index in `docs/index.html`.

## Out of scope
- Native About dialog fix ([#263](https://github.com/peteb4ker/romper/issues/263)) — tracked separately.
- DMG installer background ([#261](https://github.com/peteb4ker/romper/issues/261)) — tracked separately.