### PR TITLE
refactor: extract migration machinery from dbUtilities

### DIFF
--- a/electron/main/db/utils/dbMigrations.ts
+++ b/electron/main/db/utils/dbMigrations.ts
@@ -1,0 +1,269 @@
+import type { DbResult } from "@romper/shared/db/schema.js";
+
+import * as schema from "@romper/shared/db/schema.js";
+// Database migration machinery: locating the migrations folder, applying
+// migrations, one-time history repair, and the per-session migration cache.
+import BetterSqlite3 from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { logger } from "../../utils/logger.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const DB_FILENAME = "romper.sqlite";
+
+// Track which databases have been migration-checked this session
+const migrationCheckedDbs = new Set<string>();
+
+/**
+ * Check migration state of database
+ */
+export function checkMigrationState(sqlite: BetterSqlite3.Database): void {
+  // Check if schema tables exist
+  const tables = sqlite
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    )
+    .all() as { name: string }[];
+
+  logger.log(
+    `[Main] Found ${tables.length} tables:`,
+    tables.map((t) => t.name),
+  );
+
+  // Check if __drizzle_migrations table exists
+  const migrationTable = tables.find((t) => t.name === "__drizzle_migrations");
+  if (migrationTable) {
+    const migrations = sqlite
+      .prepare("SELECT hash, created_at FROM __drizzle_migrations ORDER BY id")
+      .all();
+    logger.log(`[Main] Found ${migrations.length} applied migrations`);
+  } else {
+    logger.log("[Main] No migration history found");
+  }
+}
+
+// Export function to clear migration cache (for tests)
+export function clearMigrationCache(): void {
+  migrationCheckedDbs.clear();
+}
+
+/**
+ * Ensure database migrations are up to date
+ */
+export function ensureDatabaseMigrations(dbDir: string): DbResult<boolean> {
+  const dbPath = path.join(dbDir, DB_FILENAME);
+
+  // Skip if already checked this session
+  if (migrationCheckedDbs.has(dbPath)) {
+    return { data: true, success: true };
+  }
+
+  // Check if database file exists
+  if (!fs.existsSync(dbPath)) {
+    return {
+      error: `Database file does not exist: ${dbPath}`,
+      success: false,
+    };
+  }
+
+  try {
+    const sqlite = new BetterSqlite3(dbPath);
+    const db = drizzle(sqlite, { schema });
+
+    checkMigrationState(sqlite);
+    repairMigrationHistory(sqlite);
+    executeMigrations(db, dbPath, dbDir);
+
+    sqlite.close();
+    migrationCheckedDbs.add(dbPath);
+
+    return { data: true, success: true };
+  } catch (e) {
+    logMigrationError(e, dbPath, dbDir);
+    const error = e instanceof Error ? e.message : String(e);
+    return { error: `Migration failed: ${error}`, success: false };
+  }
+}
+
+/**
+ * Execute database migrations
+ */
+export function executeMigrations(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  dbPath: string,
+  dbDir: string,
+): void {
+  const migrationsPath = getMigrationsPath();
+  if (!migrationsPath) {
+    throw new Error("Migrations folder not found");
+  }
+
+  logger.log(`[Main] Migrating database: ${dbPath}`);
+  logger.log(`[Main] Using migrations from: ${migrationsPath}`);
+
+  try {
+    migrate(db, { migrationsFolder: migrationsPath });
+    logger.log(`[Main] Migrations completed successfully for ${dbPath}`);
+  } catch (e) {
+    logMigrationError(e, dbPath, dbDir);
+    throw e;
+  }
+}
+
+/**
+ * Get the path to migrations folder, checking multiple possible locations
+ */
+export function getMigrationsPath(): null | string {
+  const possiblePaths = [
+    // Built app paths - when bundled, __dirname is dist/electron/main
+    path.join(__dirname, "db", "migrations"),
+    // Also check if migrations are directly in main folder
+    path.join(__dirname, "migrations"),
+    // Built app paths (dist/electron/main/db/utils -> migrations)
+    path.join(__dirname, "..", "migrations"),
+    // Development paths
+    path.join(__dirname, "..", "..", "..", "..", "migrations"),
+    path.join(__dirname, "..", "..", "..", "migrations"),
+    path.join(__dirname, "..", "..", "migrations"),
+    // Working directory paths
+    path.join(process.cwd(), "migrations"),
+    path.join(process.cwd(), "drizzle"),
+    path.join(process.cwd(), "electron", "main", "db", "migrations"),
+    // Development source paths
+    path.join(process.cwd(), "dist", "electron", "main", "db", "migrations"),
+  ];
+
+  for (const migrationsPath of possiblePaths) {
+    if (fs.existsSync(migrationsPath)) {
+      logger.log(`[Main] Found migrations folder at: ${migrationsPath}`);
+      return migrationsPath;
+    }
+  }
+
+  console.error("[Main] No migrations folder found in any expected location:");
+  possiblePaths.forEach((p) => console.error(`  - ${p}`));
+  return null;
+}
+
+/**
+ * Log migration errors with context
+ */
+export function logMigrationError(
+  e: unknown,
+  dbPath: string,
+  dbDir: string,
+): void {
+  const error = e instanceof Error ? e.message : String(e);
+  console.error(`[Main] Migration error for ${dbPath}:`, error);
+  console.error(`[Main] Database directory: ${dbDir}`);
+  console.error(`[Main] Database exists: ${fs.existsSync(dbPath)}`);
+
+  if (fs.existsSync(dbPath)) {
+    try {
+      const stats = fs.statSync(dbPath);
+      console.error(`[Main] Database size: ${stats.size} bytes`);
+    } catch (statError) {
+      console.error(`[Main] Could not get database stats:`, statError);
+    }
+  }
+}
+
+/**
+ * Repair migration history for databases affected by the 0008→0009 consolidation.
+ *
+ * Commit 24f89f4 deleted migration 0008_ordinary_mastermind (which added
+ * wav_bit_depth and wav_channels to samples) and consolidated those changes
+ * plus a new stereo_mode column into 0009_purple_zaladane. Databases that
+ * already applied 0008 have some columns but not all, and lack a record for
+ * 0009 — causing Drizzle to re-run it and fail on "duplicate column".
+ *
+ * This function detects that state, applies any missing columns individually,
+ * and records 0009 as applied so Drizzle skips it.
+ */
+export function repairMigrationHistory(sqlite: BetterSqlite3.Database): void {
+  // Check which columns from 0009 already exist
+  const sampleCols = sqlite.prepare("PRAGMA table_info(samples)").all() as {
+    name: string;
+  }[];
+  const voiceCols = sqlite.prepare("PRAGMA table_info(voices)").all() as {
+    name: string;
+  }[];
+
+  const hasWavBitDepth = sampleCols.some((c) => c.name === "wav_bit_depth");
+  const hasWavChannels = sampleCols.some((c) => c.name === "wav_channels");
+  const hasStereoMode = voiceCols.some((c) => c.name === "stereo_mode");
+
+  // If none of the 0009 columns exist, this is a fresh DB — no repair needed
+  if (!hasWavBitDepth && !hasWavChannels && !hasStereoMode) {
+    return;
+  }
+
+  // Check if __drizzle_migrations table exists
+  const tables = sqlite
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='__drizzle_migrations'",
+    )
+    .all();
+  if (tables.length === 0) {
+    return;
+  }
+
+  const migrationsPath = getMigrationsPath();
+  if (!migrationsPath) return;
+
+  const migrationTag = "0009_purple_zaladane";
+  const sqlPath = path.join(migrationsPath, `${migrationTag}.sql`);
+  if (!fs.existsSync(sqlPath)) return;
+
+  // Compute the hash the same way Drizzle does (SHA-256 of raw SQL content)
+  const migrationSql = fs.readFileSync(sqlPath).toString();
+  const hash = crypto.createHash("sha256").update(migrationSql).digest("hex");
+
+  // Check if this migration is already recorded
+  const existing = sqlite
+    .prepare("SELECT id FROM __drizzle_migrations WHERE hash = ?")
+    .all(hash);
+  if (existing.length > 0) {
+    return; // Already applied
+  }
+
+  // Apply any missing columns individually
+  if (!hasWavBitDepth) {
+    sqlite.exec("ALTER TABLE `samples` ADD `wav_bit_depth` integer");
+  }
+  if (!hasWavChannels) {
+    sqlite.exec("ALTER TABLE `samples` ADD `wav_channels` integer");
+  }
+  if (!hasStereoMode) {
+    sqlite.exec(
+      "ALTER TABLE `voices` ADD `stereo_mode` integer DEFAULT false NOT NULL",
+    );
+  }
+
+  // Read the journal to get the timestamp for 0009
+  const journalStr = fs
+    .readFileSync(path.join(migrationsPath, "meta", "_journal.json"))
+    .toString();
+  const journal = JSON.parse(journalStr);
+  const entry = journal.entries.find(
+    (e: { tag: string }) => e.tag === migrationTag,
+  );
+
+  if (entry) {
+    logger.log(
+      `[Main] Repairing migration history: applied missing columns and recorded ${migrationTag} (partially applied from deleted 0008)`,
+    );
+    sqlite
+      .prepare(
+        'INSERT INTO __drizzle_migrations ("hash", "created_at") VALUES (?, ?)',
+      )
+      .run(hash, entry.when);
+  }
+}

