### PR TITLE
refactor: extract local-store gate and refresh listener from KitsView

### DIFF
--- a/app/renderer/components/EnvironmentBanner.tsx
+++ b/app/renderer/components/EnvironmentBanner.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface EnvironmentBannerProps {
+  localStorePath?: null | string;
+  onDismiss: () => void;
+}
+
+/**
+ * Dismissible banner shown when the local store path is overridden via the
+ * ROMPER_LOCAL_PATH environment variable (test mode).
+ */
+export const EnvironmentBanner: React.FC<EnvironmentBannerProps> = ({
+  localStorePath,
+  onDismiss,
+}) => (
+  <div className="bg-accent-warning/10 border-l-4 border-accent-warning p-3 mb-2">
+    <div className="flex items-center justify-between">
+      <div className="flex items-center">
+        <span className="text-accent-warning text-sm font-medium">
+          🧪 Test Mode: Using ROMPER_LOCAL_PATH environment override
+        </span>
+        <span className="ml-2 text-accent-warning/70 text-xs font-mono">
+          {localStorePath}
+        </span>
+      </div>
+      <button
+        className="text-accent-warning/70 hover:text-accent-warning text-sm"
+        onClick={onDismiss}
+      >
+        Dismiss
+      </button>
+    </div>
+  </div>
+);

