### PR TITLE
refactor: split KitGridItem into focused modules

### DIFF
--- a/app/renderer/components/KitGridItem.tsx
+++ b/app/renderer/components/KitGridItem.tsx
@@ -4,206 +4,47 @@ import {
   LockSimpleIcon,
   MusicNoteIcon,
   TrashIcon,
-  WarningIcon,
 } from "@phosphor-icons/react";
 import { toCapitalCase } from "@romper/shared/kitUtilsShared";
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
+
+import type {
+  DuplicateKitFn,
+  RequestDeleteSummaryFn,
+} from "./hooks/kit-management/useKitItemActions";
 
 import { useKitItem } from "./hooks/kit-management/useKitItem";
+import { useKitItemActions } from "./hooks/kit-management/useKitItemActions";
 import StereoIcon from "./icons/StereoIcon";
+import { KitVoiceStrip } from "./KitVoiceStrip";
 import ActionPopover from "./shared/ActionPopover";
 import { KitIconRenderer } from "./shared/KitIconRenderer";
+import {
+  DeletePopoverContent,
+  DuplicatePopoverContent,
+} from "./shared/KitItemActionPopovers";
 import {
   BaseKitItemProps,
   extractVoiceNames,
   KitItemRenderProps,
 } from "./shared/kitItemUtils";
-
-type DeleteSummary = { locked: boolean; sampleCount: number };
-
-type DuplicateKitFn = (
-  source: string,
-  dest: string,
-) => Promise<{ error?: string }>;
+import { highlightMatch } from "./shared/searchHighlight";
 
 interface KitGridItemProps extends BaseKitItemProps {
   // The NOSONAR markers below suppress S6767 false positives: every
-  // one of these props is destructured at lines 199-217 and referenced
-  // 3-6 times in the body. SonarTS's TS analyser misses the usage.
+  // one of these props is destructured and referenced multiple times
+  // in the body. SonarTS's TS analyser misses the usage.
   isNew?: boolean; // NOSONAR
   onDeleteKit?: (kitName: string) => Promise<void>; // NOSONAR
   onDuplicateKit?: DuplicateKitFn; // NOSONAR
   onRequestDeleteSummary?: RequestDeleteSummaryFn; // NOSONAR
 }
 
-type RequestDeleteSummaryFn = (
-  kitName: string,
-) => Promise<DeleteSummary | null>;
-
-const EXIT_ANIMATION_MS = 250;
-
-const stripExtension = (filename: string) => filename.replace(/\.[^.]+$/, "");
-
-const highlightMatch = (
-  text: string,
-  term: string,
-  markClass = "bg-accent-primary/25 text-accent-primary",
-) => {
-  const idx = text.toLowerCase().indexOf(term.toLowerCase());
-  if (idx === -1) return <>{text}</>;
-  return (
-    <>
-      {text.slice(0, idx)}
-      <mark className={`${markClass} font-semibold rounded-sm px-0.5`}>
-        {text.slice(idx, idx + term.length)}
-      </mark>
-      {text.slice(idx + term.length)}
-    </>
-  );
-};
-
 const getBorderStyle = (isValid: boolean, modifiedSinceSync?: boolean) => {
   if (!isValid) return "border-border-subtle opacity-70 cursor-not-allowed";
   if (modifiedSinceSync) return "border-accent-warning/40 bg-accent-warning/5";
   return "border-border-subtle";
 };
