### PR TITLE
bump: version 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/electron/main/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump version to **v1.2.0** ahead of cutting the release. Minor bump per semver: two `feat:` commits have landed since `v1.1.0` (no breaking changes).

### Notable changes since v1.1.0
- ✨ `feat(devtools)`: expose DevTools in packaged builds via `ROMPER_ENABLE_DEVTOOLS` (closes #262)
- ✨ `feat(dmg)`: add branded background to installer DMG
- 🐛 `fix(menu)`: macOS About opens custom AboutDialog (#263)
- 🐛 `fix(ci)`: apply per-helper entitlements via rcodesign config (fixes #260)
- 🔧 chores: vitest 4 migration (#255), Sonar cleanup (#246), Node-24 CI runtime (#236)

## Release plan

Once this merges, `v1.2.0` will be tagged on `main`, which triggers the cross-platform build + auto-generated release notes via `.github/workflows/release.yml`.