--- a/electron/main/db/utils/dbUtilities.ts
+++ b/electron/main/db/utils/dbUtilities.ts
@@ -1,57 +1,31 @@
 import type { DbResult } from "@romper/shared/db/schema.js";
 
 import * as schema from "@romper/shared/db/schema.js";
-// Database utility functions for connection, migration, and validation
+// Database utility functions for connection, creation, and validation.
+// Migration machinery lives in dbMigrations.ts and is re-exported below.
 import BetterSqlite3 from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { logger } from "../../utils/logger.js";
+import {
+  DB_FILENAME,
+  ensureDatabaseMigrations,
+  getMigrationsPath,
+} from "./dbMigrations.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-export const DB_FILENAME = "romper.sqlite";
-
-// Track which databases have been migration-checked this session
-const migrationCheckedDbs = new Set<string>();
-
-/**
- * Check migration state of database
- */
-export function checkMigrationState(sqlite: BetterSqlite3.Database): void {
-  // Check if schema tables exist
-  const tables = sqlite
-    .prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-    )
-    .all() as { name: string }[];
-
-  logger.log(
-    `[Main] Found ${tables.length} tables:`,
-    tables.map((t) => t.name),
-  );
-
-  // Check if __drizzle_migrations table exists
-  const migrationTable = tables.find((t) => t.name === "__drizzle_migrations");
-  if (migrationTable) {
-    const migrations = sqlite
-      .prepare("SELECT hash, created_at FROM __drizzle_migrations ORDER BY id")
-      .all();
-    logger.log(`[Main] Found ${migrations.length} applied migrations`);
-  } else {
-    logger.log("[Main] No migration history found");
-  }
-}
-
-// Export function to clear migration cache (for tests)
-export function clearMigrationCache(): void {
-  migrationCheckedDbs.clear();
-}
+export {
+  checkMigrationState,
+  clearMigrationCache,
+  DB_FILENAME,
+  ensureDatabaseMigrations,
+  executeMigrations,
+  getMigrationsPath,
+  logMigrationError,
+  repairMigrationHistory,
+} from "./dbMigrations.js";
 
 /**
  * Initialize database with schema using Drizzle migrations
@@ -100,220 +74,6 @@ export function createRomperDbFile(dbDir: string): {
     const error = e instanceof Error ? e.message : String(e);
     console.error("[Main] Database creation error:", error);
     return { error, success: false };
-  }
-}
-
-/**
- * Ensure database migrations are up to date
- */
-export function ensureDatabaseMigrations(dbDir: string): DbResult<boolean> {
-  const dbPath = path.join(dbDir, DB_FILENAME);
-
-  // Skip if already checked this session
-  if (migrationCheckedDbs.has(dbPath)) {
-    return { data: true, success: true };
-  }
-
-  // Check if database file exists
-  if (!fs.existsSync(dbPath)) {
-    return {
-      error: `Database file does not exist: ${dbPath}`,
-      success: false,
-    };
-  }
-
-  try {
-    const sqlite = new BetterSqlite3(dbPath);
-    const db = drizzle(sqlite, { schema });
-
-    checkMigrationState(sqlite);
-    repairMigrationHistory(sqlite);
-    executeMigrations(db, dbPath, dbDir);
-
-    sqlite.close();
-    migrationCheckedDbs.add(dbPath);
-
-    return { data: true, success: true };
-  } catch (e) {
-    logMigrationError(e, dbPath, dbDir);
-    const error = e instanceof Error ? e.message : String(e);
-    return { error: `Migration failed: ${error}`, success: false };
-  }
-}
-
-/**
- * Execute database migrations
- */
-export function executeMigrations(
-  db: ReturnType<typeof drizzle<typeof schema>>,
-  dbPath: string,
-  dbDir: string,
-): void {
-  const migrationsPath = getMigrationsPath();
-  if (!migrationsPath) {
-    throw new Error("Migrations folder not found");
-  }
-
-  logger.log(`[Main] Migrating database: ${dbPath}`);
-  logger.log(`[Main] Using migrations from: ${migrationsPath}`);
-
-  try {
-    migrate(db, { migrationsFolder: migrationsPath });
-    logger.log(`[Main] Migrations completed successfully for ${dbPath}`);
-  } catch (e) {
-    logMigrationError(e, dbPath, dbDir);
-    throw e;
-  }
-}
-
-/**
- * Get the path to migrations folder, checking multiple possible locations
- */
-export function getMigrationsPath(): null | string {
-  const possiblePaths = [
-    // Built app paths - when bundled, __dirname is dist/electron/main
-    path.join(__dirname, "db", "migrations"),
-    // Also check if migrations are directly in main folder
-    path.join(__dirname, "migrations"),
-    // Built app paths (dist/electron/main/db/utils -> migrations)
-    path.join(__dirname, "..", "migrations"),
-    // Development paths
-    path.join(__dirname, "..", "..", "..", "..", "migrations"),
-    path.join(__dirname, "..", "..", "..", "migrations"),
-    path.join(__dirname, "..", "..", "migrations"),
-    // Working directory paths
-    path.join(process.cwd(), "migrations"),
-    path.join(process.cwd(), "drizzle"),
-    path.join(process.cwd(), "electron", "main", "db", "migrations"),
-    // Development source paths
-    path.join(process.cwd(), "dist", "electron", "main", "db", "migrations"),
-  ];
-
-  for (const migrationsPath of possiblePaths) {
-    if (fs.existsSync(migrationsPath)) {
-      logger.log(`[Main] Found migrations folder at: ${migrationsPath}`);
-      return migrationsPath;
-    }
-  }
-
-  console.error("[Main] No migrations folder found in any expected location:");
-  possiblePaths.forEach((p) => console.error(`  - ${p}`));
-  return null;
-}
-
-/**
- * Log migration errors with context
- */
-export function logMigrationError(
-  e: unknown,
-  dbPath: string,
-  dbDir: string,
-): void {
-  const error = e instanceof Error ? e.message : String(e);
-  console.error(`[Main] Migration error for ${dbPath}:`, error);
-  console.error(`[Main] Database directory: ${dbDir}`);
-  console.error(`[Main] Database exists: ${fs.existsSync(dbPath)}`);
-
-  if (fs.existsSync(dbPath)) {
-    try {
-      const stats = fs.statSync(dbPath);
-      console.error(`[Main] Database size: ${stats.size} bytes`);
-    } catch (statError) {
-      console.error(`[Main] Could not get database stats:`, statError);
-    }
-  }
-}
-
-/**
- * Repair migration history for databases affected by the 0008→0009 consolidation.
- *
- * Commit 24f89f4 deleted migration 0008_ordinary_mastermind (which added
- * wav_bit_depth and wav_channels to samples) and consolidated those changes
- * plus a new stereo_mode column into 0009_purple_zaladane. Databases that
- * already applied 0008 have some columns but not all, and lack a record for
- * 0009 — causing Drizzle to re-run it and fail on "duplicate column".
- *
- * This function detects that state, applies any missing columns individually,
- * and records 0009 as applied so Drizzle skips it.
- */
-export function repairMigrationHistory(sqlite: BetterSqlite3.Database): void {
-  // Check which columns from 0009 already exist
-  const sampleCols = sqlite.prepare("PRAGMA table_info(samples)").all() as {
-    name: string;
-  }[];
-  const voiceCols = sqlite.prepare("PRAGMA table_info(voices)").all() as {
-    name: string;
-  }[];
-
-  const hasWavBitDepth = sampleCols.some((c) => c.name === "wav_bit_depth");
-  const hasWavChannels = sampleCols.some((c) => c.name === "wav_channels");
-  const hasStereoMode = voiceCols.some((c) => c.name === "stereo_mode");
-
-  // If none of the 0009 columns exist, this is a fresh DB — no repair needed
-  if (!hasWavBitDepth && !hasWavChannels && !hasStereoMode) {
-    return;
-  }
-
-  // Check if __drizzle_migrations table exists
-  const tables = sqlite
-    .prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='__drizzle_migrations'",
-    )
-    .all();
-  if (tables.length === 0) {
-    return;
-  }
-
-  const migrationsPath = getMigrationsPath();
-  if (!migrationsPath) return;
-
-  const migrationTag = "0009_purple_zaladane";
-  const sqlPath = path.join(migrationsPath, `${migrationTag}.sql`);
-  if (!fs.existsSync(sqlPath)) return;
-
-  // Compute the hash the same way Drizzle does (SHA-256 of raw SQL content)
-  const migrationSql = fs.readFileSync(sqlPath).toString();
-  const hash = crypto.createHash("sha256").update(migrationSql).digest("hex");
-
-  // Check if this migration is already recorded
-  const existing = sqlite
-    .prepare("SELECT id FROM __drizzle_migrations WHERE hash = ?")
-    .all(hash);
-  if (existing.length > 0) {
-    return; // Already applied
-  }
-
-  // Apply any missing columns individually
-  if (!hasWavBitDepth) {
-    sqlite.exec("ALTER TABLE `samples` ADD `wav_bit_depth` integer");
-  }
-  if (!hasWavChannels) {
-    sqlite.exec("ALTER TABLE `samples` ADD `wav_channels` integer");
-  }
-  if (!hasStereoMode) {
-    sqlite.exec(
-      "ALTER TABLE `voices` ADD `stereo_mode` integer DEFAULT false NOT NULL",
-    );
-  }
-
-  // Read the journal to get the timestamp for 0009
-  const journalStr = fs
-    .readFileSync(path.join(migrationsPath, "meta", "_journal.json"))
-    .toString();
-  const journal = JSON.parse(journalStr);
-  const entry = journal.entries.find(
-    (e: { tag: string }) => e.tag === migrationTag,
-  );
-
-  if (entry) {
-    logger.log(
-      `[Main] Repairing migration history: applied missing columns and recorded ${migrationTag} (partially applied from deleted 0008)`,
-    );
-    sqlite
-      .prepare(
-        'INSERT INTO __drizzle_migrations ("hash", "created_at") VALUES (?, ?)',
-      )
-      .run(hash, entry.when);
   }
 }
 


