### PR TITLE
refactor: slim useLocalStoreWizard orchestrator

### DIFF
--- a/app/renderer/components/hooks/wizard/__tests__/useWizardProgress.test.ts
+++ b/app/renderer/components/hooks/wizard/__tests__/useWizardProgress.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useWizardProgress } from "../useWizardProgress";
+
+describe("useWizardProgress", () => {
+  it("fans progress out to wizard state and the external callback", () => {
+    const setProgress = vi.fn();
+    const onProgress = vi.fn();
+    const { result } = renderHook(() =>
+      useWizardProgress(setProgress, onProgress),
+    );
+
+    result.current.reportProgress({ percent: 42, phase: "Copying" });
+
+    expect(setProgress).toHaveBeenCalledWith({ percent: 42, phase: "Copying" });
+    expect(onProgress).toHaveBeenCalledWith({ percent: 42, phase: "Copying" });
+  });
+
+  it("works without an external callback", () => {
+    const setProgress = vi.fn();
+    const { result } = renderHook(() => useWizardProgress(setProgress));
+
+    result.current.reportProgress({ percent: 1, phase: "x" });
+    expect(setProgress).toHaveBeenCalledWith({ percent: 1, phase: "x" });
+  });
+
+  it("reports sequential per-item progress and a final 100%", async () => {
+    const setProgress = vi.fn();
+    const seen: Array<{ idx: number; item: string }> = [];
+    const { result } = renderHook(() => useWizardProgress(setProgress));
+
+    await result.current.reportStepProgress({
+      items: ["a", "b"],
+      onStep: async (item, idx) => {
+        seen.push({ idx, item });
+      },
+      phase: "Scanning",
+    });
+
+    expect(seen).toEqual([
+      { idx: 0, item: "a" },
+      { idx: 1, item: "b" },
+    ]);
+    expect(setProgress).toHaveBeenNthCalledWith(1, {
+      currentKit: 1,
+      file: "a",
+      kitName: "a",
+      percent: 50,
+      phase: "Scanning",
+      totalKits: 2,
+    });
+    expect(setProgress).toHaveBeenNthCalledWith(2, {
+      currentKit: 2,
+      file: "b",
+      kitName: "b",
+      percent: 100,
+      phase: "Scanning",
+      totalKits: 2,
+    });
+    expect(setProgress).toHaveBeenLastCalledWith({
+      percent: 100,
+      phase: "Scanning",
+    });
+  });
+
+  it("does not emit a completion event for an empty item list", async () => {
+    const setProgress = vi.fn();
+    const { result } = renderHook(() => useWizardProgress(setProgress));
+
+    await result.current.reportStepProgress({
+      items: [],
+      onStep: async () => {},
+      phase: "Scanning",
+    });
+
+    expect(setProgress).not.toHaveBeenCalled();
+  });
+});

