### PR TITLE
fix(security): canonicalize delete scope and stop following symlinks on copy

### DIFF
--- a/electron/main/services/__tests__/archiveServiceCopyDirectory.test.ts
+++ b/electron/main/services/__tests__/archiveServiceCopyDirectory.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ArchiveService } from "../archiveService";
+
+// Real-filesystem tests for copyDirectory's symlink handling. These do not mock
+// node:fs (unlike archiveService.test.ts), so they exercise the actual copy.
+describe("ArchiveService.copyDirectory symlink handling", () => {
+  let tmpRoot: string;
+  const service = new ArchiveService();
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "romper-copydir-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it("copies regular files and nested directories", () => {
+    const src = path.join(tmpRoot, "src");
+    fs.mkdirSync(path.join(src, "nested"), { recursive: true });
+    fs.writeFileSync(path.join(src, "a.wav"), "a");
+    fs.writeFileSync(path.join(src, "nested", "b.wav"), "b");
+
+    const dest = path.join(tmpRoot, "dest");
+    const result = service.copyDirectory(src, dest);
+
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(path.join(dest, "a.wav"), "utf-8")).toBe("a");
+    expect(fs.readFileSync(path.join(dest, "nested", "b.wav"), "utf-8")).toBe(
+      "b",
+    );
+  });
+
+  it("skips symlinks instead of following them", () => {
+    // A sensitive file outside the source tree.
+    const secret = path.join(tmpRoot, "secret.txt");
+    fs.writeFileSync(secret, "top secret");
+
+    const src = path.join(tmpRoot, "src");
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, "real.wav"), "real");
+    // A planted symlink pointing at the sensitive file.
+    fs.symlinkSync(secret, path.join(src, "link.txt"));
+
+    const dest = path.join(tmpRoot, "dest");
+    const result = service.copyDirectory(src, dest);
+
+    expect(result.success).toBe(true);
+    // The real file is copied...
+    expect(fs.readFileSync(path.join(dest, "real.wav"), "utf-8")).toBe("real");
+    // ...but the symlink is not, so the secret content never lands in dest.
+    expect(fs.existsSync(path.join(dest, "link.txt"))).toBe(false);
+  });
+
+  it("skips a symlinked subdirectory", () => {
+    const outsideDir = path.join(tmpRoot, "outside");
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, "leak.txt"), "leak");
+
+    const src = path.join(tmpRoot, "src");
+    fs.mkdirSync(src, { recursive: true });
+    fs.symlinkSync(outsideDir, path.join(src, "linkdir"));
+
+    const dest = path.join(tmpRoot, "dest");
+    const result = service.copyDirectory(src, dest);
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(dest, "linkdir"))).toBe(false);
+  });
+});