-
-const getVoiceCountStyle = (count: number) => {
-  if (count === 0) {
-    return { text: "text-accent-danger", weight: "" };
-  }
-  if (count === 12) {
-    return { text: "text-accent-success", weight: "font-bold" };
-  }
-  return { text: "text-accent-primary", weight: "" };
-};
-
-interface DeletePopoverContentProps {
-  isDeleting: boolean;
-  kitName: string;
-  onCancel: () => void;
-  onConfirm: () => void;
-  sampleCount: number;
-}
-
-const DeletePopoverContent: React.FC<DeletePopoverContentProps> = ({
-  isDeleting,
-  kitName,
-  onCancel,
-  onConfirm,
-  sampleCount,
-}) => (
-  <div className="flex flex-col gap-2">
-    <div className="flex items-center gap-1.5">
-      {sampleCount > 0 ? (
-        <WarningIcon
-          className="text-accent-warning flex-shrink-0"
-          size={14}
-          weight="bold"
-        />
-      ) : null}
-      <span className="text-sm font-semibold text-text-primary">
-        Delete kit {kitName}?
-      </span>
-    </div>
-    {sampleCount > 0 && (
-      <p className="text-xs text-text-secondary">
-        {sampleCount} sample {sampleCount === 1 ? "reference" : "references"}{" "}
-        will be removed. Files on disk are not affected.
-      </p>
-    )}
-    {sampleCount === 0 && (
-      <p className="text-xs text-text-tertiary">No samples. Safe to remove.</p>
-    )}
-    <div className="flex gap-2">
-      <button
-        className={`px-2 py-1 text-xs text-white rounded font-semibold inline-flex items-center gap-1 disabled:opacity-50 ${sampleCount > 0 ? "bg-accent-danger hover:bg-accent-danger/80" : "bg-accent-primary hover:bg-accent-primary/80"}`}
-        data-testid="confirm-delete-button"
-        disabled={isDeleting}
-        onClick={(e) => {
-          e.stopPropagation();
-          onConfirm();
-        }}
-      >
-        <TrashIcon size={13} />
-        {isDeleting ? "Deleting..." : "Delete"}
-      </button>
-      <button
-        className="px-2 py-1 text-xs bg-surface-4 text-text-secondary rounded hover:bg-surface-3 font-semibold"
-        disabled={isDeleting}
-        onClick={(e) => {
-          e.stopPropagation();
-          onCancel();
-        }}
-      >
-        Cancel
-      </button>
-    </div>
-  </div>
-);
-
-interface DuplicatePopoverContentProps {
-  duplicateDest: string;
-  duplicateError: null | string;
-  kitName: string;
-  onCancel: () => void;
-  onConfirm: () => void;
-  onDestChange: (value: string) => void;
-}
-
-const DuplicatePopoverContent: React.FC<DuplicatePopoverContentProps> = ({
-  duplicateDest,
-  duplicateError,
-  kitName,
-  onCancel,
-  onConfirm,
-  onDestChange,
-}) => (
-  <div className="flex flex-col gap-2">
-    <label className="text-xs font-semibold text-text-primary">
-      Duplicate {kitName} to:
-      <input
-        autoFocus
-        className="ml-2 px-2 py-1 rounded border border-border-default text-sm bg-surface-2 text-text-primary w-16"
-        data-testid="duplicate-dest-input"
-        maxLength={3}
-        onChange={(e) => onDestChange(e.target.value.toUpperCase())}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            onConfirm();
-          }
-        }}
-        value={duplicateDest}
-      />
-    </label>
-    {duplicateError && (
-      <div className="text-xs text-accent-danger">{duplicateError}</div>
-    )}
-    <div className="flex gap-2">
-      <button
-        className="px-2 py-1 text-xs bg-accent-success text-white rounded hover:bg-accent-success/80 font-semibold"
-        data-testid="confirm-duplicate-button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onConfirm();
-        }}
-      >
-        Duplicate
-      </button>
-      <button
-        className="px-2 py-1 text-xs bg-surface-4 text-text-secondary rounded hover:bg-surface-3 font-semibold"
-        onClick={(e) => {
-          e.stopPropagation();
-          onCancel();
-        }}
-      >
-        Cancel
-      </button>
-    </div>
-  </div>
-);
 
 const KitGridItem = React.memo(
   React.forwardRef<HTMLDivElement, KitGridItemProps & KitItemRenderProps>(
@@ -232,73 +73,18 @@ const KitGridItem = React.memo(
       const icon = <KitIconRenderer iconType={iconType} size="md" />;
       const isFavorite = isFavoriteProp ?? kitData?.is_favorite ?? false;
 
-      // Animation states
-      const [isExiting, setIsExiting] = useState(false);
+      // Favorite pulse animation state
       const [isPulsing, setIsPulsing] = useState(false);
 
-      // Delete popover state
-      const deleteButtonRef = useRef<HTMLButtonElement>(null);
-      const [showDeletePopover, setShowDeletePopover] = useState(false);
-      const [deleteSampleCount, setDeleteSampleCount] = useState<number>(0);
-      const [isDeleting, setIsDeleting] = useState(false);
-
-      // Duplicate popover state
-      const duplicateButtonRef = useRef<HTMLButtonElement>(null);
-      const [showDuplicatePopover, setShowDuplicatePopover] = useState(false);
-      const [duplicateDest, setDuplicateDest] = useState("");
-      const [duplicateError, setDuplicateError] = useState<null | string>(null);
-
-      const handleDeleteClick = async (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (!onRequestDeleteSummary) {
-          onDelete?.();
-          return;
-        }
-        const summary = await onRequestDeleteSummary(kit);
-        if (!summary) return;
-        setDeleteSampleCount(summary.sampleCount);
-        setShowDeletePopover(true);
-      };
-
-      const handleConfirmDelete = async () => {
-        if (!onDeleteKit) return;
-        setIsDeleting(true);
-        try {
-          setShowDeletePopover(false);
-          setIsExiting(true);
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, EXIT_ANIMATION_MS);
-          });
-          await onDeleteKit(kit);
-        } catch {
-          // Only reset if deletion failed — component stays mounted
-          setIsDeleting(false);
-          setIsExiting(false);
-        }
-      };
-
-      const handleDuplicateClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (!onDuplicateKit) {
-          onDuplicate();
-          return;
-        }
-        setDuplicateDest("");
-        setDuplicateError(null);
-        setShowDuplicatePopover(true);
-      };
-
-      const handleConfirmDuplicate = async () => {
-        if (!onDuplicateKit) return;
-        const result = await onDuplicateKit(kit, duplicateDest);
-        if (result.error) {
-          setDuplicateError(result.error);
-          return;
-        }
-        setShowDuplicatePopover(false);
-        setDuplicateDest("");
-        setDuplicateError(null);
-      };
+      // Delete/duplicate popover state machines and exit animation
+      const actions = useKitItemActions({
+        kitName: kit,
+        onDelete,
+        onDeleteKit,
+        onDuplicate,
+        onDuplicateKit,
+        onRequestDeleteSummary,
+      });
 
       const totalSamples =
         (sampleCounts?.[0] || 0) +