--- a/app/renderer/components/hooks/kit-management/__tests__/useLocalStoreSetupFlow.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useLocalStoreSetupFlow.test.ts
@@ -1,0 +1,211 @@
+import type { LocalStoreValidationDetailedResult } from "@romper/shared/db/schema.js";
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupElectronAPIMock } from "../../../../../../tests/mocks/electron/electronAPI";
+import { useLocalStoreSetupFlow } from "../useLocalStoreSetupFlow";
+
+// Note: vitest runs with import.meta.env.MODE === "test", so the hook's
+// isTestEnvironment branch is active in all of these tests.
+
+const makeStatus = (
+  overrides: Partial<LocalStoreValidationDetailedResult>,
+): LocalStoreValidationDetailedResult =>
+  ({
+    hasLocalStore: true,
+    isValid: true,
+    localStorePath: "/store",
+    ...overrides,
+  }) as LocalStoreValidationDetailedResult;
+
+describe("useLocalStoreSetupFlow", () => {
+  const closeWizard = vi.fn();
+  const refreshLocalStoreStatus = vi.fn().mockResolvedValue(undefined);
+  const setShowWizard = vi.fn();
+
+  const render = (
+    localStoreStatus: LocalStoreValidationDetailedResult | null,
+    isInitialized = true,
+  ) =>
+    renderHook(
+      (props: {
+        isInitialized: boolean;
+        localStoreStatus: LocalStoreValidationDetailedResult | null;
+      }) =>
+        useLocalStoreSetupFlow({
+          closeWizard,
+          isInitialized: props.isInitialized,
+          localStoreStatus: props.localStoreStatus,
+          refreshLocalStoreStatus,
+          setShowWizard,
+        }),
+      { initialProps: { isInitialized, localStoreStatus } },
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectronAPIMock();
+    refreshLocalStoreStatus.mockResolvedValue(undefined);
+  });
+
+  describe("scenario flags", () => {
+    it("reports nothing before initialization or status", () => {
+      const { result } = render(null, false);
+
+      expect(result.current.needsLocalStoreSetup).toBe(false);
+      expect(result.current.hasInvalidLocalStore).toBe(false);
+      expect(result.current.hasCriticalEnvironmentError).toBe(false);
+      expect(setShowWizard).not.toHaveBeenCalled();
+    });
+
+    it("needs setup when no local store is configured (A1-A3)", () => {
+      const { result } = render(makeStatus({ hasLocalStore: false }));
+
+      expect(result.current.needsLocalStoreSetup).toBe(true);
+      expect(result.current.hasInvalidLocalStore).toBe(false);
+      expect(setShowWizard).toHaveBeenCalledWith(true);
+    });
+
+    it("flags an invalid configured store as blocking (C1-C6)", () => {
+      const { result } = render(makeStatus({ isValid: false }));
+
+      expect(result.current.hasInvalidLocalStore).toBe(true);
+      expect(result.current.needsLocalStoreSetup).toBe(false);
+      expect(setShowWizard).not.toHaveBeenCalled();
+    });
+
+    it("routes an invalid env-override store to setup instead of blocking in test env", () => {
+      const { result } = render(
+        makeStatus({ isEnvironmentOverride: true, isValid: false }),
+      );
+
+      expect(result.current.needsLocalStoreSetup).toBe(true);
+      expect(result.current.hasInvalidLocalStore).toBe(false);
+    });
+
+    it("flags critical environment errors", () => {
+      const { result } = render(
+        makeStatus({ isCriticalEnvironmentError: true }),
+      );
+
+      expect(result.current.hasCriticalEnvironmentError).toBe(true);
+    });
+
+    it("reports a valid configured store as fully healthy", () => {
+      const { result } = render(makeStatus({}));
+
+      expect(result.current.needsLocalStoreSetup).toBe(false);
+      expect(result.current.hasInvalidLocalStore).toBe(false);
+      expect(result.current.hasCriticalEnvironmentError).toBe(false);
+    });
+  });
+
+  describe("environment banner", () => {
+    it("shows on environment override and can be dismissed", () => {
+      const { result } = render(makeStatus({ isEnvironmentOverride: true }));
+
+      expect(result.current.showEnvironmentBanner).toBe(true);
+
+      act(() => {
+        result.current.dismissEnvironmentBanner();
+      });
+
+      expect(result.current.showEnvironmentBanner).toBe(false);
+    });
+
+    it("stays hidden without an override", () => {
+      const { result } = render(makeStatus({}));
+
+      expect(result.current.showEnvironmentBanner).toBe(false);
+    });
+  });
+
+  describe("wizard lifecycle", () => {
+    it("suppresses re-opening the wizard after a successful completion", async () => {
+      const { rerender, result } = render(makeStatus({ hasLocalStore: false }));
+      expect(setShowWizard).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.handleWizardSuccess();
+      });
+
+      expect(closeWizard).toHaveBeenCalledTimes(1);
+      expect(refreshLocalStoreStatus).toHaveBeenCalledTimes(1);
+
+      // Status still says "needs setup" until the refresh lands, but the
+      // just-completed flag must prevent the auto-trigger from re-firing
+      setShowWizard.mockClear();
+      rerender({
+        isInitialized: true,
+        localStoreStatus: makeStatus({ hasLocalStore: false }),
+      });
+      expect(setShowWizard).not.toHaveBeenCalled();
+    });
+
+    it("re-arms the auto-trigger once setup is no longer needed", async () => {
+      const { rerender, result } = render(makeStatus({ hasLocalStore: false }));
+
+      await act(async () => {
+        await result.current.handleWizardSuccess();
+      });
+
+      // Refresh lands: store is now valid, just-completed flag resets
+      rerender({ isInitialized: true, localStoreStatus: makeStatus({}) });
+      expect(result.current.needsLocalStoreSetup).toBe(false);
+
+      // Store disappears again: wizard auto-opens once more
+      setShowWizard.mockClear();
+      rerender({
+        isInitialized: true,
+        localStoreStatus: makeStatus({ hasLocalStore: false }),
+      });
+      expect(setShowWizard).toHaveBeenCalledWith(true);
+    });
+
+    it("exposes the wizard-initializing flag", () => {
+      const { result } = render(makeStatus({}));
+
+      expect(result.current.isWizardInitializing).toBe(false);
+      act(() => {
+        result.current.setIsWizardInitializing(true);
+      });
+      expect(result.current.isWizardInitializing).toBe(true);
+    });
+  });
+
+  describe("handleCriticalError", () => {
+    it("closes the app via the electron API", () => {
+      const { result } = render(
+        makeStatus({ isCriticalEnvironmentError: true }),
+      );
+
+      act(() => {
+        result.current.handleCriticalError();
+      });
+
+      expect(window.electronAPI.closeApp).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to window.close without the electron API", () => {
+      delete (window.electronAPI as { closeApp?: unknown }).closeApp;
+      const windowCloseSpy = vi
+        .spyOn(window, "close")
+        .mockImplementation(() => {});
+
+      const { result } = render(
+        makeStatus({ isCriticalEnvironmentError: true }),
+      );
+
+      act(() => {
+        result.current.handleCriticalError();
+      });
+
+      expect(windowCloseSpy).toHaveBeenCalledTimes(1);
+
+      windowCloseSpy.mockRestore();
+      // Rebuild the centralized mock to restore closeApp for later tests
+      setupElectronAPIMock();
+    });
+  });
+});

