### PR TITLE
fix: stop swallowing settings persistence errors

### DIFF
--- a/app/renderer/utils/SettingsContext.tsx
+++ b/app/renderer/utils/SettingsContext.tsx
@@ -24,6 +24,7 @@ type SettingsAction =
     }
   | { payload: Settings; type: "INIT_SUCCESS" }
   | { payload: string; type: "INIT_ERROR" }
+  | { payload: string; type: "SET_ERROR" }
   | { payload: string; type: "UPDATE_LOCAL_STORE_PATH" }
   | { payload: ThemeMode; type: "UPDATE_THEME_MODE" }
   | { type: "CLEAR_ERROR" }
@@ -72,6 +73,12 @@ const initialState: SettingsState = {
   },
 };
 
+// Helper function to build a user-facing error message from a caught error
+function describeError(prefix: string, error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `${prefix}: ${detail}`;
+}
+
 // Helper function to detect system theme preference
 function getSystemThemePreference(): boolean {
   if (typeof globalThis !== "undefined" && globalThis.matchMedia) {
@@ -107,6 +114,9 @@ function settingsReducer(
         isLoading: false,
         settings: action.payload,
       };
+
+    case "SET_ERROR":
+      return { ...state, error: action.payload };
 
     case "UPDATE_CONFIRM_DESTRUCTIVE_ACTIONS":
       return {
@@ -215,6 +225,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
         await refreshLocalStoreStatus();
       } catch (error) {
         console.error("Failed to update local store path:", error);
+        dispatch({
+          payload: describeError("Failed to save local store path", error),
+          type: "SET_ERROR",
+        });
       }
     },
     [refreshLocalStoreStatus],
@@ -229,6 +243,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
         applyTheme(shouldUseDarkMode(mode));
       } catch (error) {
         console.error("Failed to update theme mode:", error);
+        dispatch({
+          payload: describeError("Failed to save theme mode", error),
+          type: "SET_ERROR",
+        });
       }
     },
     [applyTheme],
@@ -250,6 +268,13 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
         "Failed to update confirmDestructiveActions setting:",
         error,
       );
+      dispatch({
+        payload: describeError(
+          "Failed to save destructive-action confirmation setting",
+          error,
+        ),
+        type: "SET_ERROR",
+      });
     }
   }, []);
 