--- a/app/renderer/components/hooks/wizard/__tests__/wizardInitUtils.test.ts
+++ b/app/renderer/components/hooks/wizard/__tests__/wizardInitUtils.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ElectronAPI } from "../../../../electron.d";
+
+import {
+  getElectronAPI,
+  normalizeErrorMessage,
+  runPreChecks,
+} from "../wizardInitUtils";
+
+describe("wizardInitUtils", () => {
+  describe("normalizeErrorMessage", () => {
+    it("maps premature close to an actionable download message", () => {
+      expect(normalizeErrorMessage("premature close")).toContain(
+        "Download failed",
+      );
+    });
+
+    it("passes other messages through unchanged", () => {
+      expect(normalizeErrorMessage("disk on fire")).toBe("disk on fire");
+    });
+  });
+
+  describe("getElectronAPI", () => {
+    it("returns the global electronAPI when present", () => {
+      expect(getElectronAPI()).toBe(globalThis.electronAPI);
+    });
+  });
+
+  describe("runPreChecks", () => {
+    const writable = vi
+      .fn()
+      .mockResolvedValue({ writable: true } as { writable: boolean });
+
+    it("throws when the target path is not writable", async () => {
+      const api = {
+        checkPathWritable: vi.fn().mockResolvedValue({ writable: false }),
+      } as unknown as ElectronAPI;
+
+      await expect(runPreChecks(api, "/target", "squarp")).rejects.toThrow(
+        "Cannot write to /target",
+      );
+    });
+
+    it("throws with sizes when disk space is insufficient", async () => {
+      const api = {
+        checkDiskSpace: vi.fn().mockResolvedValue({
+          availableBytes: 100 * 1024 * 1024,
+          requiredBytes: 1024 * 1024 * 1024,
+          sufficient: false,
+        }),
+        checkPathWritable: writable,
+      } as unknown as ElectronAPI;
+
+      await expect(runPreChecks(api, "/target", "squarp")).rejects.toThrow(
+        "Need ~1024 MB but only 100 MB available",
+      );
+    });
+
+    it("requires less space for sdcard than squarp", async () => {
+      const checkDiskSpace = vi
+        .fn()
+        .mockResolvedValue({ sufficient: true } as { sufficient: boolean });
+      const api = {
+        checkDiskSpace,
+        checkPathWritable: writable,
+      } as unknown as ElectronAPI;
+
+      await runPreChecks(api, "/target", "squarp");
+      expect(checkDiskSpace).toHaveBeenLastCalledWith(
+        "/target",
+        1024 * 1024 * 1024,
+      );
+
+      await runPreChecks(api, "/target", "sdcard");
+      expect(checkDiskSpace).toHaveBeenLastCalledWith(
+        "/target",
+        500 * 1024 * 1024,
+      );
+    });
+
+    it("skips the disk space check for a blank store", async () => {
+      const checkDiskSpace = vi.fn();
+      const api = {
+        checkDiskSpace,
+        checkPathWritable: writable,
+      } as unknown as ElectronAPI;
+
+      await runPreChecks(api, "/target", "blank");
+      expect(checkDiskSpace).not.toHaveBeenCalled();
+    });
+
+    it("skips checks the API does not provide", async () => {
+      await expect(
+        runPreChecks({} as ElectronAPI, "/target", "squarp"),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
+++ b/app/renderer/components/hooks/wizard/useLocalStoreWizard.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { ElectronAPI } from "../../../electron.d";
 
 import { config } from "../../../config";
+import { createLogger } from "../../../utils/logger";
 import { useLocalStoreWizardFileOps } from "./useLocalStoreWizardFileOps";
 import { useLocalStoreWizardScanning } from "./useLocalStoreWizardScanning";
 import {
@@ -10,6 +11,12 @@ import {
   type ProgressEvent,
   useLocalStoreWizardState,
 } from "./useLocalStoreWizardState";
+import { useWizardProgress } from "./useWizardProgress";
+import {
+  getElectronAPI,
+  normalizeErrorMessage,
+  runPreChecks,
+} from "./wizardInitUtils";
 
 // Re-export types for convenience
 export type { LocalStoreSource, ProgressEvent };
@@ -21,57 +28,23 @@ declare global {
   }
 }
 
+const log = createLogger("LocalStoreWizard");
+
 // --- Main Hook ---
 export function useLocalStoreWizard(
   onProgress?: (p: ProgressEvent) => void,
   setLocalStorePath?: (path: string) => void,
 ) {
   const api = useElectronAPI();
-  const progressCb = useRef(onProgress);
-  progressCb.current = onProgress;
 
   // State management hook
   const stateHook = useLocalStoreWizardState({ api });
   const { defaultPath, progress, state } = stateHook;
 
-  // --- Progress reporting ---
-  const reportProgress = useCallback(
-    (p: ProgressEvent) => {
-      stateHook.setProgress(p);
-      if (progressCb.current) progressCb.current(p);
-    },
-    [stateHook],
-  );
-
-  // --- Progress reporting helper ---
-  const reportStepProgress = useCallback(
-    ({
-      items,
-      onStep,
-      phase,
-    }: {
-      items: string[];
-      onStep: (item: string, idx: number) => Promise<void>;
-      phase: string;
-    }) => {
-      // Sequentially process items for correct progress updates
-      return (async () => {
-        for (let idx = 0; idx < items.length; idx++) {
-          const item = items[idx];
-          reportProgress({
-            currentKit: idx + 1,
-            file: item,
-            kitName: item,
-            percent: Math.round(((idx + 1) / items.length) * 100),
-            phase,
-            totalKits: items.length,
-          });
-          await onStep(item, idx);
-        }
-        if (items.length > 0) reportProgress({ percent: 100, phase });
-      })();
-    },
-    [reportProgress],
+  // Progress reporting (wizard state + optional external callback)
+  const { reportProgress, reportStepProgress } = useWizardProgress(
+    stateHook.setProgress,
+    onProgress,
   );
 
   // File operations hook
@@ -91,60 +64,41 @@ export function useLocalStoreWizard(
 
   // Helper function to set the local store path
   const setLocalStorePathHelper = useCallback(async () => {
-    const isDev = process.env.NODE_ENV === "development";
-    isDev &&
-      console.debug(
-        "[Hook] setLocalStorePath callback available:",
-        !!setLocalStorePath,
-      );
-    isDev && console.debug("[Hook] state.targetPath:", state.targetPath);
+    log.debug(
+      `setLocalStorePath callback available: ${!!setLocalStorePath}, targetPath: ${state.targetPath}`,
+    );
 
     if (setLocalStorePath) {
-      isDev &&
-        console.debug(
-          "[Hook] Calling setLocalStorePath with:",
-          state.targetPath,
-        );
       setLocalStorePath(state.targetPath);
-      isDev && console.debug("[Hook] setLocalStorePath called successfully");
     } else if (api.setSetting) {
-      isDev && console.debug("[Hook] Falling back to api.setSetting");
+      log.debug("Falling back to api.setSetting");
       await api.setSetting("localStorePath", state.targetPath);
-      isDev && console.debug("[Hook] api.setSetting called successfully");
     } else {
-      isDev &&
-        console.debug("[Hook] No method available to set local store path!");
+      log.debug("No method available to set local store path!");
     }
   }, [state.targetPath, setLocalStorePath, api]);
 
   // Helper function to handle source-specific operations
   const processSource = useCallback(async () => {
-    const isDev = process.env.NODE_ENV === "development";
-
     if (state.source === "sdcard") {
       if (!state.sdCardSourcePath) throw new Error("No SD card path selected");
-      isDev && console.debug("[Hook] initialize - copying SD card kits");
+      log.debug("initialize - copying SD card kits");
       await fileOpsHook.validateAndCopySdCardKits(
         state.sdCardSourcePath,
         state.targetPath,
       );
     } else if (state.source === "squarp") {
-      isDev && console.debug("[Hook] initialize - extracting Squarp archive");
+      log.debug("initialize - extracting Squarp archive");
       await fileOpsHook.extractSquarpArchive(state.targetPath);
-      isDev &&
-        console.debug(
-          "[Hook] initialize - Squarp archive extraction completed",
-        );
+      log.debug("initialize - Squarp archive extraction completed");
       // Add a small delay to ensure filesystem sync
       await new Promise((resolve) => setTimeout(resolve, 100));
-      isDev &&
-        console.debug("[Hook] initialize - filesystem sync delay completed");
+      log.debug("initialize - filesystem sync delay completed");
     }
   }, [state.source, state.sdCardSourcePath, state.targetPath, fileOpsHook]);
 
   const initialize = useCallback(async () => {
-    const isDev = process.env.NODE_ENV === "development";
-    isDev && console.debug("[Hook] initialize starting with state:", state);
+    log.debug("initialize starting");
     stateHook.setIsInitializing(true);
     stateHook.setError(null);
     stateHook.setProgress(null);
@@ -161,29 +115,26 @@ export function useLocalStoreWizard(
       await processSource();
 
       // Create and populate database
-      isDev &&
-        console.debug("[Hook] initialize - creating and populating database");
+      log.debug("initialize - creating and populating database");
       const { dbDir, truncationWarnings, validKits } =
         await fileOpsHook.createAndPopulateDb(state.targetPath);
-      isDev && console.debug("[Hook] initialize - database creation completed");
+      log.debug("initialize - database creation completed");
       if (truncationWarnings && truncationWarnings.length > 0) {
         stateHook.setWizardState({ truncationWarnings });
       }
 
       // Run scanning operations as the final step
-      isDev &&
-        console.debug("[Hook] initialize - starting scanning operations");
+      log.debug("initialize - starting scanning operations");
       await scanningHook.runScanning(state.targetPath, dbDir, validKits);
-      isDev &&
-        console.debug("[Hook] initialize - scanning operations completed");
+      log.debug("initialize - scanning operations completed");
 
       // Set the local store path only after everything is ready
       await setLocalStorePathHelper();
 
-      isDev && console.debug("[Hook] initialize completed successfully");
+      log.debug("initialize completed successfully");
       return { success: true };
     } catch (e: unknown) {
-      console.error("[Hook] initialize error:", e);
+      log.error("initialize error:", e);
       const errorMessage = e instanceof Error ? e.message : "Unknown error";
       stateHook.setError(normalizeErrorMessage(errorMessage));
 
@@ -191,10 +142,7 @@ export function useLocalStoreWizard(
       if (state.targetPath && api.cleanupPartialInit) {
         try {
           await api.cleanupPartialInit(state.targetPath);
-          isDev &&
-            console.debug(
-              "[Hook] Cleaned up partial .romperdb after failed initialization",
-            );
+          log.debug("Cleaned up partial .romperdb after failed initialization");
         } catch {
           // Cleanup is best-effort; don't mask the original error
         }
@@ -290,51 +238,6 @@ export function useLocalStoreWizard(
       fileOpsHook.validateSdCardFolder,
     ],
   );
-}
-
-function getElectronAPI(): ElectronAPI {
-  // Use type assertion to avoid type conflict with window.electronAPI
-  return typeof globalThis !== "undefined" && globalThis.electronAPI
-    ? globalThis.electronAPI
-    : ({} as ElectronAPI);
-}
-
-function normalizeErrorMessage(msg: string) {
-  if (msg.includes("premature close")) {
-    return "Download failed: The connection was closed before completion. Please check your internet connection and try again.";
-  }
-  return msg;
-}
-
-// --- Error message normalization ---
-async function runPreChecks(
-  api: ElectronAPI,
-  targetPath: string,
-  source: LocalStoreSource,
-) {
-  if (api.checkPathWritable) {
-    const writableResult = await api.checkPathWritable(targetPath);
-    if (!writableResult.writable) {
-      throw new Error(
-        `Cannot write to ${targetPath}. Please choose a folder you have permission to write to.`,
-      );
-    }
-  }
-
-  if (api.checkDiskSpace && source !== "blank") {
-    const requiredBytes =
-      source === "squarp" ? 1024 * 1024 * 1024 : 500 * 1024 * 1024;
-    const spaceResult = await api.checkDiskSpace(targetPath, requiredBytes);
-    if (!spaceResult.sufficient) {
-      const availableMB = Math.round(
-        spaceResult.availableBytes / (1024 * 1024),
-      );
-      const requiredMB = Math.round(spaceResult.requiredBytes / (1024 * 1024));
-      throw new Error(
-        `Not enough disk space. Need ~${requiredMB} MB but only ${availableMB} MB available at ${targetPath}.`,
-      );
-    }
-  }
 }
 
 function useElectronAPI(): ElectronAPI {

--- a/app/renderer/components/hooks/wizard/useWizardProgress.ts
+++ b/app/renderer/components/hooks/wizard/useWizardProgress.ts
@@ -1,0 +1,55 @@
+import { useCallback, useRef } from "react";
+
+import type { ProgressEvent } from "./useLocalStoreWizardState";
+
+export interface StepProgressParams {
+  items: string[];
+  onStep: (item: string, idx: number) => Promise<void>;
+  phase: string;
+}
+
+/**
+ * Progress reporting for the local store wizard: fans each progress event out
+ * to the wizard's own state and the optional external onProgress callback,
+ * and provides the sequential per-item step driver used by the file-ops and
+ * scanning phases.
+ */
+export function useWizardProgress(
+  setProgress: (p: null | ProgressEvent) => void,
+  onProgress?: (p: ProgressEvent) => void,
+) {
+  const progressCb = useRef(onProgress);
+  progressCb.current = onProgress;
+
+  const reportProgress = useCallback(
+    (p: ProgressEvent) => {
+      setProgress(p);
+      if (progressCb.current) progressCb.current(p);
+    },
+    [setProgress],
+  );
+
+  const reportStepProgress = useCallback(
+    ({ items, onStep, phase }: StepProgressParams) => {
+      // Sequentially process items for correct progress updates
+      return (async () => {
+        for (let idx = 0; idx < items.length; idx++) {
+          const item = items[idx];
+          reportProgress({
+            currentKit: idx + 1,
+            file: item,
+            kitName: item,
+            percent: Math.round(((idx + 1) / items.length) * 100),
+            phase,
+            totalKits: items.length,
+          });
+          await onStep(item, idx);
+        }
+        if (items.length > 0) reportProgress({ percent: 100, phase });
+      })();
+    },
+    [reportProgress],
+  );
+
+  return { reportProgress, reportStepProgress };
+}

--- a/app/renderer/components/hooks/wizard/wizardInitUtils.ts
+++ b/app/renderer/components/hooks/wizard/wizardInitUtils.ts
@@ -1,0 +1,53 @@
+import type { ElectronAPI } from "../../../electron.d";
+
+import { type LocalStoreSource } from "./useLocalStoreWizardState";
+
+/**
+ * Pure helpers for the local store wizard's initialization flow.
+ */
+
+export function getElectronAPI(): ElectronAPI {
+  // Use type assertion to avoid type conflict with window.electronAPI
+  return typeof globalThis !== "undefined" && globalThis.electronAPI
+    ? globalThis.electronAPI
+    : ({} as ElectronAPI);
+}
+
+/** Map low-level error strings to actionable user-facing messages */
+export function normalizeErrorMessage(msg: string) {
+  if (msg.includes("premature close")) {
+    return "Download failed: The connection was closed before completion. Please check your internet connection and try again.";
+  }
+  return msg;
+}
+
+/** Verify the target is writable and has enough space for the chosen source */
+export async function runPreChecks(
+  api: ElectronAPI,
+  targetPath: string,
+  source: LocalStoreSource,
+) {
+  if (api.checkPathWritable) {
+    const writableResult = await api.checkPathWritable(targetPath);
+    if (!writableResult.writable) {
+      throw new Error(
+        `Cannot write to ${targetPath}. Please choose a folder you have permission to write to.`,
+      );
+    }
+  }
+
+  if (api.checkDiskSpace && source !== "blank") {
+    const requiredBytes =
+      source === "squarp" ? 1024 * 1024 * 1024 : 500 * 1024 * 1024;
+    const spaceResult = await api.checkDiskSpace(targetPath, requiredBytes);
+    if (!spaceResult.sufficient) {
+      const availableMB = Math.round(
+        spaceResult.availableBytes / (1024 * 1024),
+      );
+      const requiredMB = Math.round(spaceResult.requiredBytes / (1024 * 1024));
+      throw new Error(
+        `Not enough disk space. Need ~${requiredMB} MB but only ${availableMB} MB available at ${targetPath}.`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Third and final slice of the audit's **mega-hook backlog** (#287 `useKitEditorLogic`, #288 `useLedVisualization`). `useLocalStoreWizard` (342 lines) was a different case: it was already composed of state / file-ops / scanning sub-hooks, so the remaining weight was inline helpers and hand-rolled debug noise rather than tangled concerns.

### Changes

- **`useWizardProgress`** — extracts the progress fan-out (wizard state + optional external `onProgress` callback) and the sequential per-item step driver used by the file-ops and scanning phases. Now directly unit-tested: per-item percentages, the trailing 100% event, and the empty-list no-op.
- **`wizardInitUtils`** — extracts the pure module-level helpers: `getElectronAPI`, `normalizeErrorMessage`, and `runPreChecks`. `runPreChecks` (writability + source-dependent disk-space requirements) gains direct tests for the failure messages, the 1 GiB squarp / 500 MiB sdcard thresholds, and the blank-source skip — none of which had targeted coverage before.
- **Debug noise** — the ~20 `isDev && console.debug("[Hook] …")` lines collapse into the project's `createLogger("LocalStoreWizard")`, whose `debug` level is dev-gated identically (`app/renderer/utils/logger.ts`), so runtime behaviour is unchanged. Also drops a misplaced section comment that labelled `runPreChecks` as "error message normalization".

The hook keeps its **exact return shape** (callers `LocalStoreWizardUI` etc. untouched) and drops to ~240 lines of actual orchestration — `initialize`, `processSource`, source selection — which is its real job.

### Validation

- All existing wizard suites (state, file-ops, scanning, orchestrator, wizard-e2e) pass **unmodified**: 82 tests including the 14 new ones.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

This completes the mega-hook items. Remaining backlog: duplicate scan logic (`scanService.rescanKit` vs `databaseScanning.scanKitToDatabase`), error-contract standardization, and the component god-objects (`KitGridItem`, `dbUtilities`, `formatConverter`, `KitsView`).

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_