### PR TITLE
docs: codify release and PR-merge discipline as Claude skills

### DIFF
--- a/.claude/commands/new-worktree.md
+++ b/.claude/commands/new-worktree.md
@@ -1,16 +1,13 @@
-# New Worktree Command
+---
+description: Create a new isolated worktree following the mandatory worktree workflow
+argument-hint: "[task-name]"
+---
 
-Create a new isolated worktree following the mandatory worktree workflow.
+Create a new worktree for task `$ARGUMENTS`:
 
-## Usage
-```
-/new-worktree <task-name>
-```
-
-## Steps
-1. Pull latest main: `git pull origin main`
-2. Create worktree: `npm run worktree:create <task-name>`
-1. Switch to the main branch: `git checkout main`
-2. Pull latest main: `git pull origin main`
-3. Create worktree: `npm run worktree:create <task-name>`
-4. Navigate: `cd worktrees/<task-name>`
+1. Create the worktree: `npm run worktree:create $ARGUMENTS`
+   (the script fetches origin and branches `feature/$ARGUMENTS` from
+   `origin/main` — no manual pull or checkout needed)
+2. Navigate into it: `cd worktrees/$ARGUMENTS`
+3. Confirm the branch base is clean: `git log --oneline origin/main..HEAD`
+   should be empty before any commits are made.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: release
+description: Cut a Romper release or release candidate — version-bump PR, tag, automated build/sign/publish. Use to release a new version, cut an RC, or promote an RC to stable.
+argument-hint: "[version, e.g. 1.4.0 or 1.4.0-rc.1]"
+disable-model-invocation: true
+allowed-tools: Bash(git fetch *), Bash(git tag *), Bash(git log *), Bash(npm version *)
+---
+
+Cut release `$ARGUMENTS` (a bare semver, no `v` prefix; the tag adds it).
+
+## Non-negotiables
+
+- **A hyphen in the tag marks it prerelease.** `.github/workflows/release.yml`
+  derives `prerelease` and `makeLatest` from `contains(github.ref_name, '-')`.
+  The macOS auto-updater (update.electronjs.org) serves whatever GitHub marks
+  **Latest**, so tagging a test build in stable format (`v1.4.0` instead of
+  `v1.4.0-rc.1`) ships it to every existing user. Check the tag format twice.
+- **The version bump goes through a PR; only the tag is pushed directly.**
+  Never push commits to `main`.
+
+## Steps
+
+1. **Bump** in a worktree: `npm version $ARGUMENTS --no-git-tag-version`
+   (updates `package.json` + `package-lock.json`), commit, push, open a PR,
+   and arm auto-merge immediately — see the `ship-pr` skill.
+2. **Tag** once the bump PR is merged:
+
+   ```sh
+   git fetch origin main
+   git tag v$ARGUMENTS origin/main
+   git push origin v$ARGUMENTS
+   ```
+
+   Remote Claude Code sessions cannot push tags (the git proxy only allows
+   the session branch) — in that case hand these exact commands to the user.
+3. **Watch the workflow.** The tag fires `release.yml`:
+   SonarCloud quality gate → 3-platform builds (macOS sign/notarize, Windows
+   Azure Trusted Signing) → GitHub release with generated notes
+   (`scripts/release/generate-notes.js` handles prerelease versions).
+   A failed quality gate auto-files a GitHub issue; fix the issues and re-tag.
+4. **Verify** on the releases page: RCs must show the *Pre-release* badge and
+   **Latest** must still point at the previous stable. A stable release must
+   become Latest.
+
+## Promoting an RC to stable
+
+Semver orders `1.4.0-rc.1 < 1.4.0`, so RC users auto-update forward to the
+final. Promotion is just steps 1–4 again with the final version. Leave RC
+releases up; they are inert once a stable release is Latest.
+
+## Rolling back a bad tag
+
+```sh
+git push origin :refs/tags/v$ARGUMENTS
+```
+
+Then delete the GitHub release if it published. If a bad *stable* release
+went out, ship a fixed higher version rather than re-using the tag — the
+auto-updater caches by version.
+
+For pipeline depth (signing, notarization, artifact layout), see
+[docs/developer/release-process.md](../../../docs/developer/release-process.md).

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ship-pr
+description: Merge discipline for Romper PRs — rebase onto origin/main, arm auto-merge before CI finishes, rebase-merge method. Use when merging a PR, draining the PR queue, or a green PR is stuck waiting.
+argument-hint: "[pr-number ...]"
+---
+
+Merge PR(s) `$ARGUMENTS` following the repo's merge discipline.
+
+## The one rule that prevents stuck PRs
+
+**Arm auto-merge immediately after pushing, while CI is still running.**
+Auto-merge fires on a check-completion event; arming it after all checks are
+already green means no further event arrives and the PR sits forever. If a PR
+is already green, skip auto-merge and merge it directly (rebase method).
+
+## Per-PR procedure
+
+1. Rebase the branch onto latest main, never merge-commit it:
+
+   ```sh
+   git fetch origin main
+   git rebase origin/main
+   git push --force-with-lease
+   ```
+
+2. Arm auto-merge (rebase method) right away — before CI finishes.
+3. **Merge method is rebase**, per the repo hard rules. Not squash, not
+   merge-commit.
+4. If CI fails, it is your problem until proven otherwise — no "pre-existing
+   failure" dismissals, no `--no-verify`, no `HUSKY=0`.
+
+## Queue mechanics (no merge queue on free GitHub)
+
+- Merge serially, oldest-green first. After each merge, the next PR is
+  *behind* main; that is fine — "require branches up to date" is
+  intentionally off, so a behind-but-conflict-free PR rebase-merges without
+  re-running CI.
+- The backstop for that gap is post-merge validation on `main` (build /
+  typecheck / lint run on every push to main). If main goes red after a
+  merge, fix forward immediately; it gates nothing else.
+- Only rebase + re-push a queued PR when it actually conflicts; each re-push
+  costs a full CI round. Re-arm auto-merge after any re-push.
+- Lockfile conflicts on rebase: take your side, then `npm install` to
+  regenerate, and confirm overrides/audit state survived.

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -1,7 +1,7 @@
 <!-- 
 title: Release Process
 owners: developer-team