### PR DESCRIPTION
## Summary

Next item from the audit's **god-object backlog**: `electron/main/db/utils/dbUtilities.ts` (438 lines) stacked two concerns with a clean seam between them:

1. **The connection layer** every DB operation goes through — `withDb`, `withDbTransaction`, `createRomperDbFile`, `validateDatabaseSchema`.
2. **The migration machinery** — migrations-folder discovery across ten candidate paths, execution, the per-session migration cache, `checkMigrationState`/`logMigrationError` diagnostics, and the one-time 0008→0009 history repair (a self-contained saga with its own long doc comment).

### Change

The migration half moves **verbatim** into `dbMigrations.ts`; `dbUtilities.ts` keeps the connection layer (~200 lines) and **re-exports the full migration API**, so none of the ~25 importers (every CRUD/operations module plus their tests) change. `DB_FILENAME` moves with the migration module — it needs the constant, and importing it back from `dbUtilities` would create a cycle — and is re-exported unchanged.

### Validation

- No logic changes — pure move plus an import/re-export block.
- All db unit and integration suites (144 tests), including `dbUtilities.integration.test.ts` which imports migration functions through the old path, pass **unmodified**.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

Remaining god-objects from the audit: `KitGridItem.tsx` (635), `formatConverter.ts` (403), `KitsView.tsx` (390).

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_