### PR TITLE
fix(lint): restore type-aware ESLint rules and make CI lint a real gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,6 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
-        run: npm run lint
+        # lint:check (no --fix) so violations fail CI instead of being
+        # silently auto-fixed in the throwaway runner workspace.
+        run: npm run lint:check

--- a/app/renderer/components/KitItem.tsx
+++ b/app/renderer/components/KitItem.tsx
@@ -11,7 +11,7 @@ import {
   KitItemRenderProps,
 } from "./shared/kitItemUtils";
 
-interface KitItemProps extends BaseKitItemProps {}
+type KitItemProps = BaseKitItemProps;
 
 // Add ref forwarding to support programmatic focus from KitList
 const KitItem = React.memo(

--- a/app/renderer/components/KitStepSequencer.tsx
+++ b/app/renderer/components/KitStepSequencer.tsx
@@ -118,7 +118,11 @@ const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
   const handleVolumeChange = React.useCallback(
     (voiceNumber: number, volume: number) => {
       setVoiceVolumes((prev) => ({ ...prev, [voiceNumber]: volume }));
-      globalThis.electronAPI?.updateVoiceVolume?.(kitName, voiceNumber, volume);
+      void globalThis.electronAPI?.updateVoiceVolume?.(
+        kitName,
+        voiceNumber,
+        volume,
+      );
       debouncedRefresh();
     },
     [kitName, debouncedRefresh],
@@ -128,7 +132,7 @@ const KitStepSequencer: React.FC<KitStepSequencerProps> = (props) => {
   const handleSampleModeChange = React.useCallback(
     (voiceNumber: number, mode: SampleMode) => {
       setSampleModes((prev) => ({ ...prev, [voiceNumber]: mode }));
-      globalThis.electronAPI?.updateVoiceSampleMode?.(
+      void globalThis.electronAPI?.updateVoiceSampleMode?.(
         kitName,
         voiceNumber,
         mode,

--- a/app/renderer/components/KitVoicePanels.tsx
+++ b/app/renderer/components/KitVoicePanels.tsx
@@ -258,7 +258,7 @@ const KitVoicePanels: React.FC<KitVoicePanelsProps> = (props) => {
       }
     };
 
-    loadSampleMetadata();
+    void loadSampleMetadata();
   }, [hookProps.kitName, props.kit]);
 
   // Optimistic update for gain changes so SampleWaveform gets the new gainDb immediately

--- a/app/renderer/components/SampleWaveform.tsx
+++ b/app/renderer/components/SampleWaveform.tsx
@@ -139,7 +139,7 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
         }
         const ctx = new globalThis.AudioContext();
         audioCtxRef.current = ctx;
-        ctx.decodeAudioData(arrayBuffer.slice(0), (buf) => {
+        void ctx.decodeAudioData(arrayBuffer.slice(0), (buf) => {
           setAudioBuffer(buf);
           drawWaveform(buf);
         });

--- a/app/renderer/components/StatusBar.tsx
+++ b/app/renderer/components/StatusBar.tsx
@@ -80,11 +80,11 @@ const StatusBar: React.FC<StatusBarProps> = ({ progress = null }) => {
           onClick={() => {
             // Cycle through: light -> dark -> system
             if (themeMode === "light") {
-              setThemeMode("dark");
+              void setThemeMode("dark");
             } else if (themeMode === "dark") {
-              setThemeMode("system");
+              void setThemeMode("system");
             } else {
-              setThemeMode("light");
+              void setThemeMode("light");
             }
           }}
           title={`Current: ${themeMode}${getThemeDisplayText()}`}

--- a/app/renderer/components/ThemeToggle.tsx
+++ b/app/renderer/components/ThemeToggle.tsx
@@ -8,11 +8,11 @@ const ThemeToggle: React.FC = () => {
   const toggleDarkMode = () => {
     // Cycle through: light -> dark -> system
     if (themeMode === "light") {
-      setThemeMode("dark");
+      void setThemeMode("dark");
     } else if (themeMode === "dark") {
-      setThemeMode("system");
+      void setThemeMode("system");
     } else {
-      setThemeMode("light");
+      void setThemeMode("light");
     }
   };
 

--- a/app/renderer/components/dialogs/AboutDialog.tsx
+++ b/app/renderer/components/dialogs/AboutDialog.tsx
@@ -5,7 +5,7 @@ import LedPixelGrid from "./led-grid/LedPixelGrid";
 
 const openExternal = (url: string) => {
   if (globalThis.electronAPI?.openExternal)
-    globalThis.electronAPI.openExternal(url);
+    void globalThis.electronAPI.openExternal(url);
   else window.open(url, "_blank", "noopener,noreferrer");
 };
 

--- a/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
+++ b/app/renderer/components/dialogs/InvalidLocalStoreDialog.tsx
@@ -138,7 +138,7 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
 
     setIsUpdating(true);
     try {
-      setLocalStorePath(selectedPath);
+      void setLocalStorePath(selectedPath);
       onMessage?.(
         "Local store directory updated successfully. Refreshing...",
         "success",
@@ -146,8 +146,8 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
 
       // Give user a moment to see the success message before refresh
       // Use React-friendly settings refresh instead of window.location.reload()
-      setTimeout(async () => {
-        await refreshLocalStoreStatus();
+      setTimeout(() => {
+        void refreshLocalStoreStatus();
       }, 1000);
     } catch (error) {
       onMessage?.(
@@ -163,7 +163,7 @@ const InvalidLocalStoreDialog: React.FC<InvalidLocalStoreDialogProps> = ({
 
   const handleExitApp = () => {
     if (globalThis.electronAPI?.closeApp) {
-      globalThis.electronAPI.closeApp();
+      void globalThis.electronAPI.closeApp();
     } else {
       // Fallback for development or if API is not available
       window.close();

--- a/app/renderer/components/dialogs/ValidationResultsDialog.tsx
+++ b/app/renderer/components/dialogs/ValidationResultsDialog.tsx
@@ -40,7 +40,7 @@ const ValidationResultsDialog: React.FC<ValidationResultsDialogProps> = ({
   // Trigger validation when dialog opens
   React.useEffect(() => {
     if (isOpen) {
-      validateLocalStore();
+      void validateLocalStore();
     }
   }, [isOpen, validateLocalStore]);
 

--- a/app/renderer/components/hooks/kit-management/useKit.ts
+++ b/app/renderer/components/hooks/kit-management/useKit.ts
@@ -46,7 +46,7 @@ export function useKit({ kitName, onKitUpdated }: UseKitParams) {
 
   useEffect(() => {
     if (!kitName) return;
-    loadKit();
+    void loadKit();
   }, [kitName, loadKit]);
 
   const updateKitAlias = async (alias: string) => {

--- a/app/renderer/components/hooks/kit-management/useKitDataManager.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDataManager.ts
@@ -318,7 +318,7 @@ export function useKitDataManager({
 
   // Load all kits and samples on mount and when dependencies change
   useEffect(() => {
-    loadKitsData();
+    void loadKitsData();
   }, [loadKitsData]);
 
   return {

--- a/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
+++ b/app/renderer/components/hooks/kit-management/useKitEditorLogic.ts
@@ -373,9 +373,9 @@ export function useKitEditorLogic(props: UseKitEditorLogicParams) {
       if (e.key === "/") {
         e.preventDefault();
         if (kit?.editable) {
-          handleInferVoiceNames();
+          void handleInferVoiceNames();
         } else {
-          handleScanKit();
+          void handleScanKit();
         }
         return;
       }

--- a/app/renderer/components/hooks/kit-management/useKitFilters.ts
+++ b/app/renderer/components/hooks/kit-management/useKitFilters.ts
@@ -132,7 +132,7 @@ export function useKitFilters({ kits, onMessage }: UseKitFiltersOptions) {
       }
     };
 
-    fetchFavoritesCount();
+    void fetchFavoritesCount();
   }, [kits]); // Re-fetch when kits change
 
   // Task 20.2.2: Calculate modified count when kits change

--- a/app/renderer/components/hooks/kit-management/useKitSync.ts
+++ b/app/renderer/components/hooks/kit-management/useKitSync.ts
@@ -42,7 +42,7 @@ export function useKitSync({ onMessage, onRefreshKits }: UseKitSyncOptions) {
         }
       }
     };
-    getSettings();
+    void getSettings();
   }, []);
 
   // Sync functionality from useSyncUpdate hook

--- a/app/renderer/components/hooks/kit-management/useKitViewMenuHandlers.ts
+++ b/app/renderer/components/hooks/kit-management/useKitViewMenuHandlers.ts
@@ -73,7 +73,7 @@ export function useKitViewMenuHandlers({
     onScanAll: () => {
       log.debug("Menu scan all triggered");
       // Run bank scan first (fast), then kit scan
-      scanBanks().then(() => {
+      void scanBanks().then(() => {
         if (kitBrowserRef.current?.handleScanAllKits) {
           kitBrowserRef.current.handleScanAllKits();
         }

--- a/app/renderer/components/hooks/sample-management/useSampleActions.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleActions.ts
@@ -38,7 +38,7 @@ export function useSampleActions({
     (e: React.MouseEvent, sampleData: SampleData | undefined) => {
       e.preventDefault();
       if (sampleData?.source_path && globalThis.electronAPI?.showItemInFolder) {
-        globalThis.electronAPI.showItemInFolder(sampleData.source_path);
+        void globalThis.electronAPI.showItemInFolder(sampleData.source_path);
       }
     },
     [],

--- a/app/renderer/components/hooks/sample-management/useSampleProcessing.ts
+++ b/app/renderer/components/hooks/sample-management/useSampleProcessing.ts
@@ -68,7 +68,7 @@ export function useSampleProcessing({
   const calculateTargetSlot = useCallback(
     (path: string, slotNumber: number, droppedSlotNumber: number): number => {
       const isFromLocalStore = path.includes(kitName);
-      let targetSlot = slotNumber >= 0 ? slotNumber : droppedSlotNumber;
+      const targetSlot = slotNumber >= 0 ? slotNumber : droppedSlotNumber;
 
       if (!isFromLocalStore && slotNumber < 0) {
         for (let i = 0; i < 12; i++) {

--- a/app/renderer/components/hooks/shared/useGlobalKeyboardShortcuts.ts
+++ b/app/renderer/components/hooks/shared/useGlobalKeyboardShortcuts.ts
@@ -64,7 +64,7 @@ export function useGlobalKeyboardShortcuts({
         event.stopPropagation();
 
         if (undoRedo.canUndo && !undoRedo.isUndoing) {
-          undoRedo.undo();
+          void undoRedo.undo();
         }
         return true;
       }
@@ -81,7 +81,7 @@ export function useGlobalKeyboardShortcuts({
         event.stopPropagation();
 
         if (undoRedo.canRedo && !undoRedo.isRedoing) {
-          undoRedo.redo();
+          void undoRedo.redo();
         }
         return true;
       }

--- a/app/renderer/components/hooks/shared/useStartupActions.ts
+++ b/app/renderer/components/hooks/shared/useStartupActions.ts
@@ -37,6 +37,6 @@ export function useStartupActions({
       }
     };
 
-    runStartupActions();
+    void runStartupActions();
   }, [localStorePath, needsLocalStoreSetup]);
 }

--- a/app/renderer/components/hooks/shared/useStepPattern.ts
+++ b/app/renderer/components/hooks/shared/useStepPattern.ts
@@ -38,7 +38,7 @@ export function useStepPattern({
           pattern,
         );
         if (result.success) {
-          onSaved?.();
+          void onSaved?.();
         } else {
           console.error("Failed to save step pattern:", result.error);
           // Revert UI state on failure

--- a/app/renderer/components/hooks/shared/useTriggerConditions.ts
+++ b/app/renderer/components/hooks/shared/useTriggerConditions.ts
@@ -53,7 +53,7 @@ export function useTriggerConditions({
           conditions,
         );
         if (result.success) {
-          onSaved?.();
+          void onSaved?.();
         } else {
           console.error("Failed to save trigger conditions:", result.error);
           setTriggerConditionsState(

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelButtons.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelButtons.tsx
@@ -66,7 +66,7 @@ export function useVoicePanelButtons({
         className="p-1 rounded hover:bg-accent-danger/15 text-xs text-accent-danger ml-2"
         onClick={(e) => {
           e.stopPropagation();
-          sampleActionsHook.handleDeleteSample(slotNumber);
+          void sampleActionsHook.handleDeleteSample(slotNumber);
         }}
         style={{
           alignItems: "center",

--- a/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
+++ b/app/renderer/components/hooks/voice-panels/useVoicePanelSlotRendering.tsx
@@ -207,7 +207,7 @@ export function useVoicePanelSlotRendering({
           {isEditable && (
             <GainKnob
               onChange={(db) => {
-                globalThis.electronAPI?.updateSampleGain?.(
+                void globalThis.electronAPI?.updateSampleGain?.(
                   kitName,
                   voice,
                   slotNumber,

--- a/app/renderer/components/hooks/wizard/useLocalStoreWizardState.ts
+++ b/app/renderer/components/hooks/wizard/useLocalStoreWizardState.ts
@@ -124,7 +124,7 @@ export function useLocalStoreWizardState({
       setDefaultPath("");
     };
 
-    loadDefaultPath();
+    void loadDefaultPath();
 
     // Clear targetPath and source on wizard mount (start)
     setState((s) => ({

--- a/app/renderer/utils/SettingsContext.tsx
+++ b/app/renderer/utils/SettingsContext.tsx
@@ -260,7 +260,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Initialize on mount
   useEffect(() => {
-    initializeSettings();
+    void initializeSettings();
   }, [initializeSettings]);
 
   // Listen for system theme changes when using "system" mode

--- a/app/renderer/views/AboutView.tsx
+++ b/app/renderer/views/AboutView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const openExternal = (url: string) => {
   if (globalThis.electronAPI?.openExternal) {
-    globalThis.electronAPI.openExternal(url);
+    void globalThis.electronAPI.openExternal(url);
   } else {
     window.open(url, "_blank", "noopener,noreferrer");
   }

--- a/app/renderer/views/KitsView.tsx
+++ b/app/renderer/views/KitsView.tsx
@@ -146,7 +146,7 @@ const KitsView: React.FC = () => {
     isEditMode: currentKit?.editable ?? false,
     onBackNavigation: navigation.selectedKit
       ? () => {
-          navigation.handleBack();
+          void navigation.handleBack();
         }
       : undefined,
   });
@@ -215,7 +215,7 @@ const KitsView: React.FC = () => {
     const handleRefreshSamples = (event: Event) => {
       const customEvent = event as CustomEvent<{ kitName: string }>;
       if (customEvent.detail.kitName === selectedKitRef.current) {
-        reloadCurrentKitSamplesRef.current(selectedKitRef.current);
+        void reloadCurrentKitSamplesRef.current(selectedKitRef.current);
       }
     };
 
@@ -253,7 +253,7 @@ const KitsView: React.FC = () => {
   // Critical error handler
   const handleCriticalError = useCallback(() => {
     if (globalThis.electronAPI?.closeApp) {
-      globalThis.electronAPI.closeApp();
+      void globalThis.electronAPI.closeApp();
     } else {
       // Fallback for development or if API is not available
       window.close();

--- a/electron/main/applicationMenu.ts
+++ b/electron/main/applicationMenu.ts
@@ -169,14 +169,16 @@ export function createApplicationMenu() {
       submenu: [
         {
           click: () => {
-            shell.openExternal("https://peteb4ker.github.io/romper/manual/");
+            void shell.openExternal(
+              "https://peteb4ker.github.io/romper/manual/",
+            );
           },
           icon: menuIcons.romperManual,
           label: "Romper Manual",
         },
         {
           click: () => {
-            shell.openExternal("https://squarp.net/rample/manual/");
+            void shell.openExternal("https://squarp.net/rample/manual/");
           },
           icon: menuIcons.rampleManual,
           label: "Rample Manual",

--- a/electron/main/db/operations/sampleCrudOperations.ts
+++ b/electron/main/db/operations/sampleCrudOperations.ts
@@ -29,7 +29,7 @@ export function buildDeleteConditions(
   kitName: string,
   filter?: { slotNumber?: number; voiceNumber?: number },
 ): SQL {
-  let conditions = [eq(samples.kit_name, kitName)];
+  const conditions = [eq(samples.kit_name, kitName)];
 
   if (filter?.voiceNumber !== undefined) {
     conditions.push(eq(samples.voice_number, filter.voiceNumber));

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -138,7 +138,7 @@ app.setName("Romper");
 // S7785). Converting the Electron main entry to top-level await causes
 // `electron.launch` to hang in e2e (ESM-main bootstrap deadlock), so this
 // pattern is intentional.
-app.whenReady().then(async () => {
+void app.whenReady().then(async () => {
   logger.log("[Startup] App is starting...");
   try {
     logger.log("[Startup] App is ready. Configuring...");

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,39 @@ function trimGlobals(obj) {
 }
 import tseslint from "typescript-eslint";
 
+// typescript-eslint v8 ships its shared configs as ARRAYS of flat-config
+// objects, so `tseslint.configs.recommended.rules` is `undefined` and
+// spreading it is a silent no-op. Merge the `rules` of every object in the
+// array into one record so the preset actually loads.
+function tseslintRules(configArray) {
+  return Object.assign({}, ...configArray.map((c) => c.rules ?? {}));
+}
+
+const TS_RECOMMENDED_RULES = tseslintRules(tseslint.configs.recommended);
+
+// Type-checked-only rules worth enforcing on source (needs type information).
+// Scoped to non-test source files below, where `projectService` can resolve
+// every file against the root tsconfig.
+const TYPE_CHECKED_RULES = {
+  "@typescript-eslint/await-thenable": "error",
+  "@typescript-eslint/no-floating-promises": "error",
+  // Async functions passed as JSX event handlers (onClick={async …}) are a
+  // well-known false positive — React ignores the returned promise — so only
+  // flag genuinely misused promises (conditions, non-attribute void returns).
+  "@typescript-eslint/no-misused-promises": [
+    "error",
+    { checksVoidReturn: { attributes: false } },
+  ],
+  "@typescript-eslint/only-throw-error": "error",
+};
+
+// The codebase uses the `isDev && console.debug(…)` short-circuit idiom
+// deliberately; allow short-circuit/ternary expression statements.
+const NO_UNUSED_EXPRESSIONS = [
+  "error",
+  { allowShortCircuit: true, allowTernary: true },
+];
+
 export default defineConfig([
   {
     ignores: [
@@ -79,7 +112,7 @@ export default defineConfig([
       prettier,
     },
     rules: {
-      ...tseslint.configs.recommendedTypeChecked.rules,
+      ...TS_RECOMMENDED_RULES,
       ...prettierConfig.rules,
       ...reactHooks.configs.recommended.rules,
       ...perfectionist.configs["recommended-alphabetical"].rules,
@@ -112,7 +145,27 @@ export default defineConfig([
           ignoreRestArgs: false,
         },
       ],
+      "@typescript-eslint/no-unused-expressions": NO_UNUSED_EXPRESSIONS,
     },
+  },
+
+  // Type-checked rules for SOURCE files only (in the root tsconfig, so
+  // `projectService` can resolve them). Test files and preload are excluded
+  // from tsconfig.json, so they stay on the non-type-checked rules above.
+  {
+    files: ["app/**/*.{ts,tsx}", "electron/main/**/*.ts", "shared/**/*.ts"],
+    ignores: ["**/__tests__/**", "**/*.test.{ts,tsx}", "**/__mocks__/**"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+    },
+    rules: TYPE_CHECKED_RULES,
   },
 
   // Test files (Vitest or other test globals)
@@ -146,6 +199,11 @@ export default defineConfig([
       ],
       // Encourage use of centralized factories
       "prefer-const": "error",
+      // Tests use require() and rest-style arg capture freely
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-unsafe-function-type": "off",
+      "@typescript-eslint/no-unused-expressions": NO_UNUSED_EXPRESSIONS,
+      "prefer-rest-params": "off",
       // TypeScript any type restrictions
       "@typescript-eslint/no-explicit-any": [
         "error",
@@ -185,7 +243,7 @@ export default defineConfig([
       prettier,
     },
     rules: {
-      ...tseslint.configs.recommended.rules, // Use recommended instead of recommendedTypeChecked
+      ...TS_RECOMMENDED_RULES, // recommended (non-type-checked) rules
       ...prettierConfig.rules,
       ...perfectionist.configs["recommended-alphabetical"].rules,
       "sonarjs/no-nested-functions": "off",
@@ -202,6 +260,8 @@ export default defineConfig([
         },
       ],
       "no-unused-vars": "off",
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-unused-expressions": NO_UNUSED_EXPRESSIONS,
       // TypeScript any type restrictions
       "@typescript-eslint/no-explicit-any": [
         "error",
@@ -228,6 +288,12 @@ export default defineConfig([
       globals: trimGlobals(globals.node),
     },
   },
-]);
 
-// Remove this file. ESLint flat config should only use per-package eslint.config.mjs files, not a root config.
+  // Preload runs in a CommonJS context and uses require() by design
+  {
+    files: ["electron/preload/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+]);

--- a/shared/db/schema.ts
+++ b/shared/db/schema.ts
@@ -94,7 +94,7 @@ export const samples = sqliteTable(
 // Export types inferred from schema
 export type Bank = typeof banks.$inferSelect;
 // More specific database result types
-export interface DbKitsResult extends DbResult<Kit[]> {}
+export type DbKitsResult = DbResult<Kit[]>;
 
 // Database operation result wrapper
 export interface DbResult<T = unknown> {
@@ -102,9 +102,9 @@ export interface DbResult<T = unknown> {
   error?: string;
   success: boolean;
 }
-export interface DbSamplesResult extends DbResult<Sample[]> {}
+export type DbSamplesResult = DbResult<Sample[]>;
 
-export interface DbVoicesResult extends DbResult<Voice[]> {}
+export type DbVoicesResult = DbResult<Voice[]>;
 export type Kit = typeof kits.$inferSelect;
 
 // Kit validation types

--- a/tests/utils/renderWithProviders.tsx
+++ b/tests/utils/renderWithProviders.tsx
@@ -9,7 +9,7 @@ export const AllTheProviders: React.FC<WrapperProps> = ({ children }) => {
   return <>{children}</>;
 };
 
-interface CustomRenderOptions extends Omit<RenderOptions, "wrapper"> {}
+type CustomRenderOptions = Omit<RenderOptions, "wrapper">;
 
 const customRender = (
   ui: React.ReactElement,


### PR DESCRIPTION
## Summary

Phase 1 of the engineering-audit work plan, PR 5 of 5 (final). Two findings, both **verified empirically** before fixing.

### E1 — the typescript-eslint presets were a silent no-op

In typescript-eslint v8 the shared configs (`recommended`, `recommendedTypeChecked`) are **arrays** of flat-config objects, so `tseslint.configs.recommended.rules` is `undefined` and spreading it contributed nothing. `eslint --print-config` confirmed **zero** `@typescript-eslint` correctness rules were active beyond the two set explicitly. The project believed it had type-checked linting and had none.

- Merge each preset array's `rules` into one record (`tseslintRules` helper) so the **46 recommended rules** actually load across `ts/tsx`.
- Add a **type-checked block scoped to source files** (`app`, `electron/main`, `shared` — in the root tsconfig, so `projectService` can resolve them) enabling the rules this IPC-heavy async codebase most needs: `no-floating-promises`, `no-misused-promises`, `await-thenable`, `only-throw-error`. Test files and preload are excluded from `tsconfig.json`, so they stay on the non-type-checked rules — a tests tsconfig is a separate Phase-4 follow-up.

**Violation burn-down: 193 → 0**, triaged by class rather than blanket-suppressed:

| Count | Rule | Disposition |
|---|---|---|
| 93 | `no-unused-expressions` | The deliberate `isDev && console.debug(…)` idiom (68 in preload) — allow short-circuit/ternary |
| ~36 | `no-misused-promises` | Async JSX event handlers (`onClick={async …}`), a known false positive — `checksVoidReturn.attributes: false`; the **2 genuine** ones (async `setTimeout` callbacks) are fixed |
| 39 | `no-floating-promises` | **Genuine** fire-and-forget calls (theme apply, navigation, refreshes, menu actions) — `void`-prefixed to document intent (runtime no-op), each verified fire-and-forget |
| 12 | misc | `require()` allowed in preload (CJS) + tests; empty-`extends` interfaces → type aliases; `prefer-const`/prettier fixed |

### E2 — CI lint ran the autofix variant

`.github/workflows/lint.yml` ran `npm run lint` (= `eslint . --fix`), applying fixes to the throwaway runner workspace and exiting 0 — so violations **never failed CI**; only the pre-commit hook ran the real check. Switched the job to `npm run lint:check`. The lint gate is now real for every error rule, including the newly-active type-aware ones.

### Validation

Full unit suite green (**3,528 tests**), typecheck clean, `eslint .` reports zero problems, full pre-commit gate passes. Also removed the stale `// Remove this file` comment that contradicted the config's own existence.

This completes **Phase 1** of the audit plan (every signal — UI, tests, lint — now tells the truth). Refs: audit findings E1, E2.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_