### PR TITLE
refactor: use canonical DbResult contract for favorite toggling

### DIFF
--- a/app/renderer/components/KitEditor.tsx
+++ b/app/renderer/components/KitEditor.tsx
@@ -1,4 +1,4 @@
-import type { KitWithRelations } from "@romper/shared/db/schema";
+import type { DbResult, KitWithRelations } from "@romper/shared/db/schema";
 
 import React from "react";
 
@@ -21,7 +21,7 @@ interface KitEditorAllProps extends KitEditorProps {
   onToggleEditableMode?: (kitName: string) => Promise<void>; // Toggle editable mode - used via useKitEditorLogic hook
   onToggleFavorite?: (
     kitName: string,
-  ) => Promise<{ isFavorite?: boolean; success: boolean }>; // For favorite star button
+  ) => Promise<DbResult<{ isFavorite: boolean }>>; // For favorite star button
   onUpdateKitAlias?: (kitName: string, alias: string) => Promise<void>; // Update kit alias - used via useKitEditorLogic hook
 }
 

--- a/app/renderer/components/KitEditorContainer.tsx
+++ b/app/renderer/components/KitEditorContainer.tsx
@@ -1,4 +1,4 @@
-import type { KitWithRelations } from "@romper/shared/db/schema";
+import type { DbResult, KitWithRelations } from "@romper/shared/db/schema";
 import type { AnyUndoAction } from "@romper/shared/undoTypes";
 
 import React from "react";
@@ -24,7 +24,7 @@ interface KitEditorContainerProps {
   onToggleEditableMode?: (kitName: string) => Promise<void>;
   onToggleFavorite?: (
     kitName: string,
-  ) => Promise<{ isFavorite?: boolean; success: boolean }>;
+  ) => Promise<DbResult<{ isFavorite: boolean }>>;
   onUpdateKitAlias?: (kitName: string, alias: string) => Promise<void>;
   samples: VoiceSamples;
 }

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
@@ -1,4 +1,4 @@
-import type { KitWithRelations } from "@romper/shared/db/schema";
+import type { DbResult, KitWithRelations } from "@romper/shared/db/schema";
 
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -511,13 +511,15 @@ describe("useKitDataManager", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      let toggleResult: { isFavorite?: boolean; success: boolean };
+      let toggleResult: DbResult<{ isFavorite: boolean }>;
       await act(async () => {
         toggleResult = await result.current.toggleKitFavorite("A0");
       });
 
-      expect(toggleResult.success).toBe(true);
-      expect(toggleResult.isFavorite).toBe(true);
+      expect(toggleResult).toEqual({
+        data: { isFavorite: true },
+        success: true,
+      });
       expect(window.electronAPI.toggleKitFavorite).toHaveBeenCalledWith("A0");
 
       // Check that local state was updated
@@ -544,13 +546,15 @@ describe("useKitDataManager", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      let toggleResult: { isFavorite?: boolean; success: boolean };
+      let toggleResult: DbResult<{ isFavorite: boolean }>;
       await act(async () => {
         toggleResult = await result.current.toggleKitFavorite("A0");
       });
 
-      expect(toggleResult.success).toBe(false);
-      expect(toggleResult.isFavorite).toBeUndefined();
+      expect(toggleResult).toEqual({
+        error: "Failed to toggle favorite",
+        success: false,
+      });
     });
 
     it("should handle API exception", async () => {
@@ -571,13 +575,15 @@ describe("useKitDataManager", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      let toggleResult: { isFavorite?: boolean; success: boolean };
+      let toggleResult: DbResult<{ isFavorite: boolean }>;
       await act(async () => {
         toggleResult = await result.current.toggleKitFavorite("A0");
       });
 
-      expect(toggleResult.success).toBe(false);
-      expect(toggleResult.isFavorite).toBeUndefined();
+      expect(toggleResult).toEqual({
+        error: "Network error",
+        success: false,
+      });
     });
   });
 

--- a/app/renderer/components/hooks/kit-management/useKitDataManager.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDataManager.ts
@@ -1,5 +1,5 @@
 import type { VoiceSamples } from "@romper/app/renderer/components/kitTypes";
-import type { KitWithRelations } from "@romper/shared/db/schema";
+import type { DbResult, KitWithRelations } from "@romper/shared/db/schema";
 
 import { compareKitSlots } from "@romper/shared/kitUtilsShared";
 import React, { useCallback, useEffect, useState } from "react";
