### PR TITLE
chore(sonar): readonly props + a11y role for GainKnob (refs #246)

### DIFF
--- a/app/renderer/components/GainKnob.tsx
+++ b/app/renderer/components/GainKnob.tsx
@@ -157,6 +157,7 @@ const GainKnob: React.FC<GainKnobProps> = ({ disabled, onChange, value }) => {
       className="relative flex items-center"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      role="presentation"
       style={{ zIndex: active ? 10 : undefined }}
     >
       <svg

--- a/app/renderer/components/KitBrowserContainer.tsx
+++ b/app/renderer/components/KitBrowserContainer.tsx
@@ -6,7 +6,7 @@ import type { KitBrowserHandle } from "./KitBrowser";
 
 import KitBrowser from "./KitBrowser";
 
-interface KitBrowserContainerProps {
+type KitBrowserContainerProps = Readonly<{
   // Favorites filter functionality
   favoritesCount?: number;
   getKitFavoriteState?: (kitName: string) => boolean;
@@ -32,7 +32,7 @@ interface KitBrowserContainerProps {
   setLocalStorePath: (path: string) => void;
   showFavoritesOnly?: boolean;
   showModifiedOnly?: boolean;
-}
+}>;
 
 /**
  * Container component for KitBrowser


### PR DESCRIPTION
## Summary
Picks up the two **real** findings from issue [#246](https://github.com/peteb4ker/romper/issues/246) (15 React-component Sonar smells). The other 13 are either false positives or already-deferred dead-prop threads — detailed below.

## Real fixes (2)
- **S6759 — readonly props on `KitBrowserContainer`** ([KitBrowserContainer.tsx](app/renderer/components/KitBrowserContainer.tsx)): converted `interface KitBrowserContainerProps { ... }` to `type KitBrowserContainerProps = Readonly<{ ... }>`. Pure type-level change, no runtime effect.
- **S6848 — non-native interactive element on `GainKnob`** ([GainKnob.tsx](app/renderer/components/GainKnob.tsx)): wrapper `<div>` carried `onMouseEnter`/`onMouseLeave` (hover label) but no role. Added `role="presentation"` so screen readers treat the inner `<svg role="slider">` as the canonical interactive element. Mouse handlers stay on the wrapper because the floating dB label is a sibling of the svg and we want hover to survive crossing onto the label.

## Findings left untouched (13)
Categorized after hand-verifying each:

### False positives — props/state/keys ARE used (10)
Sonar's TypeScript analyzer mis-classifies these. They need to be marked **False Positive** in the SonarCloud UI, not patched in code.

| Rule | File | Notes |
| --- | --- | --- |
| S6767 (×4) | KitGridItem.tsx | `isNew`, `onDeleteKit`, `onDuplicateKit`, `onRequestDeleteSummary` all destructured at lines 199–217 and referenced 3–6 times each in the body. |
| S6767 (×1) | KitVoicePanel.tsx | All declared props are destructured; the one apparent unused field is the dead-prop case below, not this one. |
| S6767 (×1) | WizardPostInitGuidance.tsx | `isBlankFolder`, `onDismiss`, `truncationWarnings` all destructured at line 12 and used at lines 13/30/40/58. |
| S6754 (×4) | useBpm.ts, useTriggerConditions.ts, useStepPattern.ts, SampleWaveform.tsx | Every `useState` call already uses the `[value, setter]` destructuring pattern. No `useState()[0]` / `useState()[1]` anywhere. |
| S6479 (×1) | SampleWaveform.tsx | Both maps use stable keys (\`voice-\${voiceNumber}\` and \`\${filename}\`); no array index used as key. |

### Deferred dead-prop threads (3)
Carried forward from #246's prior burn-down (PR [#250](https://github.com/peteb4ker/romper/pull/250)). Each is a real dead prop, but removal cascades up the component tree and was scoped out previously:

| Prop | Origin → Dead destination | Why deferred |
| --- | --- | --- |
| `onShowLocalStoreWizard` | KitBrowser → KitBrowserHeader | Removing the leaf prop requires also removing the `onShowLocalStoreWizard={handleShowLocalStoreWizard}` forward in KitBrowser:227 and the test mock. Contained but still 3 sites + behavior verification. |
| `searchResultCount` | useKitSearch → KitsView → KitBrowserContainer → KitBrowserHeader | The whole thread is dead (the value is computed but never displayed). Removal touches 4 files plus the hook test suite. Bigger refactor than this PR's scope. |
| `onSampleKeyNav` | KitEditor → KitVoicePanels → KitVoicePanel | The destructure inside KitVoicePanel is commented out with a note that says "Keyboard navigation now handled by parent component". The prop should be removed from KitVoicePanel's interface and from KitVoicePanels' forward, but the KitEditor → KitVoicePanels handoff still does real work via `logic.kitVoicePanels.onSampleKeyNav`. |

Each warrants its own PR if/when we decide to chase the threads. Filing as follow-up issue would be sensible — flag if you want me to do so.

## Test plan
- [x] Local pre-commit suite green (typecheck, lint, build, 3526 unit + 529 integration tests). Type change is a strict tightening (`Readonly<>` rejects mutations); confirmed no caller mutates the props object.
- [ ] CI green on this PR
- [ ] Manual visual check: GainKnob hover label still appears/disappears as before (the mouse handlers haven't moved)
- [ ] SonarCloud next run shows 2 fewer findings on `peteb4ker_romper` (S6759, S6848)

## Out of scope
- Marking the 10 confirmed false positives in the SonarCloud UI — requires UI access I don't have. Recommended next manual step.
- The 3 deferred dead-prop threads — separate per-thread PRs.

Refs #246.