### PR TITLE
refactor: split useLedVisualization into state, renderers, and animation loop

### DIFF
--- a/app/renderer/components/led-icon/__tests__/ledRenderers.test.ts
+++ b/app/renderer/components/led-icon/__tests__/ledRenderers.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Ripple } from "../../dialogs/led-grid/ledMath";
+
+import { renderAmbientLed, renderVuLed } from "../ledRenderers";
+import {
+  VU_BORDER_BRIGHTNESS,
+  VU_LIT_MIN_BRIGHTNESS,
+  VU_PEAK_BRIGHTNESS,
+  VU_UNLIT_BRIGHTNESS,
+} from "../vuMeterConstants";
+
+const GLOW = "224, 90, 96";
+const VOICE_GLOW = "10, 20, 30";
+
+const baseVuOptions = {
+  ambientMix: 0,
+  defaultGlowColor: GLOW,
+  rawTime: 100,
+  ripples: [] as Ripple[],
+  time: 1,
+  voiceBarHeights: { 1: 0, 2: 0, 3: 0, 4: 0 },
+  voiceGlowColors: { 1: VOICE_GLOW },
+  voicePeakRows: { 1: -1, 2: -1, 3: -1, 4: -1 },
+};
+
+describe("ledRenderers", () => {
+  let el: HTMLDivElement;
+
+  beforeEach(() => {
+    el = document.createElement("div");
+  });
+
+  describe("renderVuLed", () => {
+    it("paints border columns dim with no voice colour", () => {
+      renderVuLed({ ...baseVuOptions, col: 0, el, row: 2 });
+
+      expect(el.style.opacity).toBe(String(VU_BORDER_BRIGHTNESS));
+      expect(el.style.backgroundColor).toBe("");
+      expect(el.style.boxShadow).toBe("none");
+    });
+
+    it("paints unlit voice LEDs at the unlit floor with a faint voice colour", () => {
+      // Col 1 belongs to voice 1; bar height 0 means nothing is lit
+      renderVuLed({ ...baseVuOptions, col: 1, el, row: 0 });
+
+      expect(el.style.opacity).toBe(String(VU_UNLIT_BRIGHTNESS));
+      // Unlit LEDs keep a faint 0.05-alpha wash of the voice colour
+      expect(el.style.backgroundColor).toContain("0.05");
+    });
+
+    it("paints lit voice LEDs with brightness from the bar height", () => {
+      // Full bar on voice 1: bottom row is the dimmest lit LED
+      renderVuLed({
+        ...baseVuOptions,
+        col: 1,
+        el,
+        row: 4,
+        voiceBarHeights: { ...baseVuOptions.voiceBarHeights, 1: 5 },
+      });
+
+      expect(Number(el.style.opacity)).toBeCloseTo(VU_LIT_MIN_BRIGHTNESS);
+      expect(el.style.backgroundColor).not.toBe("");
+    });
+
+    it("paints the peak row at full brightness", () => {
+      renderVuLed({
+        ...baseVuOptions,
+        col: 1,
+        el,
+        row: 1,
+        voicePeakRows: { ...baseVuOptions.voicePeakRows, 1: 1 },
+      });
+
+      expect(Number(el.style.opacity)).toBe(VU_PEAK_BRIGHTNESS);
+      // Full brightness exceeds the 0.5 glow threshold
+      expect(el.style.boxShadow).not.toBe("none");
+    });
+
+    it("clears the voice colour and blends toward ambient when the cross-fade passes half", () => {
+      renderVuLed({
+        ...baseVuOptions,
+        ambientMix: 0.8,
+        col: 1,
+        el,
+        row: 1,
+        voicePeakRows: { ...baseVuOptions.voicePeakRows, 1: 1 },
+      });
+
+      expect(el.style.backgroundColor).toBe("");
+      // Blended: well below the pure peak brightness of 1
+      expect(Number(el.style.opacity)).toBeLessThan(VU_PEAK_BRIGHTNESS);
+      expect(Number(el.style.opacity)).toBeGreaterThan(0);
+    });
+
+    it("adds ripple boost on top of the base brightness", () => {
+      const without = document.createElement("div");
+      renderVuLed({ ...baseVuOptions, col: 1, el: without, row: 0 });
+
+      const ripple: Ripple = { col: 1, row: 0, startTime: 100 };
+      renderVuLed({ ...baseVuOptions, col: 1, el, ripples: [ripple], row: 0 });
+
+      expect(Number(el.style.opacity)).toBeGreaterThan(
+        Number(without.style.opacity),
+      );
+    });
+  });
+
+  describe("renderAmbientLed", () => {
+    const baseAmbientOptions = {
+      col: 3,
+      glowColor: GLOW,
+      isHovered: false,
+      mouse: null,
+      rawTime: 100,
+      ripples: [] as Ripple[],
+      row: 2,
+      time: 1,
+    };
+
+    it("paints a base LFO brightness with no background colour", () => {
+      renderAmbientLed({ ...baseAmbientOptions, el });
+
+      expect(el.style.backgroundColor).toBe("");
+      const opacity = Number(el.style.opacity);
+      expect(opacity).toBeGreaterThan(0);
+      expect(opacity).toBeLessThanOrEqual(1);
+    });
+
+    it("boosts brightness near the hovered cell", () => {
+      const idle = document.createElement("div");
+      renderAmbientLed({ ...baseAmbientOptions, el: idle });
+
+      renderAmbientLed({
+        ...baseAmbientOptions,
+        el,
+        isHovered: true,
+        mouse: { col: 3, row: 2 },
+      });
+
+      expect(Number(el.style.opacity)).toBeGreaterThan(
+        Number(idle.style.opacity),
+      );
+    });
+
+    it("ignores the mouse position when not hovered", () => {
+      const idle = document.createElement("div");
+      renderAmbientLed({ ...baseAmbientOptions, el: idle });
+
+      renderAmbientLed({
+        ...baseAmbientOptions,
+        el,
+        mouse: { col: 3, row: 2 },
+      });
+
+      expect(el.style.opacity).toBe(idle.style.opacity);
+    });
+  });
+});

