### PR TITLE
bump: version 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/peteb4ker/romper.git"


### PR DESCRIPTION
## Summary

Bump to **v1.3.0** ahead of cutting the release. Minor bump per semver — a `feat:` has landed since v1.2.0 (no breaking changes).

### Changes since v1.2.0
- ✨ `feat(updater)`: in-app auto-update for macOS (#277, closes #274)
- 🐛 `fix(updater)`: relax update check interval to weekly (#278)

## Release plan

Once this merges, `v1.3.0` will be tagged on `main`, triggering the cross-platform build + auto-generated release notes. This is the **first release that ships in-app auto-update** — installed macOS builds from v1.3.0 onward will self-update.