--- a/app/renderer/components/hooks/kit-management/useLocalStoreSetupFlow.ts
+++ b/app/renderer/components/hooks/kit-management/useLocalStoreSetupFlow.ts
@@ -1,0 +1,130 @@
+import type { LocalStoreValidationDetailedResult } from "@romper/shared/db/schema.js";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface ImportMetaEnv {
+  env: {
+    MODE?: string;
+    VITE_ROMPER_TEST_MODE?: string;
+  };
+}
+
+interface UseLocalStoreSetupFlowParams {
+  closeWizard: () => void;
+  isInitialized: boolean;
+  localStoreStatus: LocalStoreValidationDetailedResult | null;
+  refreshLocalStoreStatus: () => Promise<void>;
+  setShowWizard: (show: boolean) => void;
+}
+
+/**
+ * Local store configuration gate for the kits view.
+ *
+ * Derives the setup-scenario flags from the validation status:
+ * - A1-A3: no local store configured — auto-open the setup wizard
+ * - C1-C6: local store configured but invalid — blocking error dialog
+ * - critical environment-variable error — app must close
+ * - D: environment override — dismissible test-mode banner
+ *
+ * Also owns the wizard lifecycle around those flags (auto-trigger,
+ * just-completed suppression, initialization-in-progress) and the
+ * success/critical-error handlers.
+ */
+export function useLocalStoreSetupFlow({
+  closeWizard,
+  isInitialized,
+  localStoreStatus,
+  refreshLocalStoreStatus,
+  setShowWizard,
+}: UseLocalStoreSetupFlowParams) {
+  // Determine local store configuration state according to requirements
+  // A1-A3: No local store configured - show setup wizard
+  // Also includes test environment overrides with invalid paths (for wizard tests)
+  const isTestEnvironment =
+    (import.meta as unknown as ImportMetaEnv).env.MODE === "test" ||
+    (import.meta as unknown as ImportMetaEnv).env.VITE_ROMPER_TEST_MODE ===
+      "true";
+  const isEnvironmentOverride =
+    localStoreStatus?.isEnvironmentOverride || false;
+  const needsLocalStoreSetup =
+    isInitialized &&
+    localStoreStatus !== null &&
+    (!localStoreStatus.hasLocalStore ||
+      (isTestEnvironment &&
+        isEnvironmentOverride &&
+        !localStoreStatus.isValid));
+
+  // C1-C6: Local store configured but invalid - show modal blocking error dialog
+  // Exception: In test environment with env override, don't block - let tests proceed
+  const hasInvalidLocalStore =
+    isInitialized &&
+    localStoreStatus !== null &&
+    Boolean(localStoreStatus.hasLocalStore) &&
+    !localStoreStatus.isValid &&
+    !(isTestEnvironment && isEnvironmentOverride);
+
+  // Critical environment variable error - should close app
+  const hasCriticalEnvironmentError = Boolean(
+    localStoreStatus?.isCriticalEnvironmentError,
+  );
+
+  // D: Environment variable override - show test mode banner
+  const [showEnvironmentBanner, setShowEnvironmentBanner] = useState(false);
+
+  useEffect(() => {
+    if (isEnvironmentOverride) {
+      setShowEnvironmentBanner(true);
+    }
+  }, [isEnvironmentOverride]);
+
+  // Track if we just completed the wizard to prevent re-opening
+  const [wizardJustCompleted, setWizardJustCompleted] = useState(false);
+
+  // Track wizard initialization state to suppress invalid store dialog
+  const [isWizardInitializing, setIsWizardInitializing] = useState(false);
+
+  // Auto-trigger wizard on startup if local store is not configured
+  useEffect(() => {
+    if (needsLocalStoreSetup && !wizardJustCompleted) {
+      setShowWizard(true);
+    }
+  }, [needsLocalStoreSetup, setShowWizard, wizardJustCompleted]);
+
+  // Reset wizardJustCompleted when needsLocalStoreSetup becomes false
+  useEffect(() => {
+    if (!needsLocalStoreSetup && wizardJustCompleted) {
+      setWizardJustCompleted(false);
+    }
+  }, [needsLocalStoreSetup, wizardJustCompleted]);
+
+  // Wizard success handler
+  const handleWizardSuccess = useCallback(async () => {
+    setWizardJustCompleted(true);
+    closeWizard();
+    await refreshLocalStoreStatus();
+  }, [closeWizard, refreshLocalStoreStatus]);
+
+  // Critical error handler
+  const handleCriticalError = useCallback(() => {
+    if (globalThis.electronAPI?.closeApp) {
+      void globalThis.electronAPI.closeApp();
+    } else {
+      // Fallback for development or if API is not available
+      window.close();
+    }
+  }, []);
+
+  return {
+    dismissEnvironmentBanner: () => setShowEnvironmentBanner(false),
+    handleCriticalError,
+    handleWizardSuccess,
+    hasCriticalEnvironmentError,
+    hasInvalidLocalStore,
+    isEnvironmentOverride,
+    isTestEnvironment,
+    isWizardInitializing,
+    needsLocalStoreSetup,
+    setIsWizardInitializing,
+    showEnvironmentBanner,
+  };
+}

