### PR TITLE
feat(updater): in-app auto-update for macOS (closes #274)

### DIFF
--- a/electron/main/__tests__/autoUpdater.test.ts
+++ b/electron/main/__tests__/autoUpdater.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initAutoUpdater } from "../autoUpdater.js";
+
+// Mutable electron app mock — `isPackaged` is overridden per test.
+const mockApp = { isPackaged: false };
+vi.mock("electron", () => ({
+  app: {
+    get isPackaged() {
+      return mockApp.isPackaged;
+    },
+  },
+}));
+
+const updateElectronApp = vi.fn();
+vi.mock("update-electron-app", () => ({
+  updateElectronApp: (...args: unknown[]) => updateElectronApp(...args),
+  UpdateSourceType: { ElectronPublicUpdateService: 0, StaticStorage: 1 },
+}));
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+describe("initAutoUpdater", () => {
+  beforeEach(() => {
+    updateElectronApp.mockReset();
+    mockApp.isPackaged = false;
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("does nothing on non-macOS platforms even when packaged", async () => {
+    setPlatform("win32");
+    mockApp.isPackaged = true;
+
+    await initAutoUpdater();
+
+    expect(updateElectronApp).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on macOS when the build is not packaged", async () => {
+    setPlatform("darwin");
+    mockApp.isPackaged = false;
+
+    await initAutoUpdater();
+
+    expect(updateElectronApp).not.toHaveBeenCalled();
+  });
+
+  it("initialises the updater on packaged macOS builds", async () => {
+    setPlatform("darwin");
+    mockApp.isPackaged = true;
+
+    await initAutoUpdater();
+
+    expect(updateElectronApp).toHaveBeenCalledTimes(1);
+    const opts = updateElectronApp.mock.calls[0][0];
+    expect(opts.updateSource).toEqual({
+      repo: "peteb4ker/romper",
+      type: 0,
+    });
+    expect(opts.updateInterval).toBe("1 hour");
+    expect(opts.notifyUser).toBe(true);
+    expect(typeof opts.logger.log).toBe("function");
+  });
+
+  it("swallows updater initialisation errors", async () => {
+    setPlatform("darwin");
+    mockApp.isPackaged = true;
+    updateElectronApp.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+
+    await expect(initAutoUpdater()).resolves.toBeUndefined();
+  });
+});

--- a/electron/main/autoUpdater.ts
+++ b/electron/main/autoUpdater.ts
@@ -1,0 +1,71 @@
+/**
+ * In-app auto-update wiring.
+ *
+ * macOS only at this time:
+ *   - Windows release artifacts currently ship unsigned (see issue #276) and
+ *     Squirrel.Windows refuses unsigned updates, so enabling it there would
+ *     fail or warn. Track Windows auto-update behind Azure Trusted Signing.
+ *   - update.electronjs.org does not support Linux; Linux stays on the
+ *     deb/rpm package managers.
+ *
+ * The updater is a no-op in dev / unpackaged builds (Squirrel is not present),
+ * and `update-electron-app` is dynamically imported only once the macOS +
+ * packaged guards pass, so it never loads during unit/e2e runs.
+ */
+
+import { app } from "electron";
+
+import { logger } from "./utils/logger.js";
+
+// GitHub repo backing the update.electronjs.org feed. Passed explicitly so the
+// updater does not depend on package.json's `repository` field being present.
+const GITHUB_REPO = "peteb4ker/romper";
+
+// Conservative cadence for a desktop app: checks on launch, then hourly.
+const UPDATE_INTERVAL = "1 hour";
+
+/**
+ * Initialise auto-update. Safe to call unconditionally on every platform —
+ * it returns early everywhere except packaged macOS builds.
+ */
+export async function initAutoUpdater(): Promise<void> {
+  if (process.platform !== "darwin") {
+    logger.log(
+      "[AutoUpdate] Skipped: auto-update is macOS-only at this time (see #276)",
+    );
+    return;
+  }
+
+  if (!app.isPackaged) {
+    logger.log("[AutoUpdate] Skipped: not a packaged build");
+    return;
+  }
+
+  try {
+    const { updateElectronApp, UpdateSourceType } =
+      await import("update-electron-app");
+
+    updateElectronApp({
+      logger: {
+        error: (message: string) => console.error("[AutoUpdate]", message),
+        info: (message: string) => logger.log("[AutoUpdate]", message),
+        log: (message: string) => logger.log("[AutoUpdate]", message),
+        warn: (message: string) => console.warn("[AutoUpdate]", message),
+      },
+      notifyUser: true,
+      updateInterval: UPDATE_INTERVAL,
+      updateSource: {
+        repo: GITHUB_REPO,
+        type: UpdateSourceType.ElectronPublicUpdateService,
+      },
+    });
+
+    logger.log("[AutoUpdate] Initialised (macOS, packaged)");
+  } catch (error: unknown) {
+    // Never let an updater failure take down app startup.
+    console.error(
+      "[AutoUpdate] Failed to initialise auto-update:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -11,6 +11,7 @@ import {
   createApplicationMenu,
   registerMenuIpcHandlers,
 } from "./applicationMenu.js";
+import { initAutoUpdater } from "./autoUpdater.js";
 import { registerDbIpcHandlers } from "./dbIpcHandlers.js";
 import { registerIpcHandlers } from "./ipcHandlers.js";
 import {
@@ -173,6 +174,10 @@ app.whenReady().then(async () => {
     // Register IPC handlers
     registerAllIpcHandlers(inMemorySettings);
     createApplicationMenu();
+
+    // Kick off auto-update (no-op outside packaged macOS builds). Fire-and-
+    // forget so a slow/failed update check never delays the window or menu.
+    void initAutoUpdater();
   } catch (error: unknown) {
     console.error(
       "[Startup] Error during app initialization:",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-router-dom": "^7.12.0",
         "react-window": "^1.8.11",
         "unzipper": "^0.12.3",
+        "update-electron-app": "^3.2.0",
         "wavesurfer.js": "^7.9.5"
       },
       "devDependencies": {
@@ -10879,6 +10880,15 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/github-url-to-object": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.6.tgz",
+      "integrity": "sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-url": "^1.1.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11994,7 +12004,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-url-superb": {
@@ -18825,6 +18834,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/update-electron-app": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/update-electron-app/-/update-electron-app-3.2.0.tgz",
+      "integrity": "sha512-l2e7bzsW+rw70pfyyQeA9E/ofpNY2ZS99XuYxD2qWL4fEy3qMjpqwwgB0me7ESpGogIQE1CM0SaDvKGsK4Jg3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "github-url-to-object": "^4.0.4",
+        "ms": "^2.1.1"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "private": true,
   "version": "1.2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peteb4ker/romper.git"
+  },
   "type": "module",
   "main": "dist/electron/main/index.js",
   "scripts": {
@@ -148,6 +152,7 @@
     "react-router-dom": "^7.12.0",
     "react-window": "^1.8.11",
     "unzipper": "^0.12.3",
+    "update-electron-app": "^3.2.0",
     "wavesurfer.js": "^7.9.5"
   }
 }


### PR DESCRIPTION
Closes #274.

## What

Adds in-app auto-update for **macOS** using [`update-electron-app`](https://github.com/electron/update-electron-app) backed by the free hosted [update.electronjs.org](https://update.electronjs.org) service. No update server of our own — it reads our public GitHub Releases.

## Scope: macOS only (by design)

- **Windows** is deferred — release artifacts currently ship unsigned (#276) and Squirrel.Windows refuses unsigned updates. Once Azure Trusted Signing is configured (#276), Windows auto-update can be a follow-up.
- **Linux** is unsupported by update.electronjs.org; stays on deb/rpm.

## How it works

- New module `electron/main/autoUpdater.ts` exposes `initAutoUpdater()`, called from the `whenReady` chain in `index.ts` (fire-and-forget so it never delays the window/menu).
- Guards: returns early unless `process.platform === 'darwin'` **and** `app.isPackaged`. `update-electron-app` is **dynamically imported only after** those guards pass, so it never loads in dev / unit / e2e runs.
- Cadence: checks on launch, then hourly. Prompts the user to restart when an update is downloaded (`notifyUser: true`).
- Any init failure is caught and logged — it can never take down app startup.
- Adds the `repository` field to `package.json` (and passes the repo explicitly to the updater).

## Why it's ready on macOS

Release builds are already signed + notarized + stapled, and the `.zip` that Squirrel.Mac consumes is already produced (`Romper-darwin-arm64-<v>.zip`). ⚠️ That macOS zip must **not** be removed — it's the update payload.

## Tests

`electron/main/__tests__/autoUpdater.test.ts` covers all four paths:
- non-macOS (even when packaged) → no-op
- macOS unpackaged → no-op
- macOS packaged → initialises with expected options
- updater throws → swallowed, resolves cleanly

Full pre-commit suite (lint, typecheck, unit + integration, 532 tests) passes.

## Verification notes

The guards mean this is a **no-op until a packaged, signed macOS build is installed** — it can't be exercised by `npm run dev`. End-to-end proof requires shipping a release and confirming an installed older build upgrades itself (tracked as a task in #274).