--- a/electron/main/services/archiveService.ts
+++ b/electron/main/services/archiveService.ts
@@ -96,9 +96,16 @@ export class ArchiveService {
     for (const item of fs.readdirSync(src)) {
       const srcItem = path.join(src, item);
       const destItem = path.join(dest, item);
-      if (fs.lstatSync(srcItem).isDirectory()) {
+      // Use lstat (no symlink following) and skip symlinks entirely: following
+      // them would copy the contents of files outside the source tree (e.g. a
+      // link planted in an SD-card folder pointing at a sensitive file).
+      const stats = fs.lstatSync(srcItem);
+      if (stats.isSymbolicLink()) {
+        continue;
+      }
+      if (stats.isDirectory()) {
         this.copyRecursiveSync(srcItem, destItem);
-      } else {
+      } else if (stats.isFile()) {
         fs.copyFileSync(srcItem, destItem);
       }
     }

--- a/electron/main/utils/__tests__/fileSystemUtils.test.ts
+++ b/electron/main/utils/__tests__/fileSystemUtils.test.ts
@@ -444,6 +444,18 @@ describe("fileSystemUtils", () => {
   describe("removeDirectorySafe", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      // Provide real-ish path semantics so the canonicalisation logic is
+      // exercised: resolve normalises ".." segments; sep is POSIX.
+      mockPath.resolve.mockImplementation((...segs: string[]) => {
+        const out: string[] = [];
+        for (const part of segs.join("/").split("/")) {
+          if (part === "" || part === ".") continue;
+          if (part === "..") out.pop();
+          else out.push(part);
+        }
+        return "/" + out.join("/");
+      });
+      (mockPath as { sep: string }).sep = "/";
     });
 
     it("should remove directory within .romperdb scope", () => {
@@ -461,6 +473,23 @@ describe("fileSystemUtils", () => {
 
     it("should refuse to remove directory outside .romperdb scope", () => {
       const result = removeDirectorySafe("/path/to/other");
+
+      expect(result.removed).toBe(false);
+      expect(result.error).toContain("Refusing to remove");
+      expect(mockFs.rmSync).not.toHaveBeenCalled();
+    });
+
+    it("should refuse a lookalike directory name (not an exact segment)", () => {
+      const result = removeDirectorySafe("/path/.romperdb-backup");
+
+      expect(result.removed).toBe(false);
+      expect(result.error).toContain("Refusing to remove");
+      expect(mockFs.rmSync).not.toHaveBeenCalled();
+    });
+
+    it("should refuse a traversal that escapes the .romperdb segment", () => {
+      // Resolves to /etc — no .romperdb segment survives normalisation.
+      const result = removeDirectorySafe("/path/.romperdb/../../etc");
 
       expect(result.removed).toBe(false);
       expect(result.error).toContain("Refusing to remove");

--- a/electron/main/utils/fileSystemUtils.ts
+++ b/electron/main/utils/fileSystemUtils.ts
@@ -160,23 +160,28 @@ export function getFileSize(filePath: string): number {
 
 /**
  * Removes a directory and its contents recursively.
- * Only removes directories under a known safe parent (must contain ".romperdb" in path).
+ * Only removes directories that have a ".romperdb" path segment, guarding
+ * against accidental removal of unrelated directories.
  */
 export function removeDirectorySafe(dirPath: string): {
   error?: string;
   removed: boolean;
 } {
   try {
-    if (!dirPath.includes(".romperdb")) {
+    // Canonicalize first so traversal (e.g. ".romperdb/../../etc") and
+    // lookalike names (e.g. ".romperdb-backup") cannot slip past the scope
+    // check via a naive substring match.
+    const resolved = path.resolve(dirPath);
+    if (!resolved.split(path.sep).includes(".romperdb")) {
       return {
         error: "Refusing to remove directory outside .romperdb scope",
         removed: false,
       };
     }
-    if (!fs.existsSync(dirPath)) {
+    if (!fs.existsSync(resolved)) {
       return { removed: true }; // Already gone
     }
-    fs.rmSync(dirPath, { force: true, recursive: true });
+    fs.rmSync(resolved, { force: true, recursive: true });
     return { removed: true };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

Finishes the security audit's two remaining low-severity findings.

### S8 — `removeDirectorySafe` scope check was a substring match

The guard used `dirPath.includes(".romperdb")`, which accepts lookalike names and traversal escapes:
- `/x/.romperdb-backup` → passed (substring), now **rejected** (not an exact segment).
- `/x/.romperdb/../../etc` → passed (substring), now **rejected** (resolves to `/etc`, no surviving `.romperdb` segment).

Fix: `path.resolve()` first (normalises `..`), then require an exact `.romperdb` **path segment** (`resolved.split(path.sep).includes(".romperdb")`). The only caller (`cleanup-partial-init`, which appends `.romperdb` itself) is unaffected.

### S10 — `ArchiveService.copyRecursiveSync` followed symlinks

`copyFileSync` follows symlinks, so a link planted in a copied source tree (e.g. an SD-card folder being imported) could copy the contents of a file *outside* the tree into the local store. Fix: `lstat` each entry and **skip symlinks** (both file and directory links); copy only real files and recurse only into real directories.

### Tests
- `removeDirectorySafe`: new unit cases for the lookalike name and the traversal escape, plus the existing happy/refuse/error cases updated to exercise the canonicalisation.
- `copyDirectory`: new real-filesystem test file proving a symlinked file and a symlinked subdirectory are skipped while real files/dirs copy normally.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

### Intentionally not changed
The sample-format validator's `statSync` (also listed under S10): it only reads 12 header bytes and never copies, and rejecting symlinks there would break legitimately symlinked sample libraries — not worth the breakage for zero copy-path exposure.

https://claude.ai/code/session_014jyLTNvc2HpXFA6w23KDfP

---
_Generated by [Claude Code](https://claude.ai/code/session_014jyLTNvc2HpXFA6w23KDfP)_