--- a/app/renderer/components/hooks/kit-management/useSampleRefreshListener.ts
+++ b/app/renderer/components/hooks/kit-management/useSampleRefreshListener.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+interface UseSampleRefreshListenerParams {
+  reloadCurrentKitSamples: (kitName: string) => Promise<void>;
+  selectedKit: null | string;
+}
+
+/**
+ * Listens for "romper:refresh-samples" events (dispatched by undo
+ * operations) and reloads the affected kit's samples when it is the
+ * currently selected kit. The listener is registered once; the latest
+ * selection and reload function are read through refs.
+ */
+export function useSampleRefreshListener({
+  reloadCurrentKitSamples,
+  selectedKit,
+}: UseSampleRefreshListenerParams) {
+  // Store latest values in refs to avoid recreating event listener
+  const selectedKitRef = useRef(selectedKit);
+  const reloadCurrentKitSamplesRef = useRef(reloadCurrentKitSamples);
+
+  // Update refs when values change
+  useEffect(() => {
+    selectedKitRef.current = selectedKit;
+  }, [selectedKit]);
+
+  useEffect(() => {
+    reloadCurrentKitSamplesRef.current = reloadCurrentKitSamples;
+  }, [reloadCurrentKitSamples]);
+
+  // Listen for refresh events from undo operations - stable event listener
+  useEffect(() => {
+    const handleRefreshSamples = (event: Event) => {
+      const customEvent = event as CustomEvent<{ kitName: string }>;
+      if (customEvent.detail.kitName === selectedKitRef.current) {
+        void reloadCurrentKitSamplesRef.current(selectedKitRef.current);
+      }
+    };
+
+    document.addEventListener("romper:refresh-samples", handleRefreshSamples);
+
+    return () => {
+      document.removeEventListener(
+        "romper:refresh-samples",
+        handleRefreshSamples,
+      );
+    };
+  }, []); // Empty dependency array - event listener is created only once
+}

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -1,21 +1,15 @@
-// Removed unused import
-
-import React, { useCallback, useEffect, useRef, useState } from "react";
-
-interface ImportMeta {
-  env: {
-    MODE?: string;
-    VITE_ROMPER_TEST_MODE?: string;
-  };
-}
+import React, { useCallback, useEffect } from "react";
 
 import CriticalErrorDialog from "../components/dialogs/CriticalErrorDialog";
 import InvalidLocalStoreDialog from "../components/dialogs/InvalidLocalStoreDialog";
+import { EnvironmentBanner } from "../components/EnvironmentBanner";
 import { useKitDataManager } from "../components/hooks/kit-management/useKitDataManager";
 import { useKitFilters } from "../components/hooks/kit-management/useKitFilters";
 import { useKitNavigation } from "../components/hooks/kit-management/useKitNavigation";
 import { useKitSearch } from "../components/hooks/kit-management/useKitSearch";
 import { useKitViewMenuHandlers } from "../components/hooks/kit-management/useKitViewMenuHandlers";
+import { useLocalStoreSetupFlow } from "../components/hooks/kit-management/useLocalStoreSetupFlow";
+import { useSampleRefreshListener } from "../components/hooks/kit-management/useSampleRefreshListener";
 import { useDialogState } from "../components/hooks/shared/useDialogState";
 import { useGlobalKeyboardShortcuts } from "../components/hooks/shared/useGlobalKeyboardShortcuts";
 import { useMessageDisplay } from "../components/hooks/shared/useMessageDisplay";