@@ -313,7 +99,7 @@ const KitGridItem = React.memo(
 
       // Build animation classes
       let animationClasses = "";
-      if (isExiting) animationClasses = "animate-kit-exit";
+      if (actions.isExiting) animationClasses = "animate-kit-exit";
       else if (isNew)
         animationClasses = "animate-kit-enter animate-border-flash";
 
@@ -436,8 +222,8 @@ const KitGridItem = React.memo(
               {isValid && (
                 <button
                   className="p-1 text-xs text-text-tertiary hover:text-accent-success ml-1"
-                  onClick={handleDuplicateClick}
-                  ref={duplicateButtonRef}
+                  onClick={actions.handleDuplicateClick}
+                  ref={actions.duplicateButtonRef}
                   title="Duplicate kit"
                 >
                   <CopyIcon size={15} />
@@ -447,8 +233,8 @@ const KitGridItem = React.memo(
                 <button
                   className="p-1 text-xs text-text-tertiary hover:text-accent-danger"
                   data-testid="delete-kit-button"
-                  onClick={handleDeleteClick}
-                  ref={deleteButtonRef}
+                  onClick={actions.handleDeleteClick}
+                  ref={actions.deleteButtonRef}
                   title="Delete kit"
                 >
                   <TrashIcon size={15} />
@@ -477,134 +263,43 @@ const KitGridItem = React.memo(
 
           {/* Delete confirmation popover */}
           <ActionPopover
-            anchorRef={deleteButtonRef}
-            isOpen={showDeletePopover}
-            onClose={() => setShowDeletePopover(false)}
+            anchorRef={actions.deleteButtonRef}
+            isOpen={actions.showDeletePopover}
+            onClose={actions.closeDeletePopover}
           >
             <DeletePopoverContent
-              isDeleting={isDeleting}
+              isDeleting={actions.isDeleting}
               kitName={kit}
-              onCancel={() => setShowDeletePopover(false)}
-              onConfirm={handleConfirmDelete}
-              sampleCount={deleteSampleCount}
+              onCancel={actions.closeDeletePopover}
+              onConfirm={actions.handleConfirmDelete}
+              sampleCount={actions.deleteSampleCount}
             />
           </ActionPopover>
 
           {/* Duplicate popover */}
           <ActionPopover
-            anchorRef={duplicateButtonRef}
-            isOpen={showDuplicatePopover}
-            onClose={() => {
-              setShowDuplicatePopover(false);
-              setDuplicateError(null);
-            }}
+            anchorRef={actions.duplicateButtonRef}
+            isOpen={actions.showDuplicatePopover}
+            onClose={actions.closeDuplicatePopover}
           >
             <DuplicatePopoverContent
-              duplicateDest={duplicateDest}
-              duplicateError={duplicateError}
+              duplicateDest={actions.duplicateDest}
+              duplicateError={actions.duplicateError}
               kitName={kit}
-              onCancel={() => {
-                setShowDuplicatePopover(false);
-                setDuplicateError(null);
-              }}
-              onConfirm={handleConfirmDuplicate}
-              onDestChange={setDuplicateDest}
+              onCancel={actions.closeDuplicatePopover}
+              onConfirm={actions.handleConfirmDuplicate}
+              onDestChange={actions.setDuplicateDest}
             />
           </ActionPopover>
 
           {/* Voice channel strip */}
-          {isValid &&
-            sampleCounts &&
-            totalSamples > 0 &&
-            (() => {
-              const matchesByVoice =
-                kitData?.searchMatch?.matchedSamplesByVoice;
-              const hasVoiceMatches =
-                matchesByVoice && Object.keys(matchesByVoice).length > 0;
-
-              return (
-                <>
-                  <div className="border-t border-border-subtle mt-1.5 mb-1" />
-                  <div className="flex items-start gap-1 w-full">
-                    {sampleCounts.map((count, idx) => {
-                      const voiceNumber = idx + 1;
-                      const voiceName = voiceNames?.[voiceNumber];
-                      const voiceDisplayName =
-                        typeof voiceName === "string"
-                          ? toCapitalCase(voiceName)
-                          : voiceName;
-                      const countStyle = getVoiceCountStyle(count);
-                      const voiceMatches = matchesByVoice?.[voiceNumber];
-                      const hasMatches =
-                        voiceMatches && voiceMatches.length > 0;
-                      const displayLabel =
-                        voiceDisplayName ||
-                        (hasVoiceMatches ? `Voice ${voiceNumber}` : "\u00A0");
-                      const countCell = hasVoiceMatches ? null : (
-                        <span
-                          className={`text-[13px] font-mono ${countStyle.text} ${countStyle.weight}`}
-                        >
-                          {count}
-                        </span>
-                      );
-
-                      return (
-                        <div
-                          className={`w-1/4 flex flex-col items-center ${
-                            hasVoiceMatches && !hasMatches
-                              ? "opacity-30 justify-center"
-                              : "gap-0.5"
-                          }`}
-                          // sampleCounts is a fixed 4-tuple; voiceNumber
-                          // (= idx + 1) is the semantic voice id, not an
-                          // arbitrary index. NOSONAR suppresses S6479.
-                          key={`voice-${voiceNumber}`} // NOSONAR
-                          title={
-                            `Voice ${voiceNumber}: ${count} samples` +
-                            (voiceName ? ` (${voiceName})` : "")
-                          }
-                        >
-                          <span className="text-[11px] text-text-secondary font-mono truncate w-full text-center">
-                            {displayLabel}
-                          </span>
-                          {hasMatches ? (
-                            <div
-                              className="w-full overflow-hidden transition-all duration-300 ease-in-out"
-                              data-testid={`voice-${voiceNumber}-matches`}
-                              style={{
-                                maxHeight: `${voiceMatches.length * 1.25 + 0.25}rem`,
-                              }}
-                            >
-                              {voiceMatches.map((filename) => {
-                                const stripped = stripExtension(filename);
-                                const term = kitData?.searchMatch?.searchTerm;
-                                return (
-                                  <span
-                                    className="block text-[10px] font-mono text-text-secondary truncate w-full text-center leading-tight"
-                                    key={filename}
-                                    title={filename}
-                                  >
-                                    {term
-                                      ? highlightMatch(
-                                          stripped,
-                                          term,
-                                          "bg-accent-success/25 text-accent-success",
-                                        )
-                                      : stripped}
-                                  </span>
-                                );
-                              })}
-                            </div>
-                          ) : (
-                            countCell
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </>
-              );
-            })()}
+          {isValid && sampleCounts && totalSamples > 0 && (
+            <KitVoiceStrip
+              kitData={kitData}
+              sampleCounts={sampleCounts}
+              voiceNames={voiceNames}
+            />
+          )}
 
           {/* Voice names row — shown when voices have names but no samples to display them in */}
           {isValid &&

--- a/app/renderer/components/KitVoiceStrip.tsx
+++ b/app/renderer/components/KitVoiceStrip.tsx
@@ -1,0 +1,119 @@
+import { toCapitalCase } from "@romper/shared/kitUtilsShared";
+import React from "react";
+
+import type { KitWithSearchMatch } from "./shared/kitItemUtils";
+
+import { highlightMatch, stripExtension } from "./shared/searchHighlight";
+
+interface KitVoiceStripProps {
+  kitData?: KitWithSearchMatch | null;
+  sampleCounts: [number, number, number, number];
+  voiceNames?: Record<number | string, string>;
+}
+
+const getVoiceCountStyle = (count: number) => {
+  if (count === 0) {
+    return { text: "text-accent-danger", weight: "" };
+  }
+  if (count === 12) {
+    return { text: "text-accent-success", weight: "font-bold" };
+  }
+  return { text: "text-accent-primary", weight: "" };
+};
+
+/**
+ * The four-voice channel strip at the bottom of a kit grid item: per-voice
+ * name and sample count, replaced by matching sample filenames (with the
+ * search term highlighted) when a sample search is active.
+ */
+export const KitVoiceStrip: React.FC<KitVoiceStripProps> = ({
+  kitData,
+  sampleCounts,
+  voiceNames,
+}) => {
+  const matchesByVoice = kitData?.searchMatch?.matchedSamplesByVoice;
+  const hasVoiceMatches =
+    matchesByVoice && Object.keys(matchesByVoice).length > 0;
+
+  return (
+    <>
+      <div className="border-t border-border-subtle mt-1.5 mb-1" />
+      <div className="flex items-start gap-1 w-full">
+        {sampleCounts.map((count, idx) => {
+          const voiceNumber = idx + 1;
+          const voiceName = voiceNames?.[voiceNumber];
+          const voiceDisplayName =
+            typeof voiceName === "string"
+              ? toCapitalCase(voiceName)
+              : voiceName;
+          const countStyle = getVoiceCountStyle(count);
+          const voiceMatches = matchesByVoice?.[voiceNumber];
+          const hasMatches = voiceMatches && voiceMatches.length > 0;
+          const displayLabel =
+            voiceDisplayName ||
+            (hasVoiceMatches ? `Voice ${voiceNumber}` : " ");
+          const countCell = hasVoiceMatches ? null : (
+            <span
+              className={`text-[13px] font-mono ${countStyle.text} ${countStyle.weight}`}
+            >
+              {count}
+            </span>
+          );
+
+          return (
+            <div
+              className={`w-1/4 flex flex-col items-center ${
+                hasVoiceMatches && !hasMatches
+                  ? "opacity-30 justify-center"
+                  : "gap-0.5"
+              }`}
+              // sampleCounts is a fixed 4-tuple; voiceNumber
+              // (= idx + 1) is the semantic voice id, not an
+              // arbitrary index. NOSONAR suppresses S6479.
+              key={`voice-${voiceNumber}`} // NOSONAR
+              title={
+                `Voice ${voiceNumber}: ${count} samples` +
+                (voiceName ? ` (${voiceName})` : "")
+              }
+            >
+              <span className="text-[11px] text-text-secondary font-mono truncate w-full text-center">
+                {displayLabel}
+              </span>
+              {hasMatches ? (
+                <div
+                  className="w-full overflow-hidden transition-all duration-300 ease-in-out"
+                  data-testid={`voice-${voiceNumber}-matches`}
+                  style={{
+                    maxHeight: `${voiceMatches.length * 1.25 + 0.25}rem`,
+                  }}
+                >
+                  {voiceMatches.map((filename) => {
+                    const stripped = stripExtension(filename);
+                    const term = kitData?.searchMatch?.searchTerm;
+                    return (
+                      <span
+                        className="block text-[10px] font-mono text-text-secondary truncate w-full text-center leading-tight"
+                        key={filename}
+                        title={filename}
+                      >
+                        {term
+                          ? highlightMatch(
+                              stripped,
+                              term,
+                              "bg-accent-success/25 text-accent-success",
+                            )
+                          : stripped}
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : (
+                countCell
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+};

--- a/app/renderer/components/hooks/kit-management/useKitItemActions.ts
+++ b/app/renderer/components/hooks/kit-management/useKitItemActions.ts
@@ -1,0 +1,130 @@
+import { useRef, useState } from "react";
+
+export type DeleteSummary = { locked: boolean; sampleCount: number };
+
+export type DuplicateKitFn = (
+  source: string,
+  dest: string,
+) => Promise<{ error?: string }>;
+
+export type RequestDeleteSummaryFn = (
+  kitName: string,
+) => Promise<DeleteSummary | null>;
+
+const EXIT_ANIMATION_MS = 250;
+
+interface UseKitItemActionsParams {
+  kitName: string;
+  onDelete?: () => void;
+  onDeleteKit?: (kitName: string) => Promise<void>;
+  onDuplicate: () => void;
+  onDuplicateKit?: DuplicateKitFn;
+  onRequestDeleteSummary?: RequestDeleteSummaryFn;
+}
+
+/**
+ * Delete/duplicate action state for a kit browser item: the confirmation
+ * popover state machines, the exit animation on confirmed delete, and the
+ * legacy no-popover fallbacks (plain onDelete / onDuplicate).
+ */
+export function useKitItemActions({
+  kitName,
+  onDelete,
+  onDeleteKit,
+  onDuplicate,
+  onDuplicateKit,
+  onRequestDeleteSummary,
+}: UseKitItemActionsParams) {
+  // Exit animation state (plays before the item unmounts on delete)
+  const [isExiting, setIsExiting] = useState(false);
+
+  // Delete popover state
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  const [showDeletePopover, setShowDeletePopover] = useState(false);
+  const [deleteSampleCount, setDeleteSampleCount] = useState<number>(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Duplicate popover state
+  const duplicateButtonRef = useRef<HTMLButtonElement>(null);
+  const [showDuplicatePopover, setShowDuplicatePopover] = useState(false);
+  const [duplicateDest, setDuplicateDest] = useState("");
+  const [duplicateError, setDuplicateError] = useState<null | string>(null);
+
+  const handleDeleteClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!onRequestDeleteSummary) {
+      onDelete?.();
+      return;
+    }
+    const summary = await onRequestDeleteSummary(kitName);
+    if (!summary) return;
+    setDeleteSampleCount(summary.sampleCount);
+    setShowDeletePopover(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!onDeleteKit) return;
+    setIsDeleting(true);
+    try {
+      setShowDeletePopover(false);
+      setIsExiting(true);
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, EXIT_ANIMATION_MS);
+      });
+      await onDeleteKit(kitName);
+    } catch {
+      // Only reset if deletion failed — component stays mounted
+      setIsDeleting(false);
+      setIsExiting(false);
+    }
+  };
+
+  const handleDuplicateClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!onDuplicateKit) {
+      onDuplicate();
+      return;
+    }
+    setDuplicateDest("");
+    setDuplicateError(null);
+    setShowDuplicatePopover(true);
+  };
+
+  const handleConfirmDuplicate = async () => {
+    if (!onDuplicateKit) return;
+    const result = await onDuplicateKit(kitName, duplicateDest);
+    if (result.error) {
+      setDuplicateError(result.error);
+      return;
+    }
+    setShowDuplicatePopover(false);
+    setDuplicateDest("");
+    setDuplicateError(null);
+  };
+
+  const closeDeletePopover = () => setShowDeletePopover(false);
+
+  const closeDuplicatePopover = () => {
+    setShowDuplicatePopover(false);
+    setDuplicateError(null);
+  };
+
+  return {
+    closeDeletePopover,
+    closeDuplicatePopover,
+    deleteButtonRef,
+    deleteSampleCount,
+    duplicateButtonRef,
+    duplicateDest,
+    duplicateError,
+    handleConfirmDelete,
+    handleConfirmDuplicate,
+    handleDeleteClick,
+    handleDuplicateClick,
+    isDeleting,
+    isExiting,
+    setDuplicateDest,
+    showDeletePopover,
+    showDuplicatePopover,
+  };
+}

--- a/app/renderer/components/shared/KitItemActionPopovers.tsx
+++ b/app/renderer/components/shared/KitItemActionPopovers.tsx
@@ -1,0 +1,136 @@
+import { TrashIcon, WarningIcon } from "@phosphor-icons/react";
+import React from "react";
+
+/**
+ * Confirmation popover bodies for the kit item delete and duplicate actions.
+ * Rendered inside an ActionPopover anchored to the triggering button.
+ */
+
+export interface DeletePopoverContentProps {
+  isDeleting: boolean;
+  kitName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  sampleCount: number;
+}
+
+export interface DuplicatePopoverContentProps {
+  duplicateDest: string;
+  duplicateError: null | string;
+  kitName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onDestChange: (value: string) => void;
+}
+
+export const DeletePopoverContent: React.FC<DeletePopoverContentProps> = ({
+  isDeleting,
+  kitName,
+  onCancel,
+  onConfirm,
+  sampleCount,
+}) => (
+  <div className="flex flex-col gap-2">
+    <div className="flex items-center gap-1.5">
+      {sampleCount > 0 ? (
+        <WarningIcon
+          className="text-accent-warning flex-shrink-0"
+          size={14}
+          weight="bold"
+        />
+      ) : null}
+      <span className="text-sm font-semibold text-text-primary">
+        Delete kit {kitName}?
+      </span>
+    </div>
+    {sampleCount > 0 && (
+      <p className="text-xs text-text-secondary">
+        {sampleCount} sample {sampleCount === 1 ? "reference" : "references"}{" "}
+        will be removed. Files on disk are not affected.
+      </p>
+    )}
+    {sampleCount === 0 && (
+      <p className="text-xs text-text-tertiary">No samples. Safe to remove.</p>
+    )}
+    <div className="flex gap-2">
+      <button
+        className={`px-2 py-1 text-xs text-white rounded font-semibold inline-flex items-center gap-1 disabled:opacity-50 ${sampleCount > 0 ? "bg-accent-danger hover:bg-accent-danger/80" : "bg-accent-primary hover:bg-accent-primary/80"}`}
+        data-testid="confirm-delete-button"
+        disabled={isDeleting}
+        onClick={(e) => {
+          e.stopPropagation();
+          onConfirm();
+        }}
+      >
+        <TrashIcon size={13} />
+        {isDeleting ? "Deleting..." : "Delete"}
+      </button>
+      <button
+        className="px-2 py-1 text-xs bg-surface-4 text-text-secondary rounded hover:bg-surface-3 font-semibold"
+        disabled={isDeleting}
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancel();
+        }}
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+);
+
+export const DuplicatePopoverContent: React.FC<
+  DuplicatePopoverContentProps
+> = ({
+  duplicateDest,
+  duplicateError,
+  kitName,
+  onCancel,
+  onConfirm,
+  onDestChange,
+}) => (
+  <div className="flex flex-col gap-2">
+    <label className="text-xs font-semibold text-text-primary">
+      Duplicate {kitName} to:
+      <input
+        autoFocus
+        className="ml-2 px-2 py-1 rounded border border-border-default text-sm bg-surface-2 text-text-primary w-16"
+        data-testid="duplicate-dest-input"
+        maxLength={3}
+        onChange={(e) => onDestChange(e.target.value.toUpperCase())}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onConfirm();
+          }
+        }}
+        value={duplicateDest}
+      />
+    </label>
+    {duplicateError && (
+      <div className="text-xs text-accent-danger">{duplicateError}</div>
+    )}
+    <div className="flex gap-2">
+      <button
+        className="px-2 py-1 text-xs bg-accent-success text-white rounded hover:bg-accent-success/80 font-semibold"
+        data-testid="confirm-duplicate-button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onConfirm();
+        }}
+      >
+        Duplicate
+      </button>
+      <button
+        className="px-2 py-1 text-xs bg-surface-4 text-text-secondary rounded hover:bg-surface-3 font-semibold"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancel();
+        }}
+      >
+        Cancel
+      </button>
+    </div>
+  </div>
+);

--- a/app/renderer/components/shared/searchHighlight.tsx
+++ b/app/renderer/components/shared/searchHighlight.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+/**
+ * Search-term highlighting helpers shared by kit browser items.
+ */
+
+export const stripExtension = (filename: string) =>
+  filename.replace(/\.[^.]+$/, "");
+
+export const highlightMatch = (
+  text: string,
+  term: string,
+  markClass = "bg-accent-primary/25 text-accent-primary",
+) => {
+  const idx = text.toLowerCase().indexOf(term.toLowerCase());
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className={`${markClass} font-semibold rounded-sm px-0.5`}>
+        {text.slice(idx, idx + term.length)}
+      </mark>
+      {text.slice(idx + term.length)}
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

The largest renderer god-object from the audit: `KitGridItem.tsx` (635 lines) held two popover bodies, the delete/duplicate confirmation state machines, search-highlight helpers, a 90-line voice-strip render block, and the actual grid-item layout. This splits each concern along its existing seam:

| New module | Contents |
|---|---|
| `shared/KitItemActionPopovers.tsx` | `DeletePopoverContent` / `DuplicatePopoverContent` bodies, moved verbatim and exported |
| `hooks/kit-management/useKitItemActions.ts` | The delete/duplicate popover state machines, the exit animation on confirmed delete, and the legacy no-popover fallbacks; exports the `DuplicateKitFn` / `RequestDeleteSummaryFn` types the props reference |
| `KitVoiceStrip.tsx` | The four-voice channel strip, including the search-match filename expansion and per-voice count styling |
| `shared/searchHighlight.tsx` | `highlightMatch` + `stripExtension`, used by both the alias line and the voice strip |

`KitGridItem` keeps the layout and the favorite-pulse state (**330 lines**, down from 635).

### Validation

- Markup is unchanged — render blocks moved verbatim (including the ` ` empty-label fallback and the NOSONAR markers with their justifications).
- The existing `KitGridItem` / `KitGrid` / `KitGridCard` suites — **126 tests** covering the delete/duplicate popovers, search highlighting, and the voice strip — pass **unmodified**.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

### Audit-backlog status after this PR

- `formatConverter.ts` (403 lines) — reviewed and **deliberately skipped**: it is one cohesive concern (WAV conversion) already factored into small documented helpers; splitting would add indirection without benefit.
- `KitsView.tsx` (390 lines) — last remaining item.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_