@@ -24,7 +24,7 @@ interface UseKitDataManagerReturn {
   toggleKitEditable: (kitName: string) => Promise<void>;
   toggleKitFavorite: (
     kitName: string,
-  ) => Promise<{ isFavorite?: boolean; success: boolean }>;
+  ) => Promise<DbResult<{ isFavorite: boolean }>>;
   updateKit: (kitName: string, updates: Partial<KitWithRelations>) => void;
   updateKitAlias: (kitName: string, alias: string) => Promise<void>;
 }
@@ -219,7 +219,7 @@ export function useKitDataManager({
 
   // Toggle kit favorite status
   const toggleKitFavorite = useCallback(
-    async (kitName: string) => {
+    async (kitName: string): Promise<DbResult<{ isFavorite: boolean }>> => {
       try {
         const result =
           await globalThis.electronAPI?.toggleKitFavorite?.(kitName);
@@ -227,12 +227,18 @@ export function useKitDataManager({
           // Update local state immediately for optimistic UI update
           const newFavoriteState = result.data?.isFavorite ?? false;
           updateKit(kitName, { is_favorite: newFavoriteState });
-          return { isFavorite: newFavoriteState, success: true };
+          return { data: { isFavorite: newFavoriteState }, success: true };
         }
-        return { success: false };
+        return {
+          error: result?.error ?? "Toggle favorite API not available",
+          success: false,
+        };
       } catch (error) {
         console.error("Error toggling kit favorite:", error);
-        return { success: false };
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          success: false,
+        };
       }
     },
     [updateKit],

--- a/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
+++ b/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
@@ -1,5 +1,5 @@
 import type { KitEditorProps } from "@romper/app/renderer/components/kitTypes";
-import type { KitWithRelations } from "@romper/shared/db/schema";
+import type { DbResult, KitWithRelations } from "@romper/shared/db/schema";
 
 import React from "react";
 
@@ -27,7 +27,7 @@ interface UseKitEditorLogicParams extends KitEditorProps {
   onToggleEditableMode?: (kitName: string) => Promise<void>;
   onToggleFavorite?: (
     kitName: string,
-  ) => Promise<{ isFavorite?: boolean; success: boolean }>;
+  ) => Promise<DbResult<{ isFavorite: boolean }>>;
   onUpdateKitAlias?: (kitName: string, alias: string) => Promise<void>;
 }
 


### PR DESCRIPTION
## Summary

First slice of the audit's **error-contract standardization** item ("three coexisting patterns: `{success,error,data}`, throw, `{isFavorite,success}`"). This eliminates the third pattern entirely — it had exactly one source.

### The deviation

The project's documented contract for database operations is `DbResult<T>` (`docs/developer/coding-guide.md`), and the favorites chain already speaks it end-to-end: the ORM operation returns `DbResult<{isFavorite: boolean}>`, the IPC handler and preload pass it through, `electron.d.ts` declares it, and `useKitFilters` consumes it properly — error message included.

The one deviation was `useKitDataManager.toggleKitFavorite`, which unwrapped the `DbResult` and re-wrapped it in a bespoke `{isFavorite?: boolean; success: boolean}` — **dropping the error message** in both the failure and the exception path (a small cousin of the swallowed-errors cleanup in #286). That shape then leaked into prop-type declarations in `KitEditor`, `KitEditorContainer`, and `useKitEditorLogic`, even though no consumer ever reads the resolved value (every UI call site types `onToggleFavorite` as `(kitName: string) => void`).

### Changes

- `useKitDataManager.toggleKitFavorite` returns `DbResult<{isFavorite: boolean}>`: the IPC error message survives on failure, exceptions are stringified into `error`, and the optimistic local-state update on success is unchanged.
- The three prop-type declarations use the shared `DbResult` type instead of restating a private shape.
- Tests assert the canonical shape, including that error messages now survive the wrapper.

### Remaining contract work (out of scope here)

The throw-vs-`DbResult` split (e.g. `createKit`/`deleteKit` style `Promise<void>` APIs vs the `DbResult` family) is a larger, behavior-affecting unification — flagging it for a dedicated discussion rather than bundling it in.

> Merge note: touches the same params interface in `useKitEditorLogic.ts` as #287 (one line) — whichever merges second has a trivial rebase.

### Validation

Full pre-commit gate passes locally; 421 tests across the kit-management and kit-editor suites pass.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_