### PR TITLE
fix: implement open-external and make Scan All Kits actually scan

### DIFF
--- a/app/renderer/components/hooks/kit-management/__tests__/useKitScan.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitScan.test.ts
@@ -1,91 +1,150 @@
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { scanSingleKit } from "../useKitScan";
+import { setupElectronAPIMock } from "../../../../../../tests/mocks/electron/electronAPI";
+import { scanAllKits, scanSingleKit, useKitScan } from "../useKitScan";
 
-// Mock the orchestration functions
-vi.mock("../../../utils/scanners/orchestrationFunctions", () => ({
-  executeFullKitScan: vi.fn(),
-  executeVoiceInferenceScan: vi.fn(),
-  executeWAVAnalysisScan: vi.fn(),
-}));
-
-// No bankOperations mocks needed anymore
+const kit = (name: string) => ({ name }) as never;
 
 describe("scanSingleKit", () => {
-  const fileReaderImpl = vi.fn();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectronAPIMock();
+  });
 
-  it("calls executeVoiceInferenceScan for voiceInference", async () => {
-    const { executeVoiceInferenceScan } =
-      await import("../../../utils/scanners/orchestrationFunctions");
-    vi.mocked(executeVoiceInferenceScan).mockResolvedValue({ success: true });
-
-    const result = await scanSingleKit({
-      fileReaderImpl,
-      kitName: "A01_Kick",
-      scanType: "voiceInference",
-      scanTypeDisplay: "voice name inference",
+  it("delegates to the main-process rescan", async () => {
+    vi.mocked(window.electronAPI.rescanKit).mockResolvedValue({
+      data: { scannedSamples: 7, updatedVoices: 2 },
+      success: true,
     });
 
-    expect(executeVoiceInferenceScan).toHaveBeenCalled();
+    const result = await scanSingleKit({ kitName: "A1" });
+
+    expect(window.electronAPI.rescanKit).toHaveBeenCalledWith("A1");
     expect(result.success).toBe(true);
   });
 
-  it("calls executeWAVAnalysisScan for wavAnalysis", async () => {
-    const { executeWAVAnalysisScan } =
-      await import("../../../utils/scanners/orchestrationFunctions");
-    vi.mocked(executeWAVAnalysisScan).mockResolvedValue({ success: true });
-
-    const result = await scanSingleKit({
-      fileReaderImpl,
-      kitName: "A01_Kick",
-      scanType: "wavAnalysis",
-      scanTypeDisplay: "WAV analysis",
+  it("returns the rescan failure as-is", async () => {
+    vi.mocked(window.electronAPI.rescanKit).mockResolvedValue({
+      error: "Kit directory not found",
+      success: false,
     });
 
-    expect(executeWAVAnalysisScan).toHaveBeenCalled();
-    expect(result.success).toBe(true);
+    const result = await scanSingleKit({ kitName: "A1" });
+    expect(result).toEqual({
+      error: "Kit directory not found",
+      success: false,
+    });
   });
 
-  it("calls executeFullKitScan for full scan", async () => {
-    const { executeFullKitScan } =
-      await import("../../../utils/scanners/orchestrationFunctions");
-    vi.mocked(executeFullKitScan).mockResolvedValue({ success: true });
+  it("fails cleanly when the rescan API is unavailable", async () => {
+    delete (window.electronAPI as { rescanKit?: unknown }).rescanKit;
 
-    const result = await scanSingleKit({
-      fileReaderImpl,
-      kitName: "A01_Kick",
-      scanType: "full",
-      scanTypeDisplay: "comprehensive",
-    });
+    const result = await scanSingleKit({ kitName: "A1" });
+    expect(result.success).toBe(false);
 
-    expect(executeFullKitScan).toHaveBeenCalled();
-    expect(result.success).toBe(true);
+    setupElectronAPIMock();
   });
 });
 
-import { act, renderHook } from "@testing-library/react";
+describe("scanAllKits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectronAPIMock();
+    vi.mocked(window.electronAPI.rescanKit).mockResolvedValue({
+      data: { scannedSamples: 3, updatedVoices: 1 },
+      success: true,
+    });
+  });
 
-import { useKitScan } from "../useKitScan";
+  it("rescans every kit and reports completion", async () => {
+    const onProgress = vi.fn();
+    const onRefreshKits = vi.fn();
+
+    await scanAllKits({
+      kits: [kit("A1"), kit("A2")],
+      onProgress,
+      onRefreshKits,
+    });
+
+    expect(window.electronAPI.rescanKit).toHaveBeenCalledTimes(2);
+    expect(window.electronAPI.rescanKit).toHaveBeenCalledWith("A1");
+    expect(window.electronAPI.rescanKit).toHaveBeenCalledWith("A2");
+    expect(onProgress).toHaveBeenLastCalledWith({
+      message: "All 2 kits scanned successfully (comprehensive).",
+      status: "complete",
+      successCount: 2,
+    });
+    expect(onRefreshKits).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts failures and surfaces their errors", async () => {
+    vi.mocked(window.electronAPI.rescanKit)
+      .mockResolvedValueOnce({ data: { scannedSamples: 3 }, success: true })
+      .mockResolvedValueOnce({ error: "boom", success: false });
+    const onProgress = vi.fn();
+
+    await scanAllKits({ kits: [kit("A1"), kit("A2")], onProgress });
+
+    expect(onProgress).toHaveBeenLastCalledWith({
+      message: expect.stringContaining("1 successful, 1 failed. A2: boom"),
+      status: "complete",
+      successCount: 1,
+    });
+  });
+
+  it("reports an error when there are no kits", async () => {
+    const onProgress = vi.fn();
+    await scanAllKits({ kits: [], onProgress });
+
+    expect(onProgress).toHaveBeenCalledWith({
+      message: "No kits to scan",
+      status: "error",
+    });
+    expect(window.electronAPI.rescanKit).not.toHaveBeenCalled();
+  });
+});
 
 describe("useKitScan", () => {
-  it("should show error if no kits", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectronAPIMock();
+    vi.mocked(window.electronAPI.rescanKit).mockResolvedValue({
+      data: { scannedSamples: 3, updatedVoices: 1 },
+      success: true,
+    });
+  });
+
+  it("tracks bulk scan progress through to completion", async () => {
+    const onRefreshKits = vi.fn();
     const { result } = renderHook(() =>
-      useKitScan({ kits: [], onRefreshKits: vi.fn() }),
+      useKitScan({ kits: [kit("A1")], onRefreshKits }),
     );
+
     await act(async () => {
       await result.current.handleScanAllKits();
     });
-    // Verify the hook returns expected state after handling empty kits
-    expect(result.current.handleScanAllKits).toBeDefined();
-    expect(typeof result.current.handleScanAllKits).toBe("function");
+
+    expect(result.current.bulkScanProgress).toEqual({
+      message: "All 1 kits scanned successfully (comprehensive).",
+      status: "complete",
+      successCount: 1,
+    });
+    expect(onRefreshKits).toHaveBeenCalledTimes(1);
   });
 
-  it("should call onRefreshKits after scan", async () => {
-    const onRefreshKits = vi.fn();
+  it("reports an error state when there are no kits", async () => {
     const { result } = renderHook(() =>
-      useKitScan({ kits: ["KitA"], onRefreshKits }),
+      useKitScan({ kits: [], onRefreshKits: vi.fn() }),
     );
-    // This test would be quite complex to properly mock, so let's simplify
-    expect(result.current.handleScanAllKits).toBeDefined();
+
+    await act(async () => {
+      await result.current.handleScanAllKits();
+    });
+
+    expect(result.current.bulkScanProgress).toEqual({
+      message: "No kits to scan",
+      status: "error",
+    });
   });
 });

--- a/app/renderer/components/hooks/kit-management/useKitScan.ts
+++ b/app/renderer/components/hooks/kit-management/useKitScan.ts
@@ -2,13 +2,6 @@ import type { KitWithRelations } from "@romper/shared/db/schema";
 
 import React, { useCallback } from "react";
 
-// --- Utility Functions ---
-import {
-  executeFullKitScan,
-  executeVoiceInferenceScan,
-  executeWAVAnalysisScan,
-} from "../../utils/scanners/orchestrationFunctions";
-
 const scanTypeDisplayMap: Record<string, string> = {
   voiceInference: "voice name inference",
   wavAnalysis: "WAV analysis",
@@ -22,25 +15,12 @@ export type BulkScanProgress =
 
 const BULK_SCAN_COMPLETE_CLEAR_MS = 5000;
 
-export async function fileReader(filePath: string): Promise<ArrayBuffer> {
-  if (!globalThis.electronAPI?.readFile) {
-    throw new Error("File reader not available");
-  }
-  const result = await globalThis.electronAPI.readFile(filePath);
-  if (!result.success || !result.data) {
-    throw new Error(result.error || "Failed to read file");
-  }
-  return result.data;
-}
-
 export async function scanAllKits({
-  fileReaderImpl = fileReader,
   kits,
   onProgress,
   onRefreshKits,
   operations,
 }: {
-  fileReaderImpl?: typeof fileReader;
   kits: KitWithRelations[];
   onProgress?: (progress: BulkScanProgress) => void;
   onRefreshKits?: () => void;
@@ -51,7 +31,7 @@ export async function scanAllKits({
     return;
   }
 
-  const { scanType, scanTypeDisplay } = getScanConfiguration(operations);
+  const { scanTypeDisplay } = getScanConfiguration(operations);
 
   onProgress?.({
     current: 0,
@@ -74,12 +54,7 @@ export async function scanAllKits({
         total: kits.length,
       });
 
-      const result = await processSingleKitScan(
-        kitName,
-        scanType,
-        scanTypeDisplay,
-        fileReaderImpl,
-      );
+      const result = await processSingleKitScan(kitName);
 
       if (result.success) {
         successCount++;
@@ -113,32 +88,13 @@ export async function scanAllKits({
   }
 }
 
-export async function scanSingleKit({
-  fileReaderImpl,
-  kitName: _kitName,
-  scanType,
-  scanTypeDisplay: _scanTypeDisplay,
-}: {
-  fileReaderImpl: typeof fileReader;
-  kitName: string;
-  scanType: string;
-  scanTypeDisplay: string;
-}) {
-  if (scanType === "voiceInference") {
-    const emptySamples = { 1: [], 2: [], 3: [], 4: [] };
-    return executeVoiceInferenceScan(emptySamples);
-  } else if (scanType === "wavAnalysis") {
-    const wavFiles: string[] = [];
-    return executeWAVAnalysisScan(wavFiles, fileReaderImpl);
-  } else {
-    // Full scan - voice inference and WAV analysis only
-    const scanInput = {
-      fileReader: fileReaderImpl,
-      samples: { 1: [], 2: [], 3: [], 4: [] },
-      wavFiles: [],
-    };
-    return executeFullKitScan(scanInput);
+export async function scanSingleKit({ kitName }: { kitName: string }) {
+  // Delegate to the main-process rescan, which re-reads the kit directory,
+  // rebuilds sample records, extracts WAV metadata, and infers voice names.
+  if (!globalThis.electronAPI?.rescanKit) {
+    return { error: "Rescan API not available", success: false as const };
   }
+  return globalThis.electronAPI.rescanKit(kitName);
 }
 
 // --- useKitScan Hook ---
@@ -212,40 +168,28 @@ function getCompletionMessage(
   }
 }
 
-// Helper function to determine scan type and display name
+// Helper function to determine the display name for the scan
 function getScanConfiguration(operations?: string[]) {
-  const scanType = operations?.length === 1 ? operations[0] : "full";
   const scanTypeDisplay =
     operations?.length === 1
       ? scanTypeDisplayMap[operations[0]] || operations[0]
       : "comprehensive";
 
-  return { scanType, scanTypeDisplay };
+  return { scanTypeDisplay };
 }
 
 // Helper function to process a single kit scan
-async function processSingleKitScan(
-  kitName: string,
-  scanType: string,
-  scanTypeDisplay: string,
-  fileReaderImpl: typeof fileReader,
-) {
+async function processSingleKitScan(kitName: string) {
   try {
-    const result = await scanSingleKit({
-      fileReaderImpl,
-      kitName,
-      scanType,
-      scanTypeDisplay,
-    });
+    const result = await scanSingleKit({ kitName });
 
     if (result.success) {
       return { success: true };
-    } else {
-      return {
-        error: `${kitName}: ${result.errors.map((e: { error: string; operation: string }) => e.error).join(", ")}`,
-        success: false,
-      };
     }
+    return {
+      error: `${kitName}: ${result.error || "Unknown error"}`,
+      success: false,
+    };
   } catch (error) {
     return {
       error: `${kitName}: ${error instanceof Error ? error.message : String(error)}`,

--- a/app/renderer/electron.d.ts
+++ b/app/renderer/electron.d.ts
@@ -233,7 +233,7 @@ export interface ElectronAPI {
       totalFiles: number;
     }) => void,
   ) => void;
-  openExternal?: (url: string) => Promise<void>;
+  openExternal?: (url: string) => Promise<{ error?: string; success: boolean }>;
   playSample?: (
     filePath: string,
     options?: { channel?: "left" | "mono" | "right" | "stereo" },

--- a/electron/main/__tests__/ipcHandlers.test.ts
+++ b/electron/main/__tests__/ipcHandlers.test.ts
@@ -17,6 +17,10 @@ vi.mock("electron", () => ({
       ipcMainHandlers[name] = fn;
     }),
   },
+  shell: {
+    openExternal: vi.fn(() => Promise.resolve()),
+    showItemInFolder: vi.fn(),
+  },
 }));
 vi.mock("node:fs", () => {
   const mock = {
@@ -118,6 +122,45 @@ describe("registerIpcHandlers", () => {
     registerIpcHandlers(inMemorySettings);
     await ipcMainHandlers["write-settings"]({}, "baz", 42);
     expect(inMemorySettings.baz).toBe(42);
+  });
+
+  it("registers open-external and opens https URLs in the system browser", async () => {
+    const { shell } = await import("electron");
+    const { registerIpcHandlers } = await import("../ipcHandlers");
+    registerIpcHandlers({});
+
+    const result = await ipcMainHandlers["open-external"](
+      {},
+      "https://github.com/peteb4ker/romper",
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(shell.openExternal).toHaveBeenCalledWith(
+      "https://github.com/peteb4ker/romper",
+    );
+  });
+
+  it("open-external refuses non-https and invalid URLs", async () => {
+    const { shell } = await import("electron");
+    const { registerIpcHandlers } = await import("../ipcHandlers");
+    registerIpcHandlers({});
+
+    const httpResult = await ipcMainHandlers["open-external"](
+      {},
+      "http://example.com",
+    );
+    expect(httpResult.success).toBe(false);
+
+    const fileResult = await ipcMainHandlers["open-external"](
+      {},
+      "file:///etc/passwd",
+    );
+    expect(fileResult.success).toBe(false);
+
+    const junkResult = await ipcMainHandlers["open-external"]({}, "not a url");
+    expect(junkResult.success).toBe(false);
+
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 
   it("registers ensure-dir and creates directory", async () => {

--- a/electron/main/ipcHandlers.ts
+++ b/electron/main/ipcHandlers.ts
@@ -63,6 +63,25 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
   ipcMain.handle("show-item-in-folder", async (_event, path: string) => {
     shell.showItemInFolder(path);
   });
+
+  // Open an external link in the system browser (https only)
+  ipcMain.handle("open-external", async (_event, url: string) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return { error: `Invalid URL: ${url}`, success: false };
+    }
+    if (parsed.protocol !== "https:") {
+      return {
+        error: `Refusing to open non-https URL: ${url}`,
+        success: false,
+      };
+    }
+    await shell.openExternal(url);
+    return { success: true };
+  });
+
   ipcMain.handle("get-kit-delete-summary", async (_event, kitName: string) => {
     const effectiveSettings: InMemorySettings = {
       ...inMemorySettings,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -414,6 +414,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
       callback(progress),
     );
   },
+  openExternal: (url: string) => {
+    isDev && console.debug("[IPC] openExternal invoked", url);
+    return ipcRenderer.invoke("open-external", url);
+  },
   playSample: (
     filePath: string,
     options?: { channel?: "left" | "mono" | "right" | "stereo" },


### PR DESCRIPTION
## Summary

Phase 1 of the engineering-audit work plan, PR 1 of 5: the two shipped-broken features the audit found (both verified before fixing).

### B1 — About links did nothing

`AboutDialog` and `AboutView` call `electronAPI.openExternal(url)`, which was **declared in `electron.d.ts` but never implemented** — no preload method, no IPC handler. Because the declaration is optional, the `?.` call sites silently no-opped, so the MIT-license, GitHub, and issue-tracker links were dead.

Fix: an `open-external` handler in main (URL-parsed, **https-only** — consistent with the navigation-hardening direction of #281), the preload method, and an accurate `DbResult`-shaped declaration.

### B2 — "Scan All Kits" scanned nothing and reported success

`scanSingleKit` hardcoded empty inputs into all three renderer-side scanner branches (`samples: {1:[],2:[],3:[],4:[]}`, `wavFiles: []`), so the menu action iterated every kit, did no work, and announced "All N kits scanned successfully."

Fix: delegate to the main-process **`rescan-kit`** channel — the real implementation that re-reads the kit directory, rebuilds sample records, extracts WAV metadata, and infers voice names. The renderer-side scanner plumbing for this path (its `fileReader`, orchestration imports, scanType switching) is deleted; progress reporting and the completion/error summaries are unchanged. (The bulk scan inherits `rescanKit`'s per-kit costs — making that path transactional/batched is Phase 3 of the audit plan.)

### Tests

- `useKitScan` suite rewritten against the real contract: per-kit rescan calls, failure aggregation in the completion message, the progress lifecycle through the hook, and the missing-API guard. The old tests asserted the scanner mocks were called — i.e., they verified the broken behavior.
- New `ipcHandlers` cases for `open-external`: https allowed, http/file/garbage refused without touching `shell`.
- Full pre-commit gate passes locally.

Refs: engineering audit findings A1-F2 (architecture agent) and P6 (performance agent).

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_