--- a/app/renderer/components/led-icon/ledRenderers.ts
+++ b/app/renderer/components/led-icon/ledRenderers.ts
@@ -1,0 +1,169 @@
+import type { Ripple } from "../dialogs/led-grid/ledMath";
+
+import {
+  applyLedStyle,
+  computeBaseLfo,
+  computeProximityBoost,
+  computeRippleBoost,
+} from "../dialogs/led-grid/ledMath";
+import {
+  ICON_BASE_MIN,
+  ICON_BASE_SCALE,
+  ICON_PROXIMITY_INTENSITY,
+  ICON_PROXIMITY_RADIUS_SQ,
+  ICON_RIPPLE_DURATION,
+  ICON_RIPPLE_SPEED,
+  ICON_RIPPLE_WIDTH,
+  ICON_ROW_LFO_CONFIGS,
+} from "./ledIconConstants";
+import {
+  VU_BORDER_BRIGHTNESS,
+  VU_BORDER_COLS,
+  VU_UNLIT_BRIGHTNESS,
+  VU_VOICE_COLS,
+} from "./vuMeterConstants";
+import { computeVuLedBrightness } from "./vuMeterState";
+
+/**
+ * Per-LED paint functions for the LED icon's two visual modes: the ambient
+ * LFO animation and the per-voice VU meter. Called once per LED per frame by
+ * the animation loop in useLedVisualization.
+ */
+
+export interface AmbientLedOptions {
+  col: number;
+  el: HTMLElement;
+  glowColor: string;
+  isHovered: boolean;
+  mouse: { col: number; row: number } | null;
+  rawTime: number;
+  ripples: Ripple[];
+  row: number;
+  time: number;
+}
+
+export interface VuLedOptions {
+  ambientMix: number;
+  col: number;
+  defaultGlowColor: string;
+  el: HTMLElement;
+  rawTime: number;
+  ripples: Ripple[];
+  row: number;
+  time: number;
+  voiceBarHeights: Record<number, number>;
+  voiceGlowColors: Record<number, string>;
+  voicePeakRows: Record<number, number>;
+}
+
+// Build column-to-voice lookup table
+const colToVoice = new Map<number, number>();
+for (const [voice, cols] of Object.entries(VU_VOICE_COLS)) {
+  for (const col of cols) {
+    colToVoice.set(col, Number(voice));
+  }
+}
+
+const borderColSet = new Set(VU_BORDER_COLS);
+
+export function renderAmbientLed(options: AmbientLedOptions): void {
+  const { col, el, glowColor, isHovered, mouse, rawTime, ripples, row, time } =
+    options;
+  el.style.backgroundColor = "";
+  let brightness = computeAmbientBrightness(col, row, time);
+
+  if (isHovered && mouse) {
+    brightness += computeProximityBoost(
+      col,
+      row,
+      mouse.col,
+      mouse.row,
+      ICON_PROXIMITY_RADIUS_SQ,
+      ICON_PROXIMITY_INTENSITY,
+    );
+  }
+
+  brightness += addRippleBoost(col, row, rawTime, ripples);
+  applyLedStyle(el, brightness, glowColor);
+}
+
+export function renderVuLed(options: VuLedOptions): void {
+  const {
+    ambientMix,
+    col,
+    defaultGlowColor,
+    el,
+    rawTime,
+    ripples,
+    row,
+    time,
+    voiceBarHeights,
+    voiceGlowColors,
+    voicePeakRows,
+  } = options;
+  const voice = colToVoice.get(col);
+  const isBorder = borderColSet.has(col);
+
+  let brightness: number;
+  let glowColor: string;
+
+  if (isBorder) {
+    brightness = VU_BORDER_BRIGHTNESS;
+    glowColor = defaultGlowColor;
+    el.style.backgroundColor = "";
+  } else if (voice) {
+    brightness = computeVuLedBrightness(
+      row,
+      voiceBarHeights[voice],
+      voicePeakRows[voice],
+    );
+    glowColor = voiceGlowColors[voice] ?? defaultGlowColor;
+    const alpha = brightness > VU_UNLIT_BRIGHTNESS ? brightness : 0.05;
+    el.style.backgroundColor = `rgba(${glowColor}, ${alpha.toFixed(2)})`;
+  } else {
+    brightness = VU_UNLIT_BRIGHTNESS;
+    glowColor = defaultGlowColor;
+    el.style.backgroundColor = "";
+  }
+
+  if (ambientMix > 0) {
+    const ambientBrightness = computeAmbientBrightness(col, row, time);
+    brightness = brightness * (1 - ambientMix) + ambientBrightness * ambientMix;
+    if (ambientMix > 0.5) {
+      el.style.backgroundColor = "";
+    }
+  }
+
+  brightness += addRippleBoost(col, row, rawTime, ripples);
+  applyLedStyle(el, brightness, glowColor);
+}
+
+function addRippleBoost(
+  col: number,
+  row: number,
+  rawTime: number,
+  ripples: Ripple[],
+): number {
+  if (ripples.length === 0) return 0;
+  return computeRippleBoost(
+    col,
+    row,
+    rawTime,
+    ripples,
+    ICON_RIPPLE_SPEED,
+    ICON_RIPPLE_WIDTH,
+    ICON_RIPPLE_DURATION,
+  );
+}
+
+function computeAmbientBrightness(
+  col: number,
+  row: number,
+  time: number,
+): number {
+  const config = ICON_ROW_LFO_CONFIGS[row];
+  return (
+    ICON_BASE_MIN +
+    computeBaseLfo(col, row, time, config, ICON_BASE_SCALE) * ICON_BASE_SCALE
+  );
+}