@@ -24,10 +18,7 @@ import KitBrowserContainer from "../components/KitBrowserContainer";
 import KitEditorContainer from "../components/KitEditorContainer";
 import KitViewDialogs from "../components/KitViewDialogs";
 import LocalStoreWizardModal from "../components/LocalStoreWizardModal";
-import {
-  // restoreSelectedKitIfExists, // DISABLED
-  saveSelectedKitState,
-} from "../utils/hmrStateManager";
+import { saveSelectedKitState } from "../utils/hmrStateManager";
 import { useSettings } from "../utils/SettingsContext";
 
 /**
@@ -45,55 +36,18 @@ const KitsView: React.FC = () => {
 
   const { showMessage } = useMessageDisplay();
 
-  // Determine local store configuration state according to requirements
-  // A1-A3: No local store configured - show setup wizard
-  // Also includes test environment overrides with invalid paths (for wizard tests)
-  const isTestEnvironment =
-    (import.meta as ImportMeta).env.MODE === "test" ||
-    (import.meta as ImportMeta).env.VITE_ROMPER_TEST_MODE === "true";
-  const isEnvironmentOverride =
-    localStoreStatus?.isEnvironmentOverride || false;
-  const needsLocalStoreSetup =
-    isInitialized &&
-    localStoreStatus !== null &&
-    (!localStoreStatus.hasLocalStore ||
-      (isTestEnvironment &&
-        isEnvironmentOverride &&
-        !localStoreStatus.isValid));
-
-  // D: Environment variable override - show test mode banner
-
-  // C1-C6: Local store configured but invalid - show modal blocking error dialog
-  // Exception: In test environment with env override, don't block - let tests proceed
-  const hasInvalidLocalStore =
-    isInitialized &&
-    localStoreStatus !== null &&
-    Boolean(localStoreStatus.hasLocalStore) &&
-    !localStoreStatus.isValid &&
-    !(isTestEnvironment && isEnvironmentOverride);
-
-  // Critical environment variable error - should close app
-  const hasCriticalEnvironmentError = Boolean(
-    localStoreStatus?.isCriticalEnvironmentError,
-  );
-
-  const [showEnvironmentBanner, setShowEnvironmentBanner] = useState(false);
-
-  // Show environment banner when environment override is detected
-  useEffect(() => {
-    if (isEnvironmentOverride) {
-      setShowEnvironmentBanner(true);
-    }
-  }, [isEnvironmentOverride]);
-
   // Dialog state management
   const dialogState = useDialogState();
 
-  // Track if we just completed the wizard to prevent re-opening
-  const [wizardJustCompleted, setWizardJustCompleted] = useState(false);
-
-  // Track wizard initialization state to suppress invalid store dialog
-  const [isWizardInitializing, setIsWizardInitializing] = useState(false);
+  // Local store configuration gate (setup wizard / invalid store / critical
+  // environment error scenarios) and the wizard lifecycle around it
+  const setupFlow = useLocalStoreSetupFlow({
+    closeWizard: dialogState.closeWizard,
+    isInitialized,
+    localStoreStatus,
+    refreshLocalStoreStatus,
+    setShowWizard: dialogState.setShowWizard,
+  });
 
   // Kit data management
   const {
@@ -110,7 +64,8 @@ const KitsView: React.FC = () => {
   } = useKitDataManager({
     isInitialized,
     localStorePath,
-    needsLocalStoreSetup: needsLocalStoreSetup || hasInvalidLocalStore,
+    needsLocalStoreSetup:
+      setupFlow.needsLocalStoreSetup || setupFlow.hasInvalidLocalStore,
   });
 
   // Kit navigation
@@ -163,25 +118,9 @@ const KitsView: React.FC = () => {
   // Startup actions
   useStartupActions({
     localStorePath,
-    needsLocalStoreSetup: needsLocalStoreSetup || hasInvalidLocalStore,
+    needsLocalStoreSetup:
+      setupFlow.needsLocalStoreSetup || setupFlow.hasInvalidLocalStore,
   });
-
-  // Auto-trigger wizard on startup if local store is not configured
-  useEffect(() => {
-    if (needsLocalStoreSetup && !wizardJustCompleted) {
-      dialogState.setShowWizard(true);
-    }
-  }, [needsLocalStoreSetup, dialogState, wizardJustCompleted]);
-
-  // HMR: Restore selected kit state after hot reload
-  // DISABLED: This was causing kits to be auto-selected after copy operations
-  // useEffect(() => {
-  //   restoreSelectedKitIfExists(
-  //     kits,
-  //     navigation.selectedKit,
-  //     navigation.setSelectedKit,
-  //   );
-  // }, [kits, navigation.selectedKit, navigation.setSelectedKit]);
 
   // HMR: Save selected kit state before hot reload
   useEffect(() => {
@@ -190,44 +129,11 @@ const KitsView: React.FC = () => {
     }
   }, [navigation.selectedKit]);
 
-  // Reset wizardJustCompleted when needsLocalStoreSetup becomes false
-  useEffect(() => {
-    if (!needsLocalStoreSetup && wizardJustCompleted) {
-      setWizardJustCompleted(false);
-    }
-  }, [needsLocalStoreSetup, wizardJustCompleted]);
-
-  // Store latest values in refs to avoid recreating event listener
-  const selectedKitRef = useRef(navigation.selectedKit);
-  const reloadCurrentKitSamplesRef = useRef(reloadCurrentKitSamples);
-
-  // Update refs when values change
-  useEffect(() => {
-    selectedKitRef.current = navigation.selectedKit;
-  }, [navigation.selectedKit]);
-
-  useEffect(() => {
-    reloadCurrentKitSamplesRef.current = reloadCurrentKitSamples;
-  }, [reloadCurrentKitSamples]);
-
-  // Listen for refresh events from undo operations - stable event listener
-  useEffect(() => {
-    const handleRefreshSamples = (event: Event) => {
-      const customEvent = event as CustomEvent<{ kitName: string }>;
-      if (customEvent.detail.kitName === selectedKitRef.current) {
-        void reloadCurrentKitSamplesRef.current(selectedKitRef.current);
-      }
-    };
-
-    document.addEventListener("romper:refresh-samples", handleRefreshSamples);
-
-    return () => {
-      document.removeEventListener(
-        "romper:refresh-samples",
-        handleRefreshSamples,
-      );
-    };
-  }, []); // Empty dependency array - event listener is created only once
+  // Reload the selected kit's samples when undo operations request it
+  useSampleRefreshListener({
+    reloadCurrentKitSamples,
+    selectedKit: navigation.selectedKit,
+  });
 
   // Handle samples reload request
   const handleRequestSamplesReload = useCallback(async () => {
@@ -243,48 +149,17 @@ const KitsView: React.FC = () => {
     }
   }, [navigation.selectedKit, refreshSingleKitMetadata]);
 
-  // Wizard success handler
-  const handleWizardSuccess = useCallback(async () => {
-    setWizardJustCompleted(true);
-    dialogState.closeWizard();
-    await refreshLocalStoreStatus();
-  }, [dialogState, refreshLocalStoreStatus]);
-
-  // Critical error handler
-  const handleCriticalError = useCallback(() => {
-    if (globalThis.electronAPI?.closeApp) {
-      void globalThis.electronAPI.closeApp();
-    } else {
-      // Fallback for development or if API is not available
-      window.close();
-    }
-  }, []);
-
   return (
     <div className="flex flex-col h-full min-h-0" data-testid="kits-view">
       {/* Environment Variable Test Mode Banner */}