-last_reviewed: 2025-08-20
+last_reviewed: 2026-06-10
 tags: developer
 -->
 
@@ -55,27 +55,32 @@ Romper uses **manual tag-based releases** because:
    # Example: "version": "1.0.1"
    ```
 
-2. **Commit the version bump**:
+2. **Land the version bump via a PR** (never push commits to `main`
+   directly — see the hard rules in `CLAUDE.md`):
    ```bash
-   git add package.json
-   git commit -m "bump: version 1.0.1"
+   npm version 1.0.1 --no-git-tag-version   # updates package.json + lockfile
+   git commit -am "release: bump version to 1.0.1"
+   # push the branch, open a PR, merge it
    ```
 
-3. **Create and push git tag**:
+3. **Create and push the git tag** once the bump is on `main`:
    ```bash
-   # Create tag (this triggers the release workflow)
-   git tag v1.0.1
-   git push origin main --tags
+   git fetch origin main
+   git tag v1.0.1 origin/main
+   git push origin v1.0.1     # this triggers the release workflow
    ```
 
 ### Step 3: Monitor Automated Process
 
 The GitHub Actions workflow will automatically:
 
-1. **Build for all platforms** (Windows, macOS, Linux)
-2. **Generate release notes** from commits since the last tag
-3. **Create GitHub release** with all artifacts and proper release notes
-4. **Attach distribution packages** for all platforms
+1. **Check the SonarCloud quality gate** — any open CRITICAL/BLOCKER issue
+   or unreviewed security hotspot blocks the release and auto-files a
+   GitHub issue; fix the issues and re-tag
+2. **Build for all platforms** (Windows, macOS, Linux)
+3. **Generate release notes** from commits since the last tag
+4. **Create GitHub release** with all artifacts and proper release notes
+5. **Attach distribution packages** for all platforms
 
 You can monitor progress at: https://github.com/peteb4ker/romper/actions
 
@@ -93,6 +98,20 @@ git tag v1.0.1  # Bug fixes
 git tag v1.1.0  # New features  
 git tag v2.0.0  # Breaking changes
 ```