--- a/app/renderer/components/led-icon/useLedVisualization.ts
+++ b/app/renderer/components/led-icon/useLedVisualization.ts
@@ -1,59 +1,38 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import type { Ripple } from "../dialogs/led-grid/ledMath";
+import type { CrossFadeState, VoiceVuState } from "./vuMeterState";
 
+import { readGlowColor, readVoiceGlowColor } from "../dialogs/led-grid/ledMath";
+import { hasActiveVoices } from "./audioLevels";
 import {
-  applyLedStyle,
-  computeBaseLfo,
-  computeProximityBoost,
-  computeRippleBoost,
-  readGlowColor,
-  readVoiceGlowColor,
-} from "../dialogs/led-grid/ledMath";
-import { getVoiceLevel, hasActiveVoices } from "./audioLevels";
-import {
-  ICON_BASE_MIN,
-  ICON_BASE_SCALE,
   ICON_COLS,
   ICON_LED_COUNT,
   ICON_MAX_RIPPLES,
-  ICON_PROXIMITY_INTENSITY,
-  ICON_PROXIMITY_RADIUS_SQ,
   ICON_RIPPLE_DURATION,
-  ICON_RIPPLE_SPEED,
-  ICON_RIPPLE_WIDTH,
-  ICON_ROW_LFO_CONFIGS,
-  ICON_ROWS,
   ICON_TIME_HOVER,
   ICON_TIME_IDLE,
 } from "./ledIconConstants";