--- a/app/renderer/utils/__tests__/SettingsContext.test.tsx
+++ b/app/renderer/utils/__tests__/SettingsContext.test.tsx
@@ -194,7 +194,7 @@ describe("SettingsContext", () => {
   });
 
   describe("Error handling", () => {
-    it("handles setSetting errors", async () => {
+    it("surfaces setConfirmDestructiveActions failures in error state", async () => {
       mockElectronAPI.setSetting.mockRejectedValue(new Error("Save failed"));
 
       const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -216,6 +216,55 @@ describe("SettingsContext", () => {
         "Failed to update confirmDestructiveActions setting:",
         expect.any(Error),
       );
+      expect(result.current.error).toBe(
+        "Failed to save destructive-action confirmation setting: Save failed",
+      );
+      // The failed value must not be reflected in state
+      expect(result.current.confirmDestructiveActions).toBe(true);
+    });
+
+    it("surfaces setThemeMode failures in error state without changing the theme", async () => {
+      mockElectronAPI.setSetting.mockRejectedValue(new Error("Disk full"));
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SettingsProvider>{children}</SettingsProvider>
+      );
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      await act(async () => {
+        await result.current.setThemeMode("dark");
+      });
+
+      expect(result.current.error).toBe("Failed to save theme mode: Disk full");
+      expect(result.current.themeMode).toBe("light");
+    });
+
+    it("surfaces setLocalStorePath failures in error state without changing the path", async () => {
+      mockElectronAPI.setSetting.mockRejectedValue(new Error("EACCES"));
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SettingsProvider>{children}</SettingsProvider>
+      );
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      await act(async () => {
+        await result.current.setLocalStorePath("/new/path");
+      });
+
+      expect(result.current.error).toBe(
+        "Failed to save local store path: EACCES",
+      );
+      expect(result.current.localStorePath).toBe("/test/path");
     });
 
     it("clears error state", async () => {

--- a/electron/preload/__tests__/index.test.tsx
+++ b/electron/preload/__tests__/index.test.tsx
@@ -279,9 +279,7 @@ describe("preload/index.tsx", () => {
       delete process.env.ROMPER_LOCAL_PATH;
     });
 
-    it("returns environment variable in readSettings when settings read fails", async () => {
-      process.env.ROMPER_LOCAL_PATH = "/env/fallback/path";
-
+    it("rethrows when settings read fails so callers can react", async () => {
       // Mock console.error to avoid test noise
       const consoleErrorSpy = vi
         .spyOn(console, "error")
@@ -303,18 +301,18 @@ describe("preload/index.tsx", () => {
         );
       const api = electronAPICall[1];
 
-      const result = await api.readSettings();
-      expect(result).toEqual({ localStorePath: "/env/fallback/path" });
+      await expect(api.readSettings()).rejects.toThrow(
+        "Failed to read settings",
+      );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Failed to read settings:",
         expect.any(Error),
       );
 
       consoleErrorSpy.mockRestore();
-      delete process.env.ROMPER_LOCAL_PATH;
     });
 
-    it("handles setSetting write errors gracefully", async () => {
+    it("rethrows setSetting write errors so callers can react", async () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -335,8 +333,10 @@ describe("preload/index.tsx", () => {
         );
       const api = electronAPICall[1];
 
-      // Should not throw, but should log error
-      await api.setSetting("testKey", "testValue");
+      // A failed write must surface to the caller, not silently resolve
+      await expect(api.setSetting("testKey", "testValue")).rejects.toThrow(
+        "Write failed",
+      );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Failed to write settings:",
         expect.any(Error),

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -54,12 +54,7 @@ class SettingsManager {
       return parsedSettings;
     } catch (e) {
       console.error("Failed to read settings:", e);
-      // Even if reading settings fails, check for environment variable
-      const fallbackSettings: SettingsData = {};
-      if (process.env.ROMPER_LOCAL_PATH) {
-        fallbackSettings.localStorePath = process.env.ROMPER_LOCAL_PATH;
-      }
-      return fallbackSettings;
+      throw e;
     }
   }
 
@@ -74,6 +69,7 @@ class SettingsManager {
       await ipcRenderer.invoke("write-settings", key, value);
     } catch (e) {
       console.error("Failed to write settings:", e);
+      throw e;
     }
   }
 }


### PR DESCRIPTION
## Summary

First of the audit's **code-smell** follow-ups: the swallowed-errors cleanup, scoped to the settings persistence path where the swallow actually misleads the user.

### The bug shape

`SettingsManager.writeSettings` in the preload caught any IPC failure, logged it, and **resolved as if the write succeeded**. The renderer then updated its state (theme, local store path, confirmation toggle) with a value that was never persisted — everything looks fine until the next launch, when the setting silently reverts. Failed reads were similarly masked by returning empty fallback settings, so a broken settings read degraded to defaults with no signal.

### Changes

- **Preload** (`electron/preload/index.ts`): `readSettings` / `writeSettings` log and **rethrow** instead of swallowing. Every renderer call site already has try/catch handling, so this makes existing error paths reachable rather than adding risk — e.g. `useKitSync.handleSdCardPathChange` has a user-facing "Failed to save SD card path" warning that could never fire before.
- **SettingsContext** (`app/renderer/utils/SettingsContext.tsx`): the three setters (`setLocalStorePath`, `setThemeMode`, `setConfirmDestructiveActions`) now dispatch a new `SET_ERROR` action on failure, landing the message in the context's `error` state (already part of its contract alongside `clearError`) instead of only the console. Because the state dispatch follows the await, a failed write no longer produces an optimistic UI update that disagrees with disk.
- Init failures keep their existing `INIT_ERROR` path; the app still renders with defaults, but the error is now recorded instead of silently swallowed in the preload.

### Deliberately left unchanged

The audit also listed `console.warn`-and-continue sites in file/sync ops. On review these are intentional best-effort steps, not swallows that mislead:
- `syncService.handleSyncFailure` cleanup warn — rethrowing would mask the original sync error.
- `syncService.writeBankRtfFiles` — cosmetic RTF files, best-effort by design.
- `fileSystemUtils.getFileSize` — documented "return 0 on error" contract used for progress totals.
- `syncService.markKitsAsSynced` warn — a real candidate for surfacing in the sync result, but that changes the sync result contract; better as its own change if wanted.

### Tests

- Preload tests now assert the rethrow contract for both read and write failures (replacing tests that asserted the swallow).
- New `SettingsContext` cases for each setter: error message lands in `error` state and the failed value is **not** reflected in state.
- Full pre-commit gate passes locally (typecheck, lint, build, 532 integration + unit suite).

Follow-up worth noting: nothing currently *renders* `useSettings().error` outside init; wiring it into visible UI (status bar or inline in the preferences dialog) would complete the loop, but that's a UX decision rather than a smell fix.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_