### PR TITLE
fix(updater): relax auto-update check interval to weekly

### DIFF
--- a/electron/main/__tests__/autoUpdater.test.ts
+++ b/electron/main/__tests__/autoUpdater.test.ts
@@ -67,7 +67,7 @@ describe("initAutoUpdater", () => {
       repo: "peteb4ker/romper",
       type: 0,
     });
-    expect(opts.updateInterval).toBe("1 hour");
+    expect(opts.updateInterval).toBe("1 week");
     expect(opts.notifyUser).toBe(true);
     expect(typeof opts.logger.log).toBe("function");
   });

--- a/electron/main/autoUpdater.ts
+++ b/electron/main/autoUpdater.ts
@@ -21,8 +21,10 @@ import { logger } from "./utils/logger.js";
 // updater does not depend on package.json's `repository` field being present.
 const GITHUB_REPO = "peteb4ker/romper";
 
-// Conservative cadence for a desktop app: checks on launch, then hourly.
-const UPDATE_INTERVAL = "1 hour";
+// Conservative cadence for a desktop app: checks on launch, then at most
+// weekly while the app stays open. (update-electron-app caps the interval at
+// just under ~24 days, so a week is well within range.)
+const UPDATE_INTERVAL = "1 week";
 
 /**
  * Initialise auto-update. Safe to call unconditionally on every platform —


### PR DESCRIPTION
Follow-up to #274 / #277.

The auto-update check interval shipped as `1 hour`, which is more aggressive than needed — the app updates weekly at most. Relax it to `1 week`.

- Checks still run **on launch**; the interval only governs re-checks while the app stays open.
- `1 week` = 604,800,000 ms, well within `update-electron-app`'s bounds (≥ 5 min, under the ~24-day signed-32-bit cap).
- Unit test assertion updated accordingly.