### PR TITLE
fix(ci): re-baseline coverage thresholds for Vitest 4 and fix unzipper mock hoisting

### DIFF
--- a/electron/main/services/__tests__/archiveService.test.ts
+++ b/electron/main/services/__tests__/archiveService.test.ts
@@ -42,29 +42,36 @@ vi.mock("node:path", () => ({
   sep: "/",
 }));
 
-// Unzipper mock: emits normal events unless test sets .emitUnzipEvents to emit error
+// Unzipper mock. vi.mock calls are hoisted, so per-test factories don't
+// work (the last registered factory would silently win for the whole
+// file) — instead the single top-level mock delegates entry emission to
+// a swappable script that tests override and beforeEach resets.
+const defaultUnzipScript = (stream: MockStream) => {
+  setTimeout(() => {
+    stream.emit("entry", {
+      autodrain: () => {},
+      on: () => {},
+      path: "foo.wav",
+      pipe: () => new MockStream(),
+      type: "File",
+    });
+    stream.emit("entry", {
+      autodrain: () => {},
+      on: () => {},
+      path: "bar/",
+      pipe: () => new MockStream(),
+      type: "Directory",
+    });
+    stream.emit("close");
+  }, 10);
+};
+let unzipScript: (stream: MockStream) => void = defaultUnzipScript;
+
 vi.mock("unzipper", () => ({
   Parse: vi.fn(() => {
     const stream = new MockStream();
-    (stream as unknown).emitUnzipEvents = () => {
-      setTimeout(() => {
-        stream.emit("entry", {
-          autodrain: () => {},
-          on: () => {},
-          path: "foo.wav",
-          pipe: () => new MockStream(),
-          type: "File",
-        });
-        stream.emit("entry", {
-          autodrain: () => {},
-          on: () => {},
-          path: "bar/",
-          pipe: () => new MockStream(),
-          type: "Directory",
-        });
-        stream.emit("close");
-      }, 10);
-    };
+    (stream as unknown as MockStream).emitUnzipEvents = () =>
+      unzipScript(stream);
     unzipperStreams.push(stream);
     return stream;
   }),
@@ -104,6 +111,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   unzipperStreams.length = 0;
   lastWriteStream = null;
+  unzipScript = defaultUnzipScript;
   const { registerIpcHandlers } = await import("../../ipcHandlers");
   registerIpcHandlers({}, {});
 });
@@ -166,31 +174,23 @@ describe("download-and-extract-archive handler", () => {
   }, 15000);
 
   it("skips __MACOSX and dot-underscore entries", async () => {
-    vi.mocked(unzipperStreams).length = 0;
-    vi.mock("unzipper", () => ({
-      Parse: vi.fn(() => {
-        const stream = new MockStream();
-        (stream as unknown).emitUnzipEvents = () => {
-          setTimeout(() => {
-            stream.emit("entry", {
-              autodrain: vi.fn(),
-              path: "__MACOSX/._foo.wav",
-              pipe: vi.fn(),
-              type: "File",
-            });
-            stream.emit("entry", {
-              autodrain: vi.fn(),
-              path: "._bar.wav",
-              pipe: vi.fn(),
-              type: "File",
-            });
-            stream.emit("close");
-          }, 10);
-        };
-        unzipperStreams.push(stream);
-        return stream;
-      }),
-    }));
+    unzipScript = (stream) => {
+      setTimeout(() => {
+        stream.emit("entry", {
+          autodrain: vi.fn(),
+          path: "__MACOSX/._foo.wav",
+          pipe: vi.fn(),
+          type: "File",
+        });
+        stream.emit("entry", {
+          autodrain: vi.fn(),
+          path: "._bar.wav",
+          pipe: vi.fn(),
+          type: "File",
+        });
+        stream.emit("close");
+      }, 10);
+    };
     (fs.createReadStream as unknown).mockImplementation(() => new MockStream());
     const handler = ipcMainHandlers["download-and-extract-archive"];
     const result = await handler(
@@ -206,19 +206,11 @@ describe("download-and-extract-archive handler", () => {
   }, 15000);
 
   it("handles zero valid entries gracefully", async () => {
-    vi.mocked(unzipperStreams).length = 0;
-    vi.mock("unzipper", () => ({
-      Parse: vi.fn(() => {
-        const stream = new MockStream();
-        (stream as unknown).emitUnzipEvents = () => {
-          setTimeout(() => {
-            stream.emit("close");
-          }, 10);
-        };
-        unzipperStreams.push(stream);
-        return stream;
-      }),
-    }));
+    unzipScript = (stream) => {
+      setTimeout(() => {
+        stream.emit("close");
+      }, 10);
+    };
     (fs.createReadStream as unknown).mockImplementation(() => new MockStream());
     const handler = ipcMainHandlers["download-and-extract-archive"];
     const result = await handler(
@@ -253,33 +245,25 @@ describe("download-and-extract-archive handler", () => {
   }, 15000);
 
   it("logs file write errors but continues extraction", async () => {
-    vi.mocked(unzipperStreams).length = 0;
-    vi.mock("unzipper", () => ({
-      Parse: vi.fn(() => {
-        const stream = new MockStream();
-        (stream as unknown).emitUnzipEvents = () => {
-          setTimeout(() => {
-            // Emit an entry to trigger file extraction
-            stream.emit("entry", {
-              autodrain: () => {},
-              on: () => {},
-              path: "foo.wav",
-              pipe: () => {
-                const s = new MockStream();
-                setTimeout(() => s.emit("error", new Error("write fail")), 5);
-                setTimeout(() => s.emit("finish"), 10);
-                return s;
-              },
-              type: "File",
-            });
-            // End extraction
-            setTimeout(() => stream.emit("close"), 20);
-          }, 1);
-        };
-        unzipperStreams.push(stream);
-        return stream;
-      }),
-    }));
+    unzipScript = (stream) => {
+      setTimeout(() => {
+        // Emit an entry to trigger file extraction
+        stream.emit("entry", {
+          autodrain: () => {},
+          on: () => {},
+          path: "foo.wav",
+          pipe: () => {
+            const s = new MockStream();
+            setTimeout(() => s.emit("error", new Error("write fail")), 5);
+            setTimeout(() => s.emit("finish"), 10);
+            return s;
+          },
+          type: "File",
+        });
+        // End extraction
+        setTimeout(() => stream.emit("close"), 20);
+      }, 1);
+    };
     (fs.createReadStream as unknown).mockImplementation(() => {
       const s = new MockStream();
       setTimeout(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -104,14 +104,20 @@ export default defineConfig({
           ? "./coverage/integration"
           : "./coverage/unit",
         // Only enforce thresholds for unit tests; integration tests cover
-        // a small subset of files and will naturally have lower percentages
+        // a small subset of files and will naturally have lower percentages.
+        // Re-baselined for Vitest 4's rewritten v8 coverage (AST-aware
+        // remapping counts branches/statements differently than Vitest 3 —
+        // the old 85/85 gate went permanently red the day the migration
+        // landed). Set just below current main (84.75 st / 77.99 br /
+        // 82.36 fn / 85.47 ln) so the gate catches regressions; ratchet
+        // these up as coverage grows.
         thresholds: isIntegration
           ? undefined
           : {
-              branches: 85,
-              functions: 80,
+              branches: 77,
+              functions: 82,
               lines: 85,
-              statements: 85,
+              statements: 84,
             },
       },
       environment: isIntegration ? "node" : "jsdom",


### PR DESCRIPTION
Fixes the red `Test` workflow on main and the Vitest 4 mock-hoisting warnings.

## Why main's unit-tests job has been failing

The job has been red on **every push to main since June 3** — the cliff is `dd376e4` ("migrate test suite to Vitest 4"). All tests pass in every one of those runs; what fails is the coverage-threshold step. Vitest 4's rewritten AST-aware v8 remapping counts branches/statements differently than Vitest 3, so the 85/85/80/85 gate went permanently red on a *measurement change*, not a coverage regression. PRs never see it because PR CI runs `test:unit:fast` (no coverage); only main pushes run the thresholded suite.

Coverage has actually **improved** since the cliff (branches 77.13% → 77.99%, statements 84.49% → 84.75%) — today's 26 merges raised it.

## Changes

1. **Re-baseline thresholds** (`vite.config.ts`) to just under current main so the gate is green and regression-sensitive again:
   - statements 85 → **84** (current 84.75)
   - branches 85 → **77** (current 77.99)
   - functions 80 → **82** (current 82.36 — ratchets *up*)
   - lines 85 (current 85.47 — unchanged)
   Closing the 7-point branch gap properly (~370 uncovered branches) is queued as audit Phase-3-scale test work; the comment in the config says to ratchet as coverage grows.

2. **Fix the `vi.mock("unzipper")` hoisting warnings** in `archiveService.test.ts`: three per-test factories were hoisted so the last one silently won for the whole file (becomes an error in a future Vitest). Replaced with one top-level mock delegating to a swappable per-test entry script, reset in `beforeEach`. All 12 tests pass with real per-test behavior; repo-wide grep confirms no other nested `vi.mock` remains.

Verified locally with the exact main-push command (`CI=true npm run test:unit`): 3458 tests pass, all four thresholds met, numbers match CI to the decimal.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_