### PR TITLE
release: prepare 1.3.0-rc.1 with prerelease-safe release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,5 +346,10 @@ jobs:
             release-artifacts/**/*.deb
             release-artifacts/**/*.rpm
             release-artifacts/**/*.AppImage
-          makeLatest: true
+          # Tags containing a hyphen (e.g. v1.3.0-rc.1) are prereleases:
+          # published on GitHub but NOT marked latest, so the
+          # update.electronjs.org feed (which serves the latest stable
+          # release) never pushes them to existing users via auto-update.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          makeLatest: ${{ !contains(github.ref_name, '-') && 'true' || 'false' }}
           draft: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.2.0",
+  "version": "1.3.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.2.0",
+      "version": "1.3.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/peteb4ker/romper.git"


### PR DESCRIPTION
## Summary

Prepares the **1.3.0-rc.1 release candidate**. The delta since v1.2.0 is unusually large — the security hardening batch (S1–S10), the full engineering-audit Phase 1+2 (restored error feedback, two repaired dead features, the lint/test guardrails, the IPC contract layer), all the code-smell refactors, and the new macOS auto-updater itself — so it soaks as an RC before going to auto-update users.

### 1. Prerelease-safe release workflow (the critical piece)

`release.yml` created every release with an unconditional **`makeLatest: true`** and no `prerelease` flag. The macOS auto-updater uses **update.electronjs.org**, which serves the repo's *latest* release — so tagging `v1.3.0-rc.1` as-is would have **auto-updated every existing 1.2.0 user onto the RC**.

Now: tags containing a hyphen (`v1.3.0-rc.1`) publish as `prerelease: true` / `makeLatest: false` — visible on GitHub for manual download, invisible to the update feed. Stable tags behave exactly as before. Prerelease semver (`1.3.0-rc.1 < 1.3.0`) also means RC installs auto-update forward to 1.3.0 final when it ships.

### 2. Version bump → `1.3.0-rc.1`

`package.json` + lockfile, so RC builds self-identify (About dialog, update comparisons).

### Release plan

1. This merges → I tag `v1.3.0-rc.1` on main → the release workflow runs the full pipeline (SonarCloud quality gate → cross-platform build → macOS sign/notarize/staple → GitHub prerelease with generated notes).
2. After the RC soaks: bump to `1.3.0`, tag `v1.3.0` → published as latest, reaches auto-update users.

> Supersedes the bump in #279 (which predates ~25 merged PRs and would have published straight to all users); #279 gets a comment with this plan and can serve as the promotion reminder or be closed.

Pre-commit gate passes; `release.yml` parse-validated.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_