+
+### Release candidates (prereleases)
+
+Tags containing a hyphen (e.g. `v1.4.0-rc.1`) are published as GitHub
+**prereleases** and are never marked *Latest* — the release workflow derives
+both flags from the tag name. This matters because the macOS auto-updater
+(update.electronjs.org) serves whatever release GitHub marks Latest: an RC
+tagged in stable format would be pushed to every existing user.
+
+- Cut an RC exactly like a release, with the prerelease version
+  (`npm version 1.4.0-rc.1 --no-git-tag-version`, PR, then tag
+  `v1.4.0-rc.1`).
+- Promote by repeating the process with the final version. Semver orders
+  `1.4.0-rc.1 < 1.4.0`, so RC users auto-update forward to the final.
 
 ## Release Artifacts
 
@@ -174,17 +193,14 @@ npm run build
    git commit -m "fix: critical security vulnerability"
    ```
 
-3. **Merge to main and release**:
+3. **Land the hotfix and bump via PRs, then tag**:
    ```bash
-   git checkout main
-   git merge hotfix/1.2.4
-   
-   # Update package.json version to 1.2.4
-   git add package.json
-   git commit -m "bump: version 1.2.4"
-   
-   git tag v1.2.4
-   git push origin main --tags
+   # open a PR for the hotfix branch (including the version bump to 1.2.4)
+   # and merge it — direct pushes to main are not allowed
+
+   git fetch origin main
+   git tag v1.2.4 origin/main
+   git push origin v1.2.4
    ```
 
 #### Rollback Process
@@ -233,6 +249,6 @@ The Romper release process is designed to be:
 - **Complete**: All platforms built and released simultaneously
 
 For most releases, the process is just:
-1. `git tag v1.0.1`
-2. `git push origin --tags`
+1. Land the version-bump PR
+2. `git tag v1.0.1 origin/main && git push origin v1.0.1`
 3. Monitor GitHub Actions for completion


### PR DESCRIPTION
Codifies the CI/release lessons from this week's merge-queue and RC work as repo skills, linted against the [Anthropic skill best-practices guide](https://code.claude.com/docs/en/skills).

## New skills

- **`.claude/skills/release/SKILL.md`** (`/release <version>`) — the full RC/stable release procedure: bump-via-PR, tag mechanics, and the load-bearing rules learned cutting 1.3.0-rc.1:
  - a hyphen in the tag is what flips `prerelease`/`makeLatest` in release.yml; the macOS auto-updater serves whatever GitHub marks *Latest*, so a mis-formatted RC tag would ship to every user
  - SonarCloud quality gate blocks the release and auto-files an issue
  - RC→stable promotion relies on semver ordering (`1.4.0-rc.1 < 1.4.0`)
  - `disable-model-invocation: true` (user-timed, side-effectful), scoped `allowed-tools`
- **`.claude/skills/ship-pr/SKILL.md`** (`/ship-pr [pr ...]`) — merge-queue discipline on free GitHub (no merge queues): rebase-merge only, **arm auto-merge before CI finishes** (arming after green never fires — the trap that stalled 12 PRs), behind-but-clean merges without CI re-runs, post-merge main validation as the backstop.

## Fixes

- `.claude/commands/new-worktree.md` — had duplicate step numbering (1,2,1,2,3,4) and no frontmatter; now frontmattered with `$ARGUMENTS` and a branch-base sanity check.
- `docs/developer/release-process.md` — removed instructions that contradicted the repo's own hard rules (`git push origin main --tags` and the hotfix flow both pushed directly to main); documented the SonarCloud release gate and the new prerelease/RC flow; bump-via-PR throughout.

Skill-guide lint applied: key-use-case-first descriptions, `argument-hint`, concise bodies (<70 lines, cap is 500), reference doc linked rather than duplicated, `name` matches directory.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_