### PR TITLE
ci: streamline PR merges and close the post-merge main gap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,18 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "**"
+
+concurrency:
+  # Cancel superseded runs on the same branch/PR; never cancel main-push runs
+  # (they carry coverage + SonarCloud).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,12 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+concurrency:
+  # Cancel superseded runs on the same branch/PR; never cancel main-push runs
+  # (they carry coverage + SonarCloud).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e-tests:
     runs-on: ${{ matrix.os }}
@@ -159,7 +165,9 @@ jobs:
 
       - name: Run end-to-end tests (Linux/macOS)
         if: matrix.os != 'windows-latest'
-        run: npm run test:e2e
+        # test:play (not test:e2e) — the build already ran above; test:e2e
+        # would rebuild a second time.
+        run: npm run test:play
         env:
           ROMPER_SDCARD_PATH: /tmp/e2e-sdcard
           CI: true
@@ -167,7 +175,7 @@ jobs:
 
       - name: Run end-to-end tests (Windows)
         if: matrix.os == 'windows-latest'
-        run: npm run test:e2e
+        run: npm run test:play
         env:
           ROMPER_SDCARD_PATH: C:\temp\e2e-sdcard
           CI: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,18 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "**"
+
+concurrency:
+  # Cancel superseded runs on the same branch/PR; never cancel main-push runs
+  # (they carry coverage + SonarCloud).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - "**"
 
+concurrency:
+  # Cancel superseded runs on the same branch/PR; never cancel main-push runs
+  # (they carry coverage + SonarCloud).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   NODE_VERSION: "22"
   JAVA_VERSION: "17"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,9 +1,18 @@
 name: TypeCheck
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "**"
+
+concurrency:
+  # Cancel superseded runs on the same branch/PR; never cancel main-push runs
+  # (they carry coverage + SonarCloud).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   typecheck:


### PR DESCRIPTION
## Summary

Three changes that make the merge loop cheaper and safer on **free GitHub (no merge queue)** — surfaced while merging the Phase-1 audit batch (#295–#299) by hand. These directly address the friction I just hit.

### 1. `concurrency` + `cancel-in-progress` on all PR workflows
build, typecheck, lint, test, e2e. Every force-push during a rebase loop currently starts a fresh full run while the superseded one keeps burning Actions minutes. The concurrency group cancels superseded **PR** runs but **never cancels main-push runs** (`cancel-in-progress` is gated to `pull_request` events), so coverage/SonarCloud on main always complete. *(audit E7)*

### 2. Validate `main` on push, not just on PRs — closes the post-merge gap
`build`, `typecheck`, and `lint` triggered on `pull_request` only. So on a push to `main`, they didn't run — meaning a **behind-but-clean PR merged via rebase-merge could break main's typecheck/lint/build with nothing catching it.** That's the precise risk of merging without a merge queue (#298 merged a moment ago while behind #297; it was fine, but nothing on main would have told us if it weren't). Added `push: branches: [main]` to those three (`test.yml`/`e2e.yml` already ran on main). This is the cheap substitute for "require branches up to date before merging": let PRs merge while behind, catch the rare semantic break fast on main.

### 3. e2e: stop building twice
`npm run test:e2e` = `npm run build && npm run test:play`, but the e2e job already has an explicit "Build application" step — so every e2e run built the app **twice**. Switched the test step to `npm run test:play`. *(audit E7)*

## Deliberately not included (with reasons)

- **`paths-ignore` filters** to skip CI on docs-only PRs: with branch protection requiring these checks, a *skipped* required check leaves the PR permanently "Expected — Waiting for status" and unmergeable. Doing it safely needs a path-gate job that always reports success — its own change, and a footgun otherwise.
- **Auto-merge as the default habit**: enabling auto-merge per-PR lets GitHub land a green PR the instant checks pass without manual polling — the single biggest convenience win, but it's a *process* adoption, not a config change. Recommend turning it on going forward (I can set it per-PR via the API).

## Validation

Pure workflow YAML; all five files parse-validated. The new `push: main` triggers + concurrency take effect on this PR's own merge. Full pre-commit gate passed locally.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_