### PR TITLE
refactor: return DbResult from the throwing kit-lifecycle IPC handlers

### DIFF
--- a/app/renderer/components/SampleWaveform.tsx
+++ b/app/renderer/components/SampleWaveform.tsx
@@ -120,10 +120,15 @@ const SampleWaveform: React.FC<SampleWaveformProps> = ({
 
     globalThis.electronAPI
       .getSampleAudioBuffer(kitName, voiceNumber, slotNumber)
-      .then(async (arrayBuffer: ArrayBuffer | null) => {
+      .then(async (result) => {
         if (cancelled) return;
 
-        // Handle null response for missing samples (empty slots)
+        if (!result.success) {
+          throw new Error(result.error || "Failed to load sample audio");
+        }
+
+        // Handle null data for missing samples (empty slots)
+        const arrayBuffer = result.data;
         if (!arrayBuffer) {
           setAudioBuffer(null);
           return;

--- a/app/renderer/components/__tests__/SampleWaveform.test.tsx
+++ b/app/renderer/components/__tests__/SampleWaveform.test.tsx
@@ -112,9 +112,10 @@ describe("SampleWaveform", () => {
   });
 
   it("loads and decodes audio buffer on mount", async () => {
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
 
     await act(async () => {
       render(
@@ -165,7 +166,10 @@ describe("SampleWaveform", () => {
   });
 
   it("handles null audio buffer response gracefully (empty slot)", async () => {
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(null);
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: null,
+      success: true,
+    });
     const onError = vi.fn();
 
     await act(async () => {
@@ -315,9 +319,10 @@ describe("SampleWaveform", () => {
       return mockAudioContext;
     });
 
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
 
     const { rerender } = render(
       <SampleWaveform
@@ -421,9 +426,10 @@ describe("SampleWaveform", () => {
       return mockAudioContext;
     });
 
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
 
     const { rerender } = render(
       <SampleWaveform
@@ -500,9 +506,10 @@ describe("SampleWaveform", () => {
     global.AudioContext = vi.fn(function () {
       return mockAudioContext;
     });
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
 
     const { rerender } = render(
       <SampleWaveform
@@ -587,9 +594,10 @@ describe("SampleWaveform", () => {
     global.AudioContext = vi.fn(function () {
       return mockAudioContext;
     });
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
     const onPlayingChange = vi.fn();
 
     const { rerender } = render(
@@ -683,9 +691,10 @@ describe("SampleWaveform", () => {
     global.AudioContext = vi.fn(function () {
       return mockAudioContext;
     });
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
     const onPlayingChange = vi.fn();
 
     const { rerender } = render(
@@ -766,9 +775,10 @@ describe("SampleWaveform", () => {
       return mockAudioContext;
     });
 
-    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue(
-      new ArrayBuffer(1024),
-    );
+    vi.mocked(window.electronAPI.getSampleAudioBuffer).mockResolvedValue({
+      data: new ArrayBuffer(1024),
+      success: true,
+    });
 
     const { rerender } = render(
       <SampleWaveform

--- a/app/renderer/components/utils/__tests__/kitOperations.test.ts
+++ b/app/renderer/components/utils/__tests__/kitOperations.test.ts
@@ -50,7 +50,7 @@ describe("validateKitSlot", () => {
 
 describe("createKit", () => {
   it("successfully creates a kit with valid slot", async () => {
-    mockElectronAPI.createKit.mockResolvedValue(undefined);
+    mockElectronAPI.createKit.mockResolvedValue({ success: true });
 
     await createKit("A1");
 
@@ -71,8 +71,11 @@ describe("createKit", () => {
     await expect(createKit("A1")).rejects.toThrow("Electron API not available");
   });
 
-  it("propagates Electron API errors", async () => {
-    mockElectronAPI.createKit.mockRejectedValue(new Error("Disk full"));
+  it("throws the DbResult error on failure", async () => {
+    mockElectronAPI.createKit.mockResolvedValue({
+      error: "Disk full",
+      success: false,
+    });
 
     await expect(createKit("A1")).rejects.toThrow("Disk full");
   });
@@ -80,7 +83,7 @@ describe("createKit", () => {
 
 describe("duplicateKit", () => {
   it("successfully duplicates a kit with valid slots", async () => {
-    mockElectronAPI.copyKit.mockResolvedValue(undefined);
+    mockElectronAPI.copyKit.mockResolvedValue({ success: true });
 
     await duplicateKit("A1", "B2");
 
@@ -103,33 +106,23 @@ describe("duplicateKit", () => {
     );
   });
 
-  it("cleans up error messages from Electron API", async () => {
-    mockElectronAPI.copyKit.mockRejectedValue(
-      new Error(
-        "Error invoking remote method 'copy-kit': Error: Source kit not found",
-      ),
-    );
+  it("throws the clean DbResult error on failure", async () => {
+    // The handler returns a DbResult envelope, so the service's own message
+    // arrives intact — no "Error invoking remote method" prefix to strip.
+    mockElectronAPI.copyKit.mockResolvedValue({
+      error: "Source kit not found",
+      success: false,
+    });
 
     await expect(duplicateKit("A1", "B2")).rejects.toThrow(
       "Source kit not found",
-    );
-  });
-
-  it("handles various error message formats", async () => {
-    // Test different error prefixes
-    mockElectronAPI.copyKit.mockRejectedValue(
-      new Error("Error: Kit already exists"),
-    );
-
-    await expect(duplicateKit("A1", "B2")).rejects.toThrow(
-      "Kit already exists",
     );
   });
 });
 
 describe("deleteKit", () => {
   it("successfully deletes a kit", async () => {
-    mockElectronAPI.deleteKit.mockResolvedValue(undefined);
+    mockElectronAPI.deleteKit.mockResolvedValue({ success: true });
 
     await deleteKit("A5");
 
@@ -142,20 +135,19 @@ describe("deleteKit", () => {
     await expect(deleteKit("A5")).rejects.toThrow("Electron API not available");
   });
 
-  it("cleans up error messages from Electron API", async () => {
-    mockElectronAPI.deleteKit.mockRejectedValue(
-      new Error(
-        "Error invoking remote method 'delete-kit': Error: Kit not found",
-      ),
-    );
+  it("throws the clean DbResult error on failure", async () => {
+    mockElectronAPI.deleteKit.mockResolvedValue({
+      error: "Kit not found",
+      success: false,
+    });
 
     await expect(deleteKit("A5")).rejects.toThrow("Kit not found");
   });
 
-  it("handles non-Error rejection values", async () => {
-    mockElectronAPI.deleteKit.mockRejectedValue("string error");
+  it("falls back to a generic message when the failure has no error", async () => {
+    mockElectronAPI.deleteKit.mockResolvedValue({ success: false });
 
-    await expect(deleteKit("A5")).rejects.toThrow("string error");
+    await expect(deleteKit("A5")).rejects.toThrow("Failed to delete kit");
   });
 });
 
@@ -167,7 +159,10 @@ describe("getKitDeleteSummary", () => {
       sampleCount: 3,
       voiceCount: 4,
     };
-    mockElectronAPI.getKitDeleteSummary.mockResolvedValue(summary);
+    mockElectronAPI.getKitDeleteSummary.mockResolvedValue({
+      data: summary,
+      success: true,
+    });
 
     const result = await getKitDeleteSummary("A5");
 
@@ -183,20 +178,21 @@ describe("getKitDeleteSummary", () => {
     );
   });
 
-  it("cleans up error messages from Electron API", async () => {
-    mockElectronAPI.getKitDeleteSummary.mockRejectedValue(
-      new Error(
-        "Error invoking remote method 'get-kit-delete-summary': Error: Kit not found",
-      ),
-    );
+  it("throws the clean DbResult error on failure", async () => {
+    mockElectronAPI.getKitDeleteSummary.mockResolvedValue({
+      error: "Kit not found",
+      success: false,
+    });
 
     await expect(getKitDeleteSummary("A5")).rejects.toThrow("Kit not found");
   });
 
-  it("handles non-Error rejection values", async () => {
-    mockElectronAPI.getKitDeleteSummary.mockRejectedValue("db failure");
+  it("throws when the summary data is missing", async () => {
+    mockElectronAPI.getKitDeleteSummary.mockResolvedValue({ success: true });
 
-    await expect(getKitDeleteSummary("A5")).rejects.toThrow("db failure");
+    await expect(getKitDeleteSummary("A5")).rejects.toThrow(
+      "Failed to get kit delete summary",
+    );
   });
 });
 

--- a/app/renderer/components/utils/kitOperations.ts
+++ b/app/renderer/components/utils/kitOperations.ts
@@ -21,7 +21,10 @@ export async function createKit(kitSlot: string): Promise<void> {
     throw new Error("Electron API not available");
   }
 
-  await globalThis.electronAPI.createKit(kitSlot);
+  const result = await globalThis.electronAPI.createKit(kitSlot);
+  if (!result.success) {
+    throw new Error(result.error || "Failed to create kit");
+  }
 }
 
 /**
@@ -32,14 +35,9 @@ export async function deleteKit(kitName: string): Promise<void> {
     throw new Error("Electron API not available");
   }
 
-  try {
-    await globalThis.electronAPI.deleteKit(kitName);
-  } catch (err) {
-    let msg = String(err instanceof Error ? err.message : err);
-    msg = msg
-      .replace(/^Error invoking remote method 'delete-kit':\s*/, "")
-      .replace(/^Error:\s*/, "");
-    throw new Error(msg);
+  const result = await globalThis.electronAPI.deleteKit(kitName);
+  if (!result.success) {
+    throw new Error(result.error || "Failed to delete kit");
   }
 }
 
@@ -58,15 +56,9 @@ export async function duplicateKit(
     throw new Error("Electron API not available");
   }
 
-  try {
-    await globalThis.electronAPI.copyKit(sourceSlot, destSlot);
-  } catch (err) {
-    // Clean up error message
-    let msg = String(err instanceof Error ? err.message : err);
-    msg = msg
-      .replace(/^Error invoking remote method 'copy-kit':\s*/, "")
-      .replace(/^Error:\s*/, "");
-    throw new Error(msg);
+  const result = await globalThis.electronAPI.copyKit(sourceSlot, destSlot);
+  if (!result.success) {
+    throw new Error(result.error || "Failed to copy kit");
   }
 }
 
@@ -117,15 +109,11 @@ export async function getKitDeleteSummary(kitName: string): Promise<{
     throw new Error("Electron API not available");
   }
 
-  try {
-    return await globalThis.electronAPI.getKitDeleteSummary(kitName);
-  } catch (err) {
-    let msg = String(err instanceof Error ? err.message : err);
-    msg = msg
-      .replace(/^Error invoking remote method 'get-kit-delete-summary':\s*/, "")
-      .replace(/^Error:\s*/, "");
-    throw new Error(msg);
+  const result = await globalThis.electronAPI.getKitDeleteSummary(kitName);
+  if (!result.success || !result.data) {
+    throw new Error(result.error || "Failed to get kit delete summary");
   }
+  return result.data;
 }
 
 /**

--- a/app/renderer/electron.d.ts
+++ b/app/renderer/electron.d.ts
@@ -53,11 +53,11 @@ export interface ElectronAPI {
   }>;
   closeApp?: () => Promise<void>;
   copyDir?: (src: string, dest: string) => Promise<void>;
-  copyKit?: (sourceKit: string, destKit: string) => Promise<void>;
-  createKit?: (kitSlot: string) => Promise<void>;
+  copyKit?: (sourceKit: string, destKit: string) => Promise<DbResult>;
+  createKit?: (kitSlot: string) => Promise<DbResult>;
   // Missing methods causing errors
   createRomperDb?: (dbDir: string) => Promise<RomperDbResult>;
-  deleteKit?: (kitName: string) => Promise<void>;
+  deleteKit?: (kitName: string) => Promise<DbResult>;
   deleteSampleFromSlot?: (
     kitName: string,
     voiceNumber: number,
@@ -120,12 +120,14 @@ export interface ElectronAPI {
   getFavoriteKitsCount?: () => Promise<DbResult<number>>;
   // Database methods for kit metadata (replacing JSON file dependency)
   getKit?: (kitName: string) => Promise<DbResult<KitWithRelations>>;
-  getKitDeleteSummary?: (kitName: string) => Promise<{
-    kitName: string;
-    locked: boolean;
-    sampleCount: number;
-    voiceCount: number;
-  }>;
+  getKitDeleteSummary?: (kitName: string) => Promise<
+    DbResult<{
+      kitName: string;
+      locked: boolean;
+      sampleCount: number;
+      voiceCount: number;
+    }>
+  >;
   getKits?: () => Promise<
     DbResult<
       Array<{
@@ -159,7 +161,7 @@ export interface ElectronAPI {
     kitName: string,
     voiceNumber: number,
     slotNumber: number,
-  ) => Promise<ArrayBuffer | null>;
+  ) => Promise<DbResult<ArrayBuffer | null>>;
   getSetting: (
     key: keyof {
       confirmDestructiveActions?: boolean;

--- a/electron/main/__tests__/ipcHandlers.test.ts
+++ b/electron/main/__tests__/ipcHandlers.test.ts
@@ -253,16 +253,16 @@ describe("registerIpcHandlers", () => {
     expect(result).toBeNull();
   });
 
-  it("registers create-kit and creates kit successfully", async () => {
+  it("registers create-kit and returns success", async () => {
     const { registerIpcHandlers } = await import("../ipcHandlers");
     registerIpcHandlers({ localStorePath: "/mock/store" });
 
-    await expect(
-      ipcMainHandlers["create-kit"]({}, "A0"),
-    ).resolves.toBeUndefined();
+    await expect(ipcMainHandlers["create-kit"]({}, "A0")).resolves.toEqual({
+      success: true,
+    });
   });
 
-  it("create-kit throws error on failure", async () => {
+  it("create-kit returns the failure DbResult", async () => {
     const { kitService } = await import("../services/kitService.js");
     vi.mocked(kitService.createKit).mockReturnValue({
       error: "Create failed",
@@ -272,21 +272,22 @@ describe("registerIpcHandlers", () => {
     const { registerIpcHandlers } = await import("../ipcHandlers");
     registerIpcHandlers({ localStorePath: "/mock/store" });
 
-    await expect(ipcMainHandlers["create-kit"]({}, "A0")).rejects.toThrow(
-      "Create failed",
-    );
+    await expect(ipcMainHandlers["create-kit"]({}, "A0")).resolves.toEqual({
+      error: "Create failed",
+      success: false,
+    });
   });
 
-  it("registers copy-kit and copies kit successfully", async () => {
+  it("registers copy-kit and returns success", async () => {
     const { registerIpcHandlers } = await import("../ipcHandlers");
     registerIpcHandlers({ localStorePath: "/mock/store" });
 
-    await expect(
-      ipcMainHandlers["copy-kit"]({}, "A0", "A1"),
-    ).resolves.toBeUndefined();
+    await expect(ipcMainHandlers["copy-kit"]({}, "A0", "A1")).resolves.toEqual({
+      success: true,
+    });
   });
 
-  it("copy-kit throws error on failure", async () => {
+  it("copy-kit returns the failure DbResult", async () => {
     const { kitService } = await import("../services/kitService.js");
     vi.mocked(kitService.copyKit).mockReturnValue({
       error: "Copy failed",
@@ -296,9 +297,10 @@ describe("registerIpcHandlers", () => {
     const { registerIpcHandlers } = await import("../ipcHandlers");
     registerIpcHandlers({ localStorePath: "/mock/store" });
 
-    await expect(ipcMainHandlers["copy-kit"]({}, "A0", "A1")).rejects.toThrow(
-      "Copy failed",
-    );
+    await expect(ipcMainHandlers["copy-kit"]({}, "A0", "A1")).resolves.toEqual({
+      error: "Copy failed",
+      success: false,
+    });
   });
 
   it("registers list-files-in-root and returns file list", async () => {
@@ -322,10 +324,11 @@ describe("registerIpcHandlers", () => {
       1,
       0,
     );
-    expect(result).toBeInstanceOf(ArrayBuffer);
+    expect(result.success).toBe(true);
+    expect(result.data).toBeInstanceOf(ArrayBuffer);
   });
 
-  it("get-sample-audio-buffer throws error on failure", async () => {
+  it("get-sample-audio-buffer returns the failure DbResult", async () => {
     const { sampleService } = await import("../services/sampleService.js");
     vi.mocked(sampleService.getSampleAudioBuffer).mockReturnValue({
       error: "Buffer failed",
@@ -337,7 +340,7 @@ describe("registerIpcHandlers", () => {
 
     await expect(
       ipcMainHandlers["get-sample-audio-buffer"]({}, "A0", 1, 0),
-    ).rejects.toThrow("Buffer failed");
+    ).resolves.toEqual({ error: "Buffer failed", success: false });
   });
 
   it("registers read-file and returns file content", async () => {

--- a/electron/main/ipcHandlers.ts
+++ b/electron/main/ipcHandlers.ts
@@ -89,11 +89,7 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
         process.env.ROMPER_LOCAL_PATH || inMemorySettings.localStorePath,
     };
 
-    const result = kitService.getKitDeleteSummary(effectiveSettings, kitName);
-    if (!result.success) {
-      throw new Error(result.error || "Failed to get kit delete summary");
-    }
-    return result.data;
+    return kitService.getKitDeleteSummary(effectiveSettings, kitName);
   });
 
   ipcMain.handle("delete-kit", async (_event, kitName: string) => {
@@ -103,10 +99,7 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
         process.env.ROMPER_LOCAL_PATH || inMemorySettings.localStorePath,
     };
 
-    const result = kitService.deleteKit(effectiveSettings, kitName);
-    if (!result.success) {
-      throw new Error(result.error || "Failed to delete kit");
-    }
+    return kitService.deleteKit(effectiveSettings, kitName);
   });
 
   ipcMain.handle("create-kit", async (_event, kitSlot: string) => {
@@ -117,10 +110,7 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
         process.env.ROMPER_LOCAL_PATH || inMemorySettings.localStorePath,
     };
 
-    const result = kitService.createKit(effectiveSettings, kitSlot);
-    if (!result.success) {
-      throw new Error(result.error || "Failed to create kit");
-    }
+    return kitService.createKit(effectiveSettings, kitSlot);
   });
 
   ipcMain.handle(
@@ -133,10 +123,7 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
           process.env.ROMPER_LOCAL_PATH || inMemorySettings.localStorePath,
       };
 
-      const result = kitService.copyKit(effectiveSettings, sourceKit, destKit);
-      if (!result.success) {
-        throw new Error(result.error || "Failed to copy kit");
-      }
+      return kitService.copyKit(effectiveSettings, sourceKit, destKit);
     },
   );
   ipcMain.handle("list-files-in-root", async (_event, localStorePath: string) =>
@@ -151,18 +138,12 @@ export function registerIpcHandlers(inMemorySettings: InMemorySettings) {
       voiceNumber: number,
       slotNumber: number,
     ) => {
-      const result = sampleService.getSampleAudioBuffer(
+      return sampleService.getSampleAudioBuffer(
         inMemorySettings,
         kitName,
         voiceNumber,
         slotNumber,
       );
-
-      if (!result.success) {
-        throw new Error(result.error || "Failed to get sample audio buffer");
-      }
-
-      return result.data;
     },
   );
   ipcMain.handle("read-file", async (_event, filePath: string) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -173,11 +173,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     isDev && console.debug("[IPC] copyDir invoked", src, dest);
     return ipcRenderer.invoke("copy-dir", src, dest);
   },
-  copyKit: (sourceKit: string, destKit: string): Promise<void> => {
+  copyKit: (sourceKit: string, destKit: string) => {
     isDev && console.debug("[IPC] copyKit invoked", sourceKit, destKit);
     return ipcRenderer.invoke("copy-kit", sourceKit, destKit);
   },
-  createKit: (kitSlot: string): Promise<void> => {
+  createKit: (kitSlot: string) => {
     isDev && console.debug("[IPC] createKit invoked", kitSlot);
     return ipcRenderer.invoke("create-kit", kitSlot);
   },
@@ -185,7 +185,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     isDev && console.debug("[IPC] createRomperDb invoked", dbDir);
     return ipcRenderer.invoke("create-romper-db", dbDir);
   },
-  deleteKit: (kitName: string): Promise<void> => {
+  deleteKit: (kitName: string) => {
     isDev && console.debug("[IPC] deleteKit invoked", kitName);
     return ipcRenderer.invoke("delete-kit", kitName);
   },

--- a/tests/mocks/electron/electronAPI.ts
+++ b/tests/mocks/electron/electronAPI.ts
@@ -21,9 +21,9 @@ export const createElectronAPIMock = (
   // Application operations
   closeApp: vi.fn().mockResolvedValue(undefined),
   copyDir: vi.fn().mockResolvedValue(undefined),
-  copyKit: vi.fn().mockResolvedValue(undefined),
+  copyKit: vi.fn().mockResolvedValue({ success: true }),
   // Kit operations
-  createKit: vi.fn().mockResolvedValue(undefined),
+  createKit: vi.fn().mockResolvedValue({ success: true }),
 
   // Database setup
   createRomperDb: vi.fn().mockResolvedValue(undefined),
@@ -100,7 +100,9 @@ export const createElectronAPIMock = (
   getLocalStoreStatus: vi
     .fn()
     .mockResolvedValue({ hasLocalStore: true, isValid: true }),
-  getSampleAudioBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+  getSampleAudioBuffer: vi
+    .fn()
+    .mockResolvedValue({ data: new ArrayBuffer(8), success: true }),
   // Settings operations
   getSetting: vi.fn().mockResolvedValue("/mock/local/store"),
   getUserHomeDir: vi.fn().mockResolvedValue("/mock/home"),


### PR DESCRIPTION
## Summary

**Phase 2 (contract layer), part 2:** finishes the error-contract standardization started in #291 by eliminating the throw family the audit named. Five handlers in `ipcHandlers.ts` unwrapped their service's `DbResult` and **re-threw** on failure — `create-kit`, `copy-kit`, `delete-kit`, `get-kit-delete-summary`, `get-sample-audio-buffer`.

A thrown error crosses the IPC boundary mangled as `"Error invoking remote method 'delete-kit': ..."`, so the renderer ran a **per-channel regex-stripping protocol** (`kitOperations.ts`) just to recover the real message — a fragile string contract that existed *only* because the envelope was discarded at the boundary.

### Changes

The handlers now **return the service's `DbResult` envelope directly** (the services already produce it — this is pure unwrap-removal in main).

Renderer:
- **`kitOperations.ts`** — `createKit` / `deleteKit` / `duplicateKit` / `getKitDeleteSummary` check `result.success` and throw the clean `result.error`. The three `Error invoking remote method` regex blocks are **deleted** — the error arrives intact because it never became an IPC rejection.
- **`SampleWaveform.tsx`** — unwraps `DbResult<ArrayBuffer | null>` in its `.then` (`success: false` → throw to the existing `.catch`; `data: null` → empty slot, unchanged).
- **`electron.d.ts` + preload** — the five return types become `DbResult<...>`.

The consuming hooks (`useKitCreation` / `Deletion` / `Duplication`) are **unchanged** — the `kitOperations` wrappers still throw on failure, just with clean messages, so their existing `catch` works as-is. That kept the blast radius small.

### Tests

- The `kitOperations` regex-stripping tests become **`DbResult`-failure tests** (the clean error arrives without a prefix) — i.e. they now assert the contract instead of the workaround.
- The `ipcHandlers` "throws on failure" tests become "returns the failure `DbResult`".
- Central mock + `SampleWaveform` mocks return `DbResult` shapes.
- Full unit suite green: **3,463 tests**; typecheck, lint, pre-commit gate pass.

After this, the only non-`DbResult` IPC contracts left are the filesystem-utility one-offs (`check-disk-space`, `check-path-writable`, `read-file`, etc.) — intentionally distinct shapes, noted in the audit as acceptable. Auto-merge enabled.

Refs: audit finding A2-F1 (error handling); completes the #291 follow-up.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_