### PR TITLE
fix(ci): scope main executable entitlements as a path in rcodesign.toml

### DIFF
--- a/electron/resources/rcodesign.toml
+++ b/electron/resources/rcodesign.toml
@@ -17,7 +17,11 @@
 # needs under hardened runtime. Splitting into per-helper plists would be
 # marginally tighter but offers no practical security gain for this app.
 
-[default.sign]
+# `entitlements_xml_file` is only valid under a per-path scope, not directly
+# under `[default.sign]`. The main executable (`executableName: "romper"` in
+# forge.config.cjs) is therefore declared as its own path scope, exactly like
+# the four Chromium helpers below.
+[default.sign.path."Contents/MacOS/romper"]
 entitlements_xml_file = "electron/resources/entitlements.plist"
 
 [default.sign.path."Contents/Frameworks/Romper Helper.app"]


### PR DESCRIPTION
## Problem

The **v1.2.0 release build failed on macOS signing** (Linux + Windows passed), which skipped the `release` job — so nothing was published. See [run 26901949348](https://github.com/peteb4ker/romper/actions/runs/26901949348).

```
configuration file error
  source path: electron/resources/rcodesign.toml
  problem key: sign, entitlements_xml_file
  problem: UnknownField("entitlements_xml_file", ["signer", "path"])
```

## Root cause

`rcodesign.toml` set `entitlements_xml_file` directly under `[default.sign]`, but per the [rcodesign config docs](https://gregoryszorc.com/docs/apple-codesign/0.28.0/apple_codesign_rcodesign_config_files.html) that field is **only valid under a per-path scope** (`[default.sign.path."..."]`). The only keys allowed directly under `[default.sign]` are `signer` and `path`.

This config was introduced after v1.1.0 (in the `fix(ci) #260` per-helper-entitlements commit) and had never been exercised by a release until v1.2.0.

## Fix

Declare the main executable (`Contents/MacOS/romper`, per `executableName` in `forge.config.cjs`) as its own path scope, exactly like the four Chromium helpers already are. The helper entries were already correctly scoped and are unchanged.

Once merged, the `v1.2.0` tag will be moved to the new main HEAD to re-trigger the release.