### PR TITLE
fix(security): harden archive extraction against Zip-Slip and zip bombs

### DIFF
--- a/electron/main/__tests__/archiveUtils.test.ts
+++ b/electron/main/__tests__/archiveUtils.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import AdmZip from "adm-zip";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { isValidEntry } from "../archiveUtils";
+import {
+  type ArchiveLimits,
+  countZipEntries,
+  DEFAULT_ARCHIVE_LIMITS,
+  extractZipEntries,
+  isValidEntry,
+  isWithinDirectory,
+} from "../archiveUtils";
 
 describe("isValidEntry", () => {
   it("returns false for __MACOSX/ entries", () => {
@@ -20,5 +31,168 @@ describe("isValidEntry", () => {
     expect(isValidEntry("foo/bar.wav")).toBe(true);
     expect(isValidEntry("foo/bar/baz.wav")).toBe(true);
     expect(isValidEntry("folder/normalfile.txt")).toBe(true);
+  });
+
+  it("rejects parent-directory traversal (Zip-Slip)", () => {
+    expect(isValidEntry("../foo.wav")).toBe(false);
+    expect(isValidEntry("../../etc/passwd")).toBe(false);
+    expect(isValidEntry("foo/../../bar.wav")).toBe(false);
+    expect(isValidEntry("foo/../bar.wav")).toBe(false);
+    // Backslash-separated traversal (Windows-style entries)
+    expect(isValidEntry("..\\foo.wav")).toBe(false);
+    expect(isValidEntry("foo\\..\\..\\bar.wav")).toBe(false);
+  });
+
+  it("rejects absolute paths", () => {
+    expect(isValidEntry("/etc/passwd")).toBe(false);
+    expect(isValidEntry("C:\\Windows\\system32\\evil.dll")).toBe(false);
+  });
+
+  it("rejects empty paths", () => {
+    expect(isValidEntry("")).toBe(false);
+  });
+});
+
+describe("isWithinDirectory", () => {
+  it("accepts entries that resolve inside the destination", () => {
+    expect(isWithinDirectory("/tmp/dest", "foo.wav")).toBe(true);
+    expect(isWithinDirectory("/tmp/dest", "a/b/c.wav")).toBe(true);
+    expect(isWithinDirectory("/tmp/dest", "")).toBe(true);
+  });
+
+  it("rejects entries that escape the destination", () => {
+    expect(isWithinDirectory("/tmp/dest", "../evil.wav")).toBe(false);
+    expect(isWithinDirectory("/tmp/dest", "../../etc/passwd")).toBe(false);
+    expect(isWithinDirectory("/tmp/dest", "/etc/passwd")).toBe(false);
+  });
+
+  it("does not treat sibling prefixes as inside", () => {
+    // "/tmp/dest-evil" shares the "/tmp/dest" string prefix but is a sibling.
+    expect(isWithinDirectory("/tmp/dest", "../dest-evil/x.wav")).toBe(false);
+  });
+});
+
+describe("extractZipEntries", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "romper-archive-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  // Build a zip on disk from a map of entry path -> contents.
+  function buildZip(entries: Record<string, Buffer | string>): string {
+    const zip = new AdmZip();
+    for (const [name, content] of Object.entries(entries)) {
+      zip.addFile(
+        name,
+        typeof content === "string" ? Buffer.from(content) : content,
+      );
+    }
+    const zipPath = path.join(
+      tmpRoot,
+      `in-${Math.random().toString(36).slice(2)}.zip`,
+    );
+    zip.writeZip(zipPath);
+    return zipPath;
+  }
+
+  function collectExtracted(dir: string): string[] {
+    const out: string[] = [];
+    const walk = (d: string, prefix: string) => {
+      for (const name of fs.readdirSync(d)) {
+        const full = path.join(d, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        if (fs.statSync(full).isDirectory()) {
+          walk(full, rel);
+        } else {
+          out.push(rel);
+        }
+      }
+    };
+    walk(dir, "");
+    return out.sort();
+  }
+
+  it("extracts valid entries into the destination", async () => {
+    const zipPath = buildZip({
+      "a.wav": "hello",
+      "nested/b.wav": "world",
+    });
+    const dest = path.join(tmpRoot, "out");
+    fs.mkdirSync(dest);
+
+    await extractZipEntries(zipPath, dest, 2, () => {});
+
+    expect(collectExtracted(dest)).toEqual(["a.wav", "nested/b.wav"]);
+    expect(fs.readFileSync(path.join(dest, "a.wav"), "utf-8")).toBe("hello");
+  });
+
+  // NOTE: the Zip-Slip *path* defence is verified exhaustively by the
+  // isValidEntry / isWithinDirectory unit tests above. We cannot build a real
+  // archive containing a "../" entry here because the zip writer sanitises
+  // entry names on write, so there is no integration fixture for it.
+
+  it("rejects archives exceeding the total size limit", async () => {
+    const big = Buffer.alloc(2048, 0x61); // 2 KiB
+    const zipPath = buildZip({ "big.wav": big });
+    const dest = path.join(tmpRoot, "out");
+    fs.mkdirSync(dest);
+
+    const limits: ArchiveLimits = {
+      ...DEFAULT_ARCHIVE_LIMITS,
+      maxTotalBytes: 1024,
+    };
+
+    await expect(
+      extractZipEntries(zipPath, dest, 1, () => {}, limits),
+    ).rejects.toThrow(/total uncompressed size limit/);
+  });
+
+  it("rejects archives exceeding the per-file size limit", async () => {
+    const big = Buffer.alloc(2048, 0x62);
+    const zipPath = buildZip({ "big.wav": big });
+    const dest = path.join(tmpRoot, "out");
+    fs.mkdirSync(dest);
+
+    const limits: ArchiveLimits = {
+      ...DEFAULT_ARCHIVE_LIMITS,
+      maxFileBytes: 1024,
+    };
+
+    await expect(
+      extractZipEntries(zipPath, dest, 1, () => {}, limits),
+    ).rejects.toThrow(/per-file size limit/);
+  });
+
+  it("rejects archives exceeding the entry count limit", async () => {
+    const zipPath = buildZip({
+      "a.wav": "1",
+      "b.wav": "2",
+      "c.wav": "3",
+    });
+    const dest = path.join(tmpRoot, "out");
+    fs.mkdirSync(dest);
+
+    const limits: ArchiveLimits = {
+      ...DEFAULT_ARCHIVE_LIMITS,
+      maxEntries: 2,
+    };
+
+    await expect(
+      extractZipEntries(zipPath, dest, 3, () => {}, limits),
+    ).rejects.toThrow(/maximum entry count/);
+  });
+
+  it("counts only valid entries", async () => {
+    const zipPath = buildZip({
+      "__MACOSX/junk.wav": "junk",
+      "a.wav": "1",
+      "b.wav": "2",
+    });
+    await expect(countZipEntries(zipPath)).resolves.toBe(2);
   });
 });

--- a/electron/main/archiveUtils.ts
+++ b/electron/main/archiveUtils.ts
@@ -2,11 +2,36 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as unzipper from "unzipper";
 
+/**
+ * Resource limits applied during archive extraction to defend against
+ * decompression bombs (a small archive that expands to an enormous size).
+ * Defaults are generous enough for legitimate Squarp sample packs while
+ * still bounding worst-case disk usage.
+ */
+export interface ArchiveLimits {
+  maxEntries: number;
+  maxFileBytes: number;
+  maxTotalBytes: number;
+}
+
 interface UnzipperEntry {
   autodrain(): void;
+  on(event: string, listener: (...args: unknown[]) => void): UnzipperEntry;
   path: string;
   pipe(destination: fs.WriteStream): fs.WriteStream;
   type: string;
+}
+
+export const DEFAULT_ARCHIVE_LIMITS: ArchiveLimits = {
+  maxEntries: 10_000,
+  maxFileBytes: 512 * 1024 * 1024, // 512 MiB per file
+  maxTotalBytes: 2 * 1024 * 1024 * 1024, // 2 GiB total uncompressed
+};
+
+// Mutable byte/entry budget shared across entries of a single extraction.
+interface ExtractionBudget {
+  totalBytes: number;
+  validEntries: number;
 }
 
 export async function countZipEntries(zipPath: string): Promise<number> {
@@ -56,31 +81,110 @@ export async function extractZipEntries(
   destDir: string,
   entryCount: number,
   onProgress: (info: { file: string; percent: null | number }) => void,
+  limits: ArchiveLimits = DEFAULT_ARCHIVE_LIMITS,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let processedCount = 0;
+    let settled = false;
+    const budget: ExtractionBudget = { totalBytes: 0, validEntries: 0 };
 
-    fs.createReadStream(zipPath)
-      .pipe(unzipper.Parse())
-      .on("entry", (entry: UnzipperEntry) => {
-        processedCount = processZipEntry(
-          entry,
-          destDir,
-          processedCount,
-          entryCount,
-          onProgress,
+    const stream = fs.createReadStream(zipPath).pipe(unzipper.Parse());
+
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      stream.destroy();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    stream.on("entry", (entry: UnzipperEntry) => {
+      if (settled) {
+        entry.autodrain();
+        return;
+      }
+
+      // Skip macOS artifacts and anything that would escape the destination
+      // directory (Zip-Slip). Both the pure-string check and the resolved-path
+      // check must pass before we write.
+      if (
+        !isValidEntry(entry.path) ||
+        !isWithinDirectory(destDir, entry.path)
+      ) {
+        entry.autodrain();
+        return;
+      }
+
+      budget.validEntries++;
+      if (budget.validEntries > limits.maxEntries) {
+        fail(
+          new Error(
+            `Archive exceeds maximum entry count (${limits.maxEntries})`,
+          ),
         );
-      })
-      .on("close", resolve)
-      .on("error", reject);
+        return;
+      }
+
+      processedCount++;
+      const percent =
+        entryCount > 0 ? Math.floor((processedCount / entryCount) * 100) : null;
+      onProgress({ file: entry.path, percent });
+
+      const destPath = path.join(destDir, entry.path);
+      if (entry.type === "Directory") {
+        handleDirectoryEntry(entry, destPath);
+      } else {
+        handleFileEntry(entry, destPath, limits, budget, fail);
+      }
+    });
+
+    stream.on("error", fail);
+    stream.on("close", () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
   });
 }
 
+/**
+ * Validates a zip entry path. Rejects macOS metadata artifacts and, critically,
+ * any entry that would escape the extraction directory (Zip-Slip), i.e. absolute
+ * paths or paths containing ".." traversal segments.
+ */
 export function isValidEntry(entryPath: string): boolean {
+  if (!entryPath) {
+    return false;
+  }
+
+  // Reject absolute paths (POSIX and Windows drive-letter) and parent-directory
+  // traversal segments — the core Zip-Slip defence.
+  if (path.isAbsolute(entryPath) || /^[a-zA-Z]:[\\/]/.test(entryPath)) {
+    return false;
+  }
+  const segments = entryPath.split(/[\\/]/);
+  if (segments.includes("..")) {
+    return false;
+  }
+
   return (
     !entryPath.startsWith("__MACOSX/") &&
     !entryPath.includes("/__MACOSX/") &&
-    !entryPath.split("/").some((p: string) => p.startsWith("._"))
+    !segments.some((p: string) => p.startsWith("._"))
+  );
+}
+
+/**
+ * Returns true when `entryPath` resolved against `destDir` stays within
+ * `destDir`. Defence-in-depth check applied at write time in addition to the
+ * pure string check in {@link isValidEntry}.
+ */
+export function isWithinDirectory(destDir: string, entryPath: string): boolean {
+  const resolvedDest = path.resolve(destDir);
+  const resolvedTarget = path.resolve(resolvedDest, entryPath);
+  return (
+    resolvedTarget === resolvedDest ||
+    resolvedTarget.startsWith(resolvedDest + path.sep)
   );
 }
 
@@ -114,8 +218,15 @@ function handleDirectoryEntry(entry: UnzipperEntry, destPath: string): void {
   });
 }
 
-// Helper function to handle file extraction
-function handleFileEntry(entry: UnzipperEntry, destPath: string): void {
+// Helper function to handle file extraction, enforcing per-file and cumulative
+// size limits to defend against decompression bombs.
+function handleFileEntry(
+  entry: UnzipperEntry,
+  destPath: string,
+  limits: ArchiveLimits,
+  budget: ExtractionBudget,
+  fail: (error: unknown) => void,
+): void {
   fs.mkdir(path.dirname(destPath), { recursive: true }, (err) => {
     if (err) {
       console.warn(
@@ -127,44 +238,32 @@ function handleFileEntry(entry: UnzipperEntry, destPath: string): void {
       return;
     }
 
-    entry
-      .pipe(fs.createWriteStream(destPath))
-      .on("error", (err: unknown) => {
-        setImmediate(() => {
-          console.warn("Failed to write file:", destPath, err);
-        });
-      })
-      .on("finish", () => {});
+    let fileBytes = 0;
+    entry.on("data", (...args: unknown[]) => {
+      const chunk = args[0] as Buffer;
+      fileBytes += chunk.length;
+      budget.totalBytes += chunk.length;
+      if (fileBytes > limits.maxFileBytes) {
+        fail(
+          new Error(
+            `Archive entry exceeds per-file size limit (${limits.maxFileBytes} bytes): ${entry.path}`,
+          ),
+        );
+      } else if (budget.totalBytes > limits.maxTotalBytes) {
+        fail(
+          new Error(
+            `Archive exceeds total uncompressed size limit (${limits.maxTotalBytes} bytes)`,
+          ),
+        );
+      }
+    });
+
+    entry.pipe(fs.createWriteStream(destPath)).on("error", (err: unknown) => {
+      setImmediate(() => {
+        console.warn("Failed to write file:", destPath, err);
+      });
+    });
   });
-}
-
-// Helper function to process a single zip entry
-function processZipEntry(
-  entry: UnzipperEntry,
-  destDir: string,
-  processedCount: number,
-  entryCount: number,
-  onProgress: (info: { file: string; percent: null | number }) => void,
-): number {
-  if (!isValidEntry(entry.path)) {
-    entry.autodrain();
-    return processedCount;
-  }
-
-  processedCount++;
-  const percent =
-    entryCount > 0 ? Math.floor((processedCount / entryCount) * 100) : null;
-  onProgress({ file: entry.path, percent });
-
-  const destPath = path.join(destDir, entry.path);
-
-  if (entry.type === "Directory") {
-    handleDirectoryEntry(entry, destPath);
-  } else {
-    handleFileEntry(entry, destPath);
-  }
-
-  return processedCount;
 }
 
 // Helper to setup file stream handlers

--- a/electron/main/services/__tests__/archiveService.test.ts
+++ b/electron/main/services/__tests__/archiveService.test.ts
@@ -32,7 +32,14 @@ vi.mock("node:fs", () => ({
 }));
 vi.mock("node:path", () => ({
   dirname: vi.fn((p) => p.split("/").slice(0, -1).join("/")),
+  isAbsolute: vi.fn((p: string) => p.startsWith("/")),
   join: vi.fn((...args) => args.join("/")),
+  resolve: vi.fn((...args: string[]) => {
+    // Minimal resolve: join non-empty segments, keeping leading slash.
+    const joined = args.filter(Boolean).join("/").replace(/\/+/g, "/");
+    return joined.startsWith("/") ? joined : `/${joined}`;
+  }),
+  sep: "/",
 }));
 
 // Unzipper mock: emits normal events unless test sets .emitUnzipEvents to emit error
@@ -43,12 +50,14 @@ vi.mock("unzipper", () => ({
       setTimeout(() => {
         stream.emit("entry", {
           autodrain: () => {},
+          on: () => {},
           path: "foo.wav",
           pipe: () => new MockStream(),
           type: "File",
         });
         stream.emit("entry", {
           autodrain: () => {},
+          on: () => {},
           path: "bar/",
           pipe: () => new MockStream(),
           type: "Directory",
@@ -253,6 +262,7 @@ describe("download-and-extract-archive handler", () => {
             // Emit an entry to trigger file extraction
             stream.emit("entry", {
               autodrain: () => {},
+              on: () => {},
               path: "foo.wav",
               pipe: () => {
                 const s = new MockStream();

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@typescript-eslint/parser": "^8.41.0",
         "@typescript-eslint/typescript-estree": "^8.41.0",
         "@vitest/coverage-v8": "^4.1.8",
+        "adm-zip": "^0.5.17",
         "archiver": "^7.0.1",
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@typescript-eslint/parser": "^8.41.0",
     "@typescript-eslint/typescript-estree": "^8.41.0",
     "@vitest/coverage-v8": "^4.1.8",
+    "adm-zip": "^0.5.17",
     "archiver": "^7.0.1",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",


### PR DESCRIPTION
## Summary

First of three security PRs from a vulnerability audit of the codebase. This one hardens the archive download/extract path (`electron/main/archiveUtils.ts`), which extracts renderer-supplied / network-supplied ZIPs during local-store sync.

### Problems fixed

1. **Zip-Slip (arbitrary file write).** `isValidEntry()` only filtered `__MACOSX`/dot-underscore artifacts and never checked for `..`. Entry paths were then joined straight onto the destination with `path.join(destDir, entry.path)`, so a crafted archive entry like `../../../<somewhere>` would be written outside the extraction directory.
2. **Decompression bomb (DoS).** Extraction had no bound on output — a small archive could expand without limit and exhaust disk during sync.

### Changes

- `isValidEntry()` now also rejects absolute paths (POSIX + Windows drive-letter) and any `..` traversal segment, for both `/` and `\` separators.
- New `isWithinDirectory()` defence-in-depth check resolves each entry against the destination and refuses anything that escapes it, applied at write time.
- Extraction enforces configurable `ArchiveLimits` — per-file size (512 MiB), cumulative uncompressed size (2 GiB), and entry count (10k). Breaching any limit aborts the stream and rejects.
- The existing extraction contract (skip-and-continue for filtered entries, log-and-continue on individual file write errors, resolve on archive close) is preserved.
- Added `adm-zip` as an explicit devDependency to build archive fixtures in tests (it was previously only transitive).

### Tests

- New unit coverage for `isValidEntry` (traversal/absolute/empty) and `isWithinDirectory` (containment, sibling-prefix).
- New integration coverage building real ZIPs and asserting the per-file / total-size / entry-count limits reject.
- Updated `archiveService.test.ts` mocks to model the new code paths.
- Full pre-commit gate passes locally: typecheck, lint, build, 3539 unit + 532 integration tests.

> Note: the Zip-Slip *path* logic is verified by the pure-function unit tests rather than an integration fixture, because the zip writer used in tests sanitises `..` on write so a malicious entry cannot be authored through it.

https://claude.ai/code/session_014jyLTNvc2HpXFA6w23KDfP

---
_Generated by [Claude Code](https://claude.ai/code/session_014jyLTNvc2HpXFA6w23KDfP)_