+import { renderAmbientLed, renderVuLed } from "./ledRenderers";
 import {
-  VU_AMPLIFICATION,
-  VU_BORDER_BRIGHTNESS,
-  VU_BORDER_COLS,
-  VU_CROSSFADE_MS,
-  VU_DECAY_RATE,
-  VU_LIT_MAX_BRIGHTNESS,
-  VU_LIT_MIN_BRIGHTNESS,
-  VU_NOISE_FLOOR,
-  VU_PEAK_BRIGHTNESS,
-  VU_PEAK_DROP_INTERVAL,
-  VU_PEAK_HOLD_FRAMES,
-  VU_POWER_CURVE,
-  VU_SILENCE_THRESHOLD,
-  VU_UNLIT_BRIGHTNESS,
-  VU_VOICE_COLS,
-} from "./vuMeterConstants";
+  computeVoiceBar,
+  getVuState,
+  updateCrossFade,
+  updatePeakState,
+} from "./vuMeterState";
 
-export type VisualizationMode = "classic" | "screensaver";
+// Re-export the pure VU state machine for existing consumers/tests
+export type { CrossFadeState, VoiceVuState } from "./vuMeterState";
 
-// Per-voice VU state
-export interface VoiceVuState {
-  peakDropCounter: number;
-  peakHoldCounter: number;
-  peakRow: number; // -1 = no peak
-  smoothedLevel: number;
-}
+export {
+  computeVoiceBar,
+  computeVuLedBrightness,
+  decayPeak,
+  getVuState,
+  initVuState,
+  updateCrossFade,
+  updatePeakState,
+} from "./vuMeterState";
 
 interface UseLedVisualizationReturn {
   addRipple: (col: number, row: number) => void;
@@ -62,176 +41,11 @@ interface UseLedVisualizationReturn {
   setMousePosition: (col: number, row: number) => void;
 }
 
-// Build column-to-voice lookup table
-const colToVoice = new Map<number, number>();
-for (const [voice, cols] of Object.entries(VU_VOICE_COLS)) {
-  for (const col of cols) {
-    colToVoice.set(col, Number(voice));
-  }
-}
-
-const borderColSet = new Set(VU_BORDER_COLS);
-
-interface AmbientLedOptions {
-  col: number;
-  el: HTMLElement;
-  glowColor: string;
-  isHovered: boolean;
-  mouse: { col: number; row: number } | null;
-  rawTime: number;
-  ripples: Ripple[];
-  row: number;
-  time: number;
-}
-
-interface CrossFadeState {
-  ambientFade: number;
-  vuInactiveSince: null | number;
-  wasVuActive: boolean;
-}
-
-interface VuLedOptions {
-  ambientMix: number;
-  col: number;
-  defaultGlowColor: string;
-  el: HTMLElement;
-  rawTime: number;
-  ripples: Ripple[];
-  row: number;
-  time: number;
-  voiceBarHeights: Record<number, number>;
-  voiceGlowColors: Record<number, string>;
-  voicePeakRows: Record<number, number>;
-}
-
-/** Compute smoothed level and bar height for a voice */
-export function computeVoiceBar(state: VoiceVuState, voice: number): number {
-  const level = getVoiceLevel(voice);
-  const actualLevel = level ? Math.max(level.left, level.right) : 0;
-  state.smoothedLevel = Math.max(
-    actualLevel,
-    state.smoothedLevel * VU_DECAY_RATE,
-  );
-  // Below noise floor = dead silence (0 bar height)
-  if (state.smoothedLevel < VU_NOISE_FLOOR) return 0;
-  const scaled = Math.pow(
-    state.smoothedLevel * VU_AMPLIFICATION,
-    VU_POWER_CURVE,
-  );
-  return Math.min(ICON_ROWS, Math.max(0, scaled * ICON_ROWS));
-}
-
-/** Compute VU brightness for a single LED */
-export function computeVuLedBrightness(
-  row: number,
-  barHeight: number,
-  peakRow: number,
-): number {
-  const litThreshold = ICON_ROWS - barHeight;
-  const isLit = row >= litThreshold;
-  const isPeak = row === peakRow && peakRow >= 0;
-
-  if (isPeak) return VU_PEAK_BRIGHTNESS;
-  if (isLit) {
-    const posInBar =
-      barHeight > 0 ? (ICON_ROWS - 1 - row) / (ICON_ROWS - 1) : 0;
-    return (
-      VU_LIT_MIN_BRIGHTNESS +
-      posInBar * (VU_LIT_MAX_BRIGHTNESS - VU_LIT_MIN_BRIGHTNESS)
-    );
-  }
-  return VU_UNLIT_BRIGHTNESS;
-}
-
-export function decayPeak(state: VoiceVuState): void {
-  if (state.peakHoldCounter > 0) {
-    state.peakHoldCounter--;
-    return;
-  }
-  state.peakDropCounter++;
-  if (state.peakDropCounter >= VU_PEAK_DROP_INTERVAL) {
-    state.peakDropCounter = 0;
-    state.peakRow++;
-    if (state.peakRow >= ICON_ROWS) {
-      state.peakRow = -1;
-    }
-  }
-}
-
-export function getVuState(
-  states: Record<number, VoiceVuState>,
-  voice: number,
-): VoiceVuState {
-  if (!states[voice]) {
-    states[voice] = initVuState();
-  }
-  return states[voice];
-}
-
-export function initVuState(): VoiceVuState {
-  return {
-    peakDropCounter: 0,
-    peakHoldCounter: 0,
-    peakRow: -1,
-    smoothedLevel: 0,
-  };
-}
-
-export function updateCrossFade(
-  cf: CrossFadeState,
-  vuActive: boolean,
-  rawTime: number,
-  vuStates: Record<number, VoiceVuState>,
-): void {
-  if (vuActive) {
-    cf.wasVuActive = true;
-    cf.vuInactiveSince = null;
-    cf.ambientFade = 0;
-    return;
-  }
-
-  if (!cf.wasVuActive) {
-    cf.ambientFade = 1;
-    return;
-  }
-
-  const allDecayed = Object.values(vuStates).every(
-    (s) => s.smoothedLevel < VU_SILENCE_THRESHOLD,
-  );
-  if (!allDecayed) return;
-
-  cf.vuInactiveSince ??= rawTime;
-  const elapsed = (rawTime - cf.vuInactiveSince) * 1000;
-  cf.ambientFade = Math.min(1, elapsed / VU_CROSSFADE_MS);
-  if (cf.ambientFade >= 1) {
-    cf.wasVuActive = false;
-    cf.vuInactiveSince = null;
-  }
-}
-
-/** Update peak hold/drop state and return current peak row */
-export function updatePeakState(state: VoiceVuState, barHeight: number): void {
-  const currentTopRow = ICON_ROWS - Math.ceil(barHeight);
-
-  if (barHeight > 0 && currentTopRow <= state.peakRow) {
-    state.peakRow = currentTopRow;
-    state.peakHoldCounter = VU_PEAK_HOLD_FRAMES;
-    state.peakDropCounter = 0;
-    return;
-  }
-
-  if (state.peakRow >= 0) {
-    decayPeak(state);
-    return;
-  }
-
-  if (barHeight > 0) {
-    state.peakRow = currentTopRow;
-    state.peakHoldCounter = VU_PEAK_HOLD_FRAMES;
-    state.peakDropCounter = 0;
-  }
-}
-
+/**
+ * Animation loop for the LED icon. Owns the rAF driver, time/hover speed
+ * handling, and the pointer/ripple interaction API; per-frame VU state comes
+ * from vuMeterState and per-LED painting from ledRenderers.
+ */
 export function useLedVisualization(
   isHoveredRef: React.RefObject<boolean>,
 ): UseLedVisualizationReturn {
@@ -371,106 +185,4 @@ export function useLedVisualization(
   }, []);
 
   return { addRipple, clearMousePosition, ledRefs, setMousePosition };
-}
-
-function addRippleBoost(
-  col: number,
-  row: number,
-  rawTime: number,
-  ripples: Ripple[],
-): number {
-  if (ripples.length === 0) return 0;
-  return computeRippleBoost(
-    col,
-    row,
-    rawTime,
-    ripples,
-    ICON_RIPPLE_SPEED,
-    ICON_RIPPLE_WIDTH,
-    ICON_RIPPLE_DURATION,
-  );
-}
-
-function computeAmbientBrightness(
-  col: number,
-  row: number,
-  time: number,
-): number {
-  const config = ICON_ROW_LFO_CONFIGS[row];
-  return (
-    ICON_BASE_MIN +
-    computeBaseLfo(col, row, time, config, ICON_BASE_SCALE) * ICON_BASE_SCALE
-  );
-}
-
-function renderAmbientLed(options: AmbientLedOptions): void {
-  const { col, el, glowColor, isHovered, mouse, rawTime, ripples, row, time } =
-    options;
-  el.style.backgroundColor = "";
-  let brightness = computeAmbientBrightness(col, row, time);
-
-  if (isHovered && mouse) {
-    brightness += computeProximityBoost(
-      col,
-      row,
-      mouse.col,
-      mouse.row,
-      ICON_PROXIMITY_RADIUS_SQ,
-      ICON_PROXIMITY_INTENSITY,
-    );
-  }
-
-  brightness += addRippleBoost(col, row, rawTime, ripples);
-  applyLedStyle(el, brightness, glowColor);
-}
-
-function renderVuLed(options: VuLedOptions): void {
-  const {
-    ambientMix,
-    col,
-    defaultGlowColor,
-    el,
-    rawTime,
-    ripples,
-    row,
-    time,
-    voiceBarHeights,
-    voiceGlowColors,
-    voicePeakRows,
-  } = options;
-  const voice = colToVoice.get(col);
-  const isBorder = borderColSet.has(col);
-
-  let brightness: number;
-  let glowColor: string;
-
-  if (isBorder) {
-    brightness = VU_BORDER_BRIGHTNESS;
-    glowColor = defaultGlowColor;
-    el.style.backgroundColor = "";
-  } else if (voice) {
-    brightness = computeVuLedBrightness(
-      row,
-      voiceBarHeights[voice],
-      voicePeakRows[voice],
-    );
-    glowColor = voiceGlowColors[voice] ?? defaultGlowColor;
-    const alpha = brightness > VU_UNLIT_BRIGHTNESS ? brightness : 0.05;
-    el.style.backgroundColor = `rgba(${glowColor}, ${alpha.toFixed(2)})`;
-  } else {
-    brightness = VU_UNLIT_BRIGHTNESS;
-    glowColor = defaultGlowColor;
-    el.style.backgroundColor = "";
-  }
-
-  if (ambientMix > 0) {
-    const ambientBrightness = computeAmbientBrightness(col, row, time);
-    brightness = brightness * (1 - ambientMix) + ambientBrightness * ambientMix;
-    if (ambientMix > 0.5) {
-      el.style.backgroundColor = "";
-    }
-  }
-
-  brightness += addRippleBoost(col, row, rawTime, ripples);
-  applyLedStyle(el, brightness, glowColor);
 }

