### PR TITLE
fix(release): use previous tag as notes baseline, not the tag being cut

### DIFF
--- a/docs/templates/RELEASE_NOTES_TEMPLATE.md
+++ b/docs/templates/RELEASE_NOTES_TEMPLATE.md
@@ -140,4 +140,4 @@ Thank you to all contributors who helped make this release possible!
 
 ---
 
-**Full Changelog**: [{{previous_version}}...{{version}}](https://github.com/peteb4ker/romper/compare/{{previous_version}}...{{version}})
+**Full Changelog**: [{{previous_version}}...v{{version}}](https://github.com/peteb4ker/romper/compare/{{previous_version}}...v{{version}})

--- a/scripts/release/utils/git.js
+++ b/scripts/release/utils/git.js
@@ -40,13 +40,21 @@ function isWorkingDirectoryClean() {
 }
 
 /**
- * Get the latest tag
+ * Get the latest tag to use as the release-notes baseline.
+ *
+ * Tags pointing at HEAD are excluded: in CI the release workflow checks
+ * out the tag being released, so a plain `git describe` returns that tag
+ * itself and "commits since last tag" comes back empty — the bug behind
+ * the generic "maintenance release" notes and self-comparing changelog
+ * links on every release through v1.3.0-rc.1.
  */
 function getLatestTag() {
   try {
-    return execGit("describe --tags --abbrev=0", { silent: true });
+    const tagsAtHead = execGit("tag --points-at HEAD", { silent: true });
+    const ref = tagsAtHead ? "HEAD~1" : "HEAD";
+    return execGit(`describe --tags --abbrev=0 ${ref}`, { silent: true });
   } catch {
-    // No tags exist yet
+    // No tags exist yet (or HEAD has no parent)
     return null;
   }
 }


### PR DESCRIPTION
Every release through v1.3.0-rc.1 has shipped generic "maintenance release with minor updates" notes with a self-comparing changelog link (`v1.2.0...1.2.0`). Two bugs:

1. **Wrong baseline** (`scripts/release/utils/git.js`): `getLatestTag()` ran `git describe` from HEAD, but the release workflow checks out the tag being released — so describe returned that very tag and "commits since last tag" was always empty. Fix: when tags point at HEAD, describe from `HEAD~1`, so the baseline is the *previous* release and the notes get real categorized commits (features/fixes/etc. from conventional commit parsing that was working all along but never fed any commits).

2. **Broken compare URL** (`docs/templates/RELEASE_NOTES_TEMPLATE.md`): the changelog link interpolated the bare version without the `v` prefix, so even with the right baseline the compare URL pointed at a nonexistent ref.

Verified both paths locally:
- HEAD tagged (CI scenario, simulated with a temp tag): baseline resolves to `v1.3.0-rc.1`, 3 commits counted, compare link `v1.3.0-rc.1...vtest-sim-release` well-formed
- HEAD untagged (dev usage): behavior unchanged

If this lands before the `v1.3.0-rc.2` tag is pushed, rc.2 gets real notes; otherwise the 1.3.0 final will.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_