-      {showEnvironmentBanner &&
-        isEnvironmentOverride &&
-        !hasCriticalEnvironmentError &&
-        !isTestEnvironment && (
-          <div className="bg-accent-warning/10 border-l-4 border-accent-warning p-3 mb-2">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <span className="text-accent-warning text-sm font-medium">
-                  🧪 Test Mode: Using ROMPER_LOCAL_PATH environment override
-                </span>
-                <span className="ml-2 text-accent-warning/70 text-xs font-mono">
-                  {localStoreStatus?.localStorePath}
-                </span>
-              </div>
-              <button
-                className="text-accent-warning/70 hover:text-accent-warning text-sm"
-                onClick={() => setShowEnvironmentBanner(false)}
-              >
-                Dismiss
-              </button>
-            </div>
-          </div>
+      {setupFlow.showEnvironmentBanner &&
+        setupFlow.isEnvironmentOverride &&
+        !setupFlow.hasCriticalEnvironmentError &&
+        !setupFlow.isTestEnvironment && (
+          <EnvironmentBanner
+            localStorePath={localStoreStatus?.localStorePath}
+            onDismiss={setupFlow.dismissEnvironmentBanner}
+          />
         )}
 
       {navigation.selectedKit && navigation.selectedKitSamples && currentKit ? (
@@ -344,12 +219,12 @@ const KitsView: React.FC = () => {
         isOpen={dialogState.showWizard}
         onClose={dialogState.closeWizard}
         onCloseApp={
-          needsLocalStoreSetup
+          setupFlow.needsLocalStoreSetup
             ? () => globalThis.electronAPI?.closeApp?.()
             : undefined
         }
-        onInitializationChange={setIsWizardInitializing}
-        onSuccess={handleWizardSuccess}
+        onInitializationChange={setupFlow.setIsWizardInitializing}
+        onSuccess={setupFlow.handleWizardSuccess}
         setLocalStorePath={setLocalStorePath}
       />
 
@@ -359,9 +234,9 @@ const KitsView: React.FC = () => {
           localStoreStatus?.error || "Invalid local store configuration"
         }
         isOpen={
-          hasInvalidLocalStore &&
-          !hasCriticalEnvironmentError &&
-          !isWizardInitializing
+          setupFlow.hasInvalidLocalStore &&
+          !setupFlow.hasCriticalEnvironmentError &&
+          !setupFlow.isWizardInitializing
         }
         localStorePath={localStoreStatus?.localStorePath || null}
         onMessage={showMessage}
@@ -369,9 +244,9 @@ const KitsView: React.FC = () => {
 
       {/* Critical Environment Error Dialog */}
       <CriticalErrorDialog
-        isOpen={Boolean(hasCriticalEnvironmentError)}
+        isOpen={Boolean(setupFlow.hasCriticalEnvironmentError)}
         message={`The environment variable ROMPER_LOCAL_PATH is set to "${localStoreStatus?.localStorePath}" but this path is invalid: ${localStoreStatus?.error}. The application cannot continue with an invalid environment override.`}
-        onConfirm={handleCriticalError}
+        onConfirm={setupFlow.handleCriticalError}
         title="Critical Configuration Error"
       />
 


### PR DESCRIPTION
## Summary

**Final item of the audit's god-object backlog.** `KitsView.tsx` (390 lines) is the top-level wiring view, but three concerns were implemented inline rather than wired:

| New module | Contents |
|---|---|
| `hooks/kit-management/useLocalStoreSetupFlow.ts` | The local-store configuration gate: the A1–A3 (needs setup wizard), C1–C6 (invalid-store blocking dialog), and critical-environment-error scenario flags derived from the validation status, plus the wizard lifecycle around them (auto-trigger, just-completed suppression, initialization-in-progress) and the success / critical-error handlers |
| `hooks/kit-management/useSampleRefreshListener.ts` | The `romper:refresh-samples` event listener with its ref plumbing (register once, read latest selection through refs) |
| `EnvironmentBanner.tsx` | The dismissible test-mode banner markup |

`KitsView` drops to **265 lines** of actual composition.

### Behaviour notes

- Logic and markup moved verbatim. One deliberate improvement: the wizard auto-trigger effect now depends on the stable `setShowWizard` setter instead of the whole `dialogState` object, which only reduces redundant effect re-runs.
- Also drops the file-local `ImportMeta` interface shadow (moved into the new hook next to its single use) and the long-disabled HMR-restore comment block.

### Validation

- The `KitsView` suite (**51 tests**, covering wizard auto-open, invalid-store dialog, and critical-error scenarios) passes **unmodified**.
- Full pre-commit gate passes locally (typecheck, lint, build, unit + integration).

### Backlog complete

With this PR, every item from the audit's code-smell backlog is resolved or dispositioned: swallowed errors (#286), the three mega-hooks (#287, #288, #289), duplicate scan logic (#290, by deletion), error contracts (#291, outlier eliminated; throw-vs-DbResult unification flagged for discussion), and the god-objects (#292 `dbUtilities`, #293 `KitGridItem`, this PR `KitsView`; `formatConverter.ts` reviewed and deliberately skipped as cohesive).

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_