### PR TITLE
test: fix 13 vi.mock paths that silently matched nothing

### DIFF
--- a/app/renderer/__tests__/main.test.tsx
+++ b/app/renderer/__tests__/main.test.tsx
@@ -20,7 +20,7 @@ vi.mock("../components/StatusBar", () => ({
   default: () => <div data-testid="status-bar">StatusBar</div>,
 }));
 
-vi.mock("../components/hooks/useMessageDisplay", () => ({
+vi.mock("../components/hooks/shared/useMessageDisplay", () => ({
   useMessageDisplay: () => ({
     addMessage: vi.fn(),
     dismissMessage: vi.fn(),

--- a/app/renderer/components/__tests__/KitGridItem.test.tsx
+++ b/app/renderer/components/__tests__/KitGridItem.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@romper/shared/kitUtilsShared", () => ({
   }),
 }));
 
-vi.mock("../hooks/useKitItem", () => ({
+vi.mock("../hooks/kit-management/useKitItem", () => ({
   useKitItem: vi.fn(() => ({
     iconLabel: "Test Icon",
     iconType: "drum",

--- a/app/renderer/components/__tests__/KitVoicePanel.test.tsx
+++ b/app/renderer/components/__tests__/KitVoicePanel.test.tsx
@@ -8,7 +8,7 @@ import { MockMessageDisplayProvider } from "./MockMessageDisplayProvider";
 import { MockSettingsProvider } from "./MockSettingsProvider";
 
 // Mock the hooks used by KitVoicePanel
-vi.mock("../hooks/useStereoHandling", () => ({
+vi.mock("../hooks/sample-management/useStereoHandling", () => ({
   useStereoHandling: vi.fn(() => ({
     analyzeStereoAssignment: vi.fn().mockReturnValue({
       assignAsMono: false,
@@ -22,14 +22,6 @@ vi.mock("../hooks/useStereoHandling", () => ({
       replaceExisting: false,
     }),
   })),
-}));
-
-vi.mock("sonner", () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-    warning: vi.fn(),
-  },
 }));
 
 const baseProps = {

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitEditorLogic.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitEditorLogic.test.ts
@@ -9,13 +9,13 @@ import { useKitVoicePanels } from "../useKitVoicePanels";
 // Mock all the hooks that useKitEditorLogic depends on
 // Note: useKit is no longer used by useKitEditorLogic
 
-vi.mock("../useVoiceAlias", () => ({
+vi.mock("../../voice-panels/useVoiceAlias", () => ({
   useVoiceAlias: vi.fn(() => ({
     updateVoiceAlias: vi.fn(),
   })),
 }));
 
-vi.mock("../useSampleManagement", () => ({
+vi.mock("../../sample-management/useSampleManagement", () => ({
   useSampleManagement: vi.fn(() => ({
     handleSampleManagement: vi.fn(),
     isManaging: false,
@@ -48,19 +48,11 @@ vi.mock("../useKitVoicePanels", () => ({
   })),
 }));
 
-vi.mock("../useStepPattern", () => ({
+vi.mock("../../shared/useStepPattern", () => ({
   useStepPattern: vi.fn(() => ({
     setStepPattern: vi.fn(),
     stepPattern: null,
   })),
-}));
-
-vi.mock("sonner", () => ({
-  toast: {
-    error: vi.fn(),
-    loading: vi.fn(),
-    success: vi.fn(),
-  },
 }));
 
 describe("useKitEditorLogic", () => {

--- a/app/renderer/components/hooks/kit-management/__tests__/useKitViewMenuHandlers.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitViewMenuHandlers.test.ts
@@ -4,13 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useKitViewMenuHandlers } from "../useKitViewMenuHandlers";
 
 // Mock the dependencies
-vi.mock("../useBankScanning", () => ({
+vi.mock("../../shared/useBankScanning", () => ({
   useBankScanning: vi.fn(() => ({
     scanBanks: vi.fn(),
   })),
 }));
 
-vi.mock("../useMenuEvents", () => ({
+vi.mock("../../shared/useMenuEvents", () => ({
   useMenuEvents: vi.fn(),
 }));
 

--- a/app/renderer/components/hooks/wizard/__tests__/useLocalStoreWizardFileOps.test.ts
+++ b/app/renderer/components/hooks/wizard/__tests__/useLocalStoreWizardFileOps.test.ts
@@ -8,14 +8,14 @@ vi.mock("@romper/shared/kitUtilsShared", () => ({
   groupSamplesByVoice: vi.fn(() => new Map()),
 }));
 
-vi.mock("../../config", () => ({
+vi.mock("../../../../config", () => ({
   config: {
     localStoreRootFolderName: "RamplerLocal",
     squarpArchiveUrl: "https://data.squarp.net/RampleSamplesV1-2.zip",
   },
 }));
 
-vi.mock("../utils/romperDb", () => ({
+vi.mock("../../../utils/romperDb", () => ({
   createRomperDb: vi.fn().mockResolvedValue(undefined),
   insertKit: vi.fn().mockResolvedValue(undefined),
   insertSample: vi.fn().mockResolvedValue(undefined),

--- a/app/renderer/components/hooks/wizard/__tests__/useLocalStoreWizardScanning.test.ts
+++ b/app/renderer/components/hooks/wizard/__tests__/useLocalStoreWizardScanning.test.ts
@@ -8,17 +8,17 @@ vi.mock("@romper/shared/kitUtilsShared", () => ({
   groupSamplesByVoice: vi.fn(() => new Map()),
 }));
 
-vi.mock("../utils/scanners/orchestrationFunctions", () => ({
+vi.mock("../../../utils/scanners/orchestrationFunctions", () => ({
   executeFullKitScan: vi.fn(() =>
     Promise.resolve({
-      scannedKitResult: {
-        data: { kits: [], samples: [] },
-        success: true,
+      completedOperations: 2,
+      errors: [],
+      results: {
+        voiceInference: { voiceNames: { 1: "Kick" } },
+        wavAnalysis: [],
       },
-      validationResult: {
-        data: { errors: [] },
-        success: true,
-      },
+      success: true,
+      totalOperations: 2,
     }),
   ),
 }));
@@ -108,7 +108,9 @@ describe("useLocalStoreWizardScanning", () => {
       // Note: Implementation uses executeFullKitScan, not scanKitForData directly
     });
 
-    it("should handle file reader creation correctly", async () => {
+    it("wires a working file reader into the scan input", async () => {
+      const { executeFullKitScan } =
+        await import("../../../utils/scanners/orchestrationFunctions");
       const { result } = renderHook(() =>
         useLocalStoreWizardScanning({
           api: mockApi,
@@ -118,7 +120,15 @@ describe("useLocalStoreWizardScanning", () => {
 
       await result.current.runScanning("/target/path", "/db/dir", ["A0"]);
 
-      expect(mockApi.readFile).toHaveBeenCalled();
+      const scanInput = vi.mocked(executeFullKitScan).mock.calls[0][0];
+      expect(scanInput.fileReader).toEqual(expect.any(Function));
+
+      // The created reader delegates to api.readFile and unwraps the result
+      const buffer = await scanInput.fileReader!("/target/path/A0/sample1.wav");
+      expect(mockApi.readFile).toHaveBeenCalledWith(
+        "/target/path/A0/sample1.wav",
+      );
+      expect(buffer).toBeInstanceOf(ArrayBuffer);
     });
 
     it("should handle errors when file reading is not available", async () => {

--- a/electron/main/services/__tests__/syncFileOperations.test.ts
+++ b/electron/main/services/__tests__/syncFileOperations.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../formatConverter.js", () => ({
   convertToRampleDefault: vi.fn().mockResolvedValue({ success: true }),
 }));
 
-vi.mock("./syncProgressManager.js", () => ({
+vi.mock("../syncProgressManager.js", () => ({
   syncProgressManager: {
     emitErrorProgress: vi.fn(),
     emitFileCompletionProgress: vi.fn(),
@@ -30,7 +30,7 @@ vi.mock("./syncProgressManager.js", () => ({
   },
 }));
 
-vi.mock("./syncValidationService.js", () => ({
+vi.mock("../syncValidationService.js", () => ({
   syncValidationService: {
     addValidationError: vi.fn(),
     categorizeError: vi.fn().mockReturnValue({

--- a/tests/unit/mockPathResolution.test.ts
+++ b/tests/unit/mockPathResolution.test.ts
@@ -1,0 +1,82 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards against vi.mock() calls whose module specifier does not resolve.
+ *
+ * vi.mock with a path that matches nothing is silently ignored: the real
+ * module runs and the test verifies less than it appears to. A directory
+ * restructure introduced thirteen of these at once (see PR for the list),
+ * one of which pulled the real `electron` module into the unit suite.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCAN_ROOTS = ["app", "electron", "shared", "tests"];
+
+// Resolution candidates for a TS/ESM specifier (a mock of "./x.js" must
+// match the on-disk ./x.ts the same way the import does)
+const CANDIDATE_SUFFIXES = [
+  "",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  "/index.ts",
+  "/index.tsx",
+];
+
+function collectTestFiles(dir: string, out: string[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "worktrees") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectTestFiles(full, out);
+    } else if (/\.test\.(t|j)sx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+function resolvesToFile(specifier: string, fromFile: string): boolean {
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const stripped = base.replace(/\.(js|jsx)$/, "");
+  for (const root of [base, stripped]) {
+    for (const suffix of CANDIDATE_SUFFIXES) {
+      const candidate = root + suffix;
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe("vi.mock path resolution", () => {
+  it("every relative vi.mock specifier resolves to a real module", () => {
+    const testFiles: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      const dir = path.join(REPO_ROOT, root);
+      if (fs.existsSync(dir)) collectTestFiles(dir, testFiles);
+    }
+    expect(testFiles.length).toBeGreaterThan(100);
+
+    const failures: string[] = [];
+    const mockPattern = /vi\.(mock|doMock)\(\s*["']([^"']+)["']/g;
+
+    for (const file of testFiles) {
+      const source = fs.readFileSync(file, "utf-8");
+      for (const match of source.matchAll(mockPattern)) {
+        const specifier = match[2];
+        if (!specifier.startsWith(".")) continue; // bare specifiers = packages
+        if (!resolvesToFile(specifier, file)) {
+          failures.push(
+            `${path.relative(REPO_ROOT, file)} mocks "${specifier}" which resolves to nothing — the real module will run`,
+          );
+        }
+      }
+    }
+
+    expect(failures, failures.join("\n")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the engineering-audit work plan, PR 3 of 5: thirteen `vi.mock` calls across seven test files referenced paths that **resolve to no module**. Vitest silently ignores these, so the *real* modules ran and the tests verified less than they appeared to — accidental integration tests with dead mock factories. The worst instance: `syncFileOperations.test.ts` believed it mocked `syncProgressManager`/`syncValidationService` but loaded both for real, pulling the real `electron` import into the unit suite.

### Fixed specifiers

| Test file | Broken → corrected |
|---|---|
| `main.test.tsx` | `hooks/useMessageDisplay` → `hooks/shared/…` |
| `KitGridItem.test.tsx` | `hooks/useKitItem` → `hooks/kit-management/…` |
| `KitVoicePanel.test.tsx` | `hooks/useStereoHandling` → `hooks/sample-management/…` |
| `useKitEditorLogic.test.ts` | 3 mocks → `../../voice-panels/`, `../../sample-management/`, `../../shared/` |
| `useKitViewMenuHandlers.test.ts` | 2 mocks → `../../shared/` |
| `useLocalStoreWizardFileOps.test.ts` | `../../config`, `../utils/romperDb` → correct depths |
| `useLocalStoreWizardScanning.test.ts` | `../utils/scanners/…` → `../../../utils/scanners/…` |
| `syncFileOperations.test.ts` | `./syncProgressManager.js`, `./syncValidationService.js` → `../…` |

Also removed two `vi.mock("sonner")` calls — **sonner is not a dependency** of this project (a leftover the docs audit traced to stale examples in `coding-guide.md`).

### The telling result

With all thirteen mocks finally applying, **exactly one test needed repair** — the scanning test, whose `executeFullKitScan` factory returned a shape the real function never had (`{scannedKitResult, validationResult}`) and whose file-reader assertion depended on the real scanner running. The factory now returns the real `ChainResult` contract, and the test verifies the file-reader wiring through the scan input. Everything else passed unchanged, which both confirms the suite's robustness and shows how long these could have drifted unnoticed.

### Guardrail

New `tests/unit/mockPathResolution.test.ts` scans every test file in the repo and **fails if any relative `vi.mock` specifier doesn't resolve to a real module** (with `.js`→`.ts` ESM mapping). It reproduces all 13 original failures against the unfixed tree, runs in the fast suite (pre-commit + CI), and prevents this class of silent test decay from recurring on the next directory restructure.

### Validation

Full unit suite green: **3,529 tests across 242 files**; full pre-commit gate passes.

Refs: audit finding T1 (testing agent).

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_