### PR TITLE
fix(security): harden window navigation and read-file IPC

### DIFF
--- a/electron/main/__tests__/index.test.ts
+++ b/electron/main/__tests__/index.test.ts
@@ -49,8 +49,10 @@ vi.mock("electron", () => {
       maximize: vi.fn(),
       on: vi.fn(),
       webContents: {
+        getURL: vi.fn(() => ""),
         on: vi.fn(),
         send: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
       },
     };
   });
@@ -214,6 +216,12 @@ describe.sequential("main/index.ts", () => {
       loadURL: vi.fn().mockRejectedValue(new Error("Load URL failed")),
       maximize: vi.fn(),
       on: vi.fn(),
+      webContents: {
+        getURL: vi.fn(() => ""),
+        on: vi.fn(),
+        send: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+      },
     };
     vi.mocked(BrowserWindow).mockImplementation(function () {
       return mockWindow as unknown;
@@ -242,6 +250,12 @@ describe.sequential("main/index.ts", () => {
       loadURL: vi.fn().mockResolvedValue(undefined),
       maximize: vi.fn(),
       on: vi.fn(),
+      webContents: {
+        getURL: vi.fn(() => ""),
+        on: vi.fn(),
+        send: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+      },
     };
     vi.mocked(BrowserWindow).mockImplementation(function () {
       return mockWindow as unknown;

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, shell } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,6 +70,8 @@ function createWindow() {
     y: windowState.y,
   });
 
+  hardenNavigation(win);
+
   if (windowState.isMaximized) {
     win.maximize();
   }
@@ -125,6 +127,43 @@ function getSettingsPath(): string {
 
 function getWindowStatePath(): string {
   return path.join(app.getPath("userData"), "window-state.json");
+}
+
+/**
+ * Apply Electron navigation hardening to a window's web contents:
+ * - Deny all `window.open` / target=_blank popups, sending http(s) URLs to the
+ *   user's external browser instead of opening an in-app window.
+ * - Block any top-level navigation that would leave the app's own origin
+ *   (e.g. an injected link), routing external http(s) links to the browser.
+ *
+ * Same-origin SPA routing uses the history API and does not trigger
+ * `will-navigate`, so this does not interfere with normal app navigation.
+ */
+function hardenNavigation(win: BrowserWindow): void {
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:\/\//i.test(url)) {
+      void shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+
+  win.webContents.on("will-navigate", (event, navigationUrl) => {
+    if (isSameOrigin(navigationUrl, win.webContents.getURL())) {
+      return;
+    }
+    event.preventDefault();
+    if (/^https?:\/\//i.test(navigationUrl)) {
+      void shell.openExternal(navigationUrl);
+    }
+  });
+}
+
+function isSameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
 }
 
 function registerAllIpcHandlers(settings: InMemorySettings) {

--- a/electron/main/services/__tests__/localStoreService.test.ts
+++ b/electron/main/services/__tests__/localStoreService.test.ts
@@ -306,6 +306,13 @@ describe("LocalStoreService", () => {
   });
 
   describe("readFile", () => {
+    // A regular, small file by default; individual tests override as needed.
+    const regularFileStat = {
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      size: 1024,
+    } as unknown;
+
     it("successfully reads file and returns ArrayBuffer", () => {
       const mockBuffer = Buffer.from("test file content");
       // Mock the buffer properties that the service uses
@@ -322,6 +329,7 @@ describe("LocalStoreService", () => {
         writable: false,
       });
 
+      mockFs.lstatSync.mockReturnValue(regularFileStat);
       mockFs.readFileSync.mockReturnValue(mockBuffer);
 
       const result = localStoreService.readFile("/test/file.txt");
@@ -331,7 +339,50 @@ describe("LocalStoreService", () => {
       expect(mockFs.readFileSync).toHaveBeenCalledWith("/test/file.txt");
     });
 
+    it("refuses to read a symbolic link", () => {
+      mockFs.lstatSync.mockReturnValue({
+        isFile: () => false,
+        isSymbolicLink: () => true,
+        size: 10,
+      } as unknown);
+
+      const result = localStoreService.readFile("/test/link.wav");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/symbolic link/i);
+      expect(mockFs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("refuses to read a non-regular file", () => {
+      mockFs.lstatSync.mockReturnValue({
+        isFile: () => false,
+        isSymbolicLink: () => false,
+        size: 10,
+      } as unknown);
+
+      const result = localStoreService.readFile("/dev/zero");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not a regular file/i);
+      expect(mockFs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("refuses to read a file over the size cap", () => {
+      mockFs.lstatSync.mockReturnValue({
+        isFile: () => true,
+        isSymbolicLink: () => false,
+        size: 1024 * 1024 * 1024, // 1 GiB > cap
+      } as unknown);
+
+      const result = localStoreService.readFile("/test/huge.bin");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/maximum readable size/i);
+      expect(mockFs.readFileSync).not.toHaveBeenCalled();
+    });
+
     it("returns error when file read fails", () => {
+      mockFs.lstatSync.mockReturnValue(regularFileStat);
       mockFs.readFileSync.mockImplementation(() => {
         throw new Error("File not found");
       });
@@ -345,6 +396,7 @@ describe("LocalStoreService", () => {
     });
 
     it("handles non-Error exceptions", () => {
+      mockFs.lstatSync.mockReturnValue(regularFileStat);
       mockFs.readFileSync.mockImplementation(() => {
         const error: unknown = "String error";
         throw error;

--- a/electron/main/services/localStoreService.ts
+++ b/electron/main/services/localStoreService.ts
@@ -10,6 +10,10 @@ import {
 } from "../localStoreValidator.js";
 import { logger } from "../utils/logger.js";
 
+// Upper bound for read-file responses. Sample WAVs are far smaller; this only
+// guards against a request for a pathologically large or special file.
+const MAX_READ_FILE_BYTES = 256 * 1024 * 1024; // 256 MiB
+
 /**
  * Service for local store validation and management operations
  * Extracted from ipcHandlers.ts and dbIpcHandlers.ts to separate business logic from IPC routing
@@ -150,7 +154,13 @@ export class LocalStoreService {
   }
 
   /**
-   * Read a file and return its buffer
+   * Read a file and return its buffer.
+   *
+   * Hardened against two misuses of this renderer-facing channel:
+   * - Symbolic links are refused (lstat), so a link planted inside the local
+   *   store cannot redirect a read to an arbitrary sensitive file.
+   * - Reads are capped, so a request for a huge/special file cannot exhaust
+   *   memory in the main process.
    */
   readFile(filePath: string): {
     data?: ArrayBuffer;
@@ -158,6 +168,20 @@ export class LocalStoreService {
     success: boolean;
   } {
     try {
+      const stats = fs.lstatSync(filePath);
+      if (stats.isSymbolicLink()) {
+        return { error: "Refusing to read a symbolic link", success: false };
+      }
+      if (!stats.isFile()) {
+        return { error: "Not a regular file", success: false };
+      }
+      if (stats.size > MAX_READ_FILE_BYTES) {
+        return {
+          error: `File exceeds maximum readable size (${MAX_READ_FILE_BYTES} bytes)`,
+          success: false,
+        };
+      }
+
       const data = fs.readFileSync(filePath);
       return {
         data: data.buffer.slice(


### PR DESCRIPTION
## Summary

Second of three security PRs from the vulnerability audit. Addresses two findings.

> **Revised after CI:** the original version of this PR confined `read-file` / `list-files-in-root` to a dialog-seeded allow-list. That broke the local-store wizard e2e flow, because the wizard legitimately reads **free-text paths the user types** into the target field (and in Electron the renderer is the trust boundary anyway, so the allow-list added little real security). That approach was dropped in favour of the non-restrictive `read-file` hardening below.

### S4 — navigation hardening

- `setWindowOpenHandler` denies all popups, routing `http(s)` URLs to the external browser instead.
- `will-navigate` blocks navigation that would leave the app's origin, routing external `http(s)` links to the browser. Same-origin SPA routing uses the history API and never triggers `will-navigate`, so normal navigation is unaffected.

### S3 — read-file hardening (non-restrictive)

`localStoreService.readFile` now:
- **Refuses symbolic links** (`lstat`) — a link planted inside the local store can no longer redirect a read to an arbitrary sensitive file.
- **Refuses non-regular files** (devices, fifos, etc.).
- **Caps the read size** (256 MiB) to guard against memory exhaustion from a request for a pathologically large/special file.

This removes the dangerous shapes of the read primitive without restricting which directories work, so it doesn't break the wizard, SD-card import, or kit scanning.

### Tests

- New `readFile` cases: symlink refused, non-regular file refused, oversize refused, plus the existing happy-path/error cases updated for the new `lstat` call.
- Updated `index.test.ts` window mocks for the new `webContents` navigation handlers.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration). e2e re-running in CI after the revision.

https://claude.ai/code/session_014jyLTNvc2HpXFA6w23KDfP