### PR TITLE
release: bump version to 1.3.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.3.0-rc.1",
+      "version": "1.3.0-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.3.0-rc.1",
+  "version": "1.3.0-rc.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/peteb4ker/romper.git"


### PR DESCRIPTION
Version bump for the second release candidate. Since rc.1, main gained:

- the re-baselined coverage thresholds + unzipper mock-hoisting fix (#306) — Test workflow on main is green again for the first time since June 3
- the `/release` and `/ship-pr` skills + corrected release docs (#305)

After this merges, tag `v1.3.0-rc.2` on main to fire the release pipeline.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_