--- a/app/renderer/components/led-icon/vuMeterState.ts
+++ b/app/renderer/components/led-icon/vuMeterState.ts
@@ -1,0 +1,165 @@
+import { getVoiceLevel } from "./audioLevels";
+import { ICON_ROWS } from "./ledIconConstants";
+import {
+  VU_AMPLIFICATION,
+  VU_CROSSFADE_MS,
+  VU_DECAY_RATE,
+  VU_LIT_MAX_BRIGHTNESS,
+  VU_LIT_MIN_BRIGHTNESS,
+  VU_NOISE_FLOOR,
+  VU_PEAK_BRIGHTNESS,
+  VU_PEAK_DROP_INTERVAL,
+  VU_PEAK_HOLD_FRAMES,
+  VU_POWER_CURVE,
+  VU_SILENCE_THRESHOLD,
+  VU_UNLIT_BRIGHTNESS,
+} from "./vuMeterConstants";
+
+/**
+ * Pure VU-meter state machine for the LED icon: per-voice level smoothing,
+ * bar heights, peak hold/decay, and the VU-to-ambient cross-fade. No DOM
+ * access — everything here is driven by the animation loop in
+ * useLedVisualization and unit-testable in isolation.
+ */
+
+export interface CrossFadeState {
+  ambientFade: number;
+  vuInactiveSince: null | number;
+  wasVuActive: boolean;
+}
+
+// Per-voice VU state
+export interface VoiceVuState {
+  peakDropCounter: number;
+  peakHoldCounter: number;
+  peakRow: number; // -1 = no peak
+  smoothedLevel: number;
+}
+
+/** Compute smoothed level and bar height for a voice */
+export function computeVoiceBar(state: VoiceVuState, voice: number): number {
+  const level = getVoiceLevel(voice);
+  const actualLevel = level ? Math.max(level.left, level.right) : 0;
+  state.smoothedLevel = Math.max(
+    actualLevel,
+    state.smoothedLevel * VU_DECAY_RATE,
+  );
+  // Below noise floor = dead silence (0 bar height)
+  if (state.smoothedLevel < VU_NOISE_FLOOR) return 0;
+  const scaled = Math.pow(
+    state.smoothedLevel * VU_AMPLIFICATION,
+    VU_POWER_CURVE,
+  );
+  return Math.min(ICON_ROWS, Math.max(0, scaled * ICON_ROWS));
+}
+
+/** Compute VU brightness for a single LED */
+export function computeVuLedBrightness(
+  row: number,
+  barHeight: number,
+  peakRow: number,
+): number {
+  const litThreshold = ICON_ROWS - barHeight;
+  const isLit = row >= litThreshold;
+  const isPeak = row === peakRow && peakRow >= 0;
+
+  if (isPeak) return VU_PEAK_BRIGHTNESS;
+  if (isLit) {
+    const posInBar =
+      barHeight > 0 ? (ICON_ROWS - 1 - row) / (ICON_ROWS - 1) : 0;
+    return (
+      VU_LIT_MIN_BRIGHTNESS +
+      posInBar * (VU_LIT_MAX_BRIGHTNESS - VU_LIT_MIN_BRIGHTNESS)
+    );
+  }
+  return VU_UNLIT_BRIGHTNESS;
+}
+
+export function decayPeak(state: VoiceVuState): void {
+  if (state.peakHoldCounter > 0) {
+    state.peakHoldCounter--;
+    return;
+  }
+  state.peakDropCounter++;
+  if (state.peakDropCounter >= VU_PEAK_DROP_INTERVAL) {
+    state.peakDropCounter = 0;
+    state.peakRow++;
+    if (state.peakRow >= ICON_ROWS) {
+      state.peakRow = -1;
+    }
+  }
+}
+
+export function getVuState(
+  states: Record<number, VoiceVuState>,
+  voice: number,
+): VoiceVuState {
+  if (!states[voice]) {
+    states[voice] = initVuState();
+  }
+  return states[voice];
+}
+
+export function initVuState(): VoiceVuState {
+  return {
+    peakDropCounter: 0,
+    peakHoldCounter: 0,
+    peakRow: -1,
+    smoothedLevel: 0,
+  };
+}
+
+export function updateCrossFade(
+  cf: CrossFadeState,
+  vuActive: boolean,
+  rawTime: number,
+  vuStates: Record<number, VoiceVuState>,
+): void {
+  if (vuActive) {
+    cf.wasVuActive = true;
+    cf.vuInactiveSince = null;
+    cf.ambientFade = 0;
+    return;
+  }
+
+  if (!cf.wasVuActive) {
+    cf.ambientFade = 1;
+    return;
+  }
+
+  const allDecayed = Object.values(vuStates).every(
+    (s) => s.smoothedLevel < VU_SILENCE_THRESHOLD,
+  );
+  if (!allDecayed) return;
+
+  cf.vuInactiveSince ??= rawTime;
+  const elapsed = (rawTime - cf.vuInactiveSince) * 1000;
+  cf.ambientFade = Math.min(1, elapsed / VU_CROSSFADE_MS);
+  if (cf.ambientFade >= 1) {
+    cf.wasVuActive = false;
+    cf.vuInactiveSince = null;
+  }
+}
+
+/** Update peak hold/drop state and return current peak row */
+export function updatePeakState(state: VoiceVuState, barHeight: number): void {
+  const currentTopRow = ICON_ROWS - Math.ceil(barHeight);
+
+  if (barHeight > 0 && currentTopRow <= state.peakRow) {
+    state.peakRow = currentTopRow;
+    state.peakHoldCounter = VU_PEAK_HOLD_FRAMES;
+    state.peakDropCounter = 0;
+    return;
+  }
+
+  if (state.peakRow >= 0) {
+    decayPeak(state);
+    return;
+  }
+
+  if (barHeight > 0) {
+    state.peakRow = currentTopRow;
+    state.peakHoldCounter = VU_PEAK_HOLD_FRAMES;
+    state.peakDropCounter = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Second slice of the audit's **mega-hook backlog**: `useLedVisualization.ts` was a 476-line module stacking three distinct layers — a pure VU-meter state machine, per-LED DOM paint functions, and the React hook driving the `requestAnimationFrame` loop. This splits along those seams; the seams were already visible in the code (the state machine was exported for tests, the renderers were module-private).

### New layout (`components/led-icon/`)

| File | Contents |
|---|---|
| `vuMeterState.ts` | The pure per-voice state machine: level smoothing, bar heights, peak hold/decay, VU↔ambient cross-fade, plus `VoiceVuState` / `CrossFadeState`. No DOM access. |
| `ledRenderers.ts` | `renderAmbientLed` / `renderVuLed` with their option types, the column→voice lookup tables, and the shared brightness/ripple helpers. |
| `useLedVisualization.ts` | Just the hook (~190 lines): refs, the rAF animation loop, hover-speed time handling, and the pointer/ripple API. |

The VU state machine is **re-exported from `useLedVisualization`**, so the existing test imports and any other consumers keep working; `LedIconGrid` and the `useMiniLedAnimation` alias are untouched. Also drops the exported-but-unused `VisualizationMode` type (no references anywhere).

### Validation

- All code is moved verbatim — no logic edits.
- The existing led-icon suites (**78 tests**, including the VU state-machine cases that import from `useLedVisualization`) pass **unmodified**.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

Remaining mega-hook from the backlog: `useLocalStoreWizard` (342 lines), coming as its own PR.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_