### PR TITLE
fix(db): copy all kit fields atomically in copyKit

### DIFF
--- a/electron/main/db/operations/crudOperations.ts
+++ b/electron/main/db/operations/crudOperations.ts
@@ -8,6 +8,7 @@ import { withDb } from "../utils/dbUtilities.js";
 // Re-export operations from extracted modules
 export {
   addKit,
+  copyKit,
   deleteKit,
   getFavoriteKits,
   getFavoriteKitsCount,

--- a/electron/main/db/operations/kitCrudOperations.ts
+++ b/electron/main/db/operations/kitCrudOperations.ts
@@ -51,6 +51,86 @@ export function addKit(dbDir: string, kit: NewKit): DbResult<void> {
 }
 
 /**
+ * Copy a kit and all its child records (voices, samples) atomically.
+ *
+ * Copies every user-editable field — bpm, trigger_conditions, step_pattern,
+ * voice aliases/volumes/modes, per-sample gain and full WAV metadata — and
+ * resets the lifecycle flags (editable on, locked/favorite/synced off).
+ * Runs in a single transaction so a mid-copy failure leaves no partial kit.
+ */
+export function copyKit(
+  dbDir: string,
+  sourceKitName: string,
+  destKitName: string,
+): DbResult<void> {
+  return withDbTransaction(dbDir, (db) => {
+    const source = db
+      .select()
+      .from(kits)
+      .where(eq(kits.name, sourceKitName))
+      .get();
+    if (!source) {
+      throw new Error("Source kit does not exist.");
+    }
+
+    const existing = db
+      .select()
+      .from(kits)
+      .where(eq(kits.name, destKitName))
+      .get();
+    if (existing) {
+      throw new Error("Destination kit already exists.");
+    }
+
+    db.insert(kits)
+      .values({
+        ...source,
+        bank_letter: destKitName.charAt(0),
+        editable: true, // Duplicated kits are editable by default
+        is_favorite: false,
+        locked: false,
+        modified_since_sync: false,
+        name: destKitName,
+      })
+      .run();
+
+    const sourceVoices = db
+      .select()
+      .from(voices)
+      .where(eq(voices.kit_name, sourceKitName))
+      .orderBy(voices.voice_number)
+      .all();
+    // Strip the autoincrement id and retarget the kit; everything else is
+    // copied wholesale so new columns are picked up automatically.
+    const cloneForDest = <T extends { id: number }>(row: T) => {
+      const { id, ...rest } = row;
+      void id;
+      return { ...rest, kit_name: destKitName };
+    };
+
+    const voiceRows =
+      sourceVoices.length > 0
+        ? sourceVoices.map(cloneForDest)
+        : Array.from({ length: 4 }, (_, i) => ({
+            kit_name: destKitName,
+            stereo_mode: false,
+            voice_alias: null,
+            voice_number: i + 1,
+          }));
+    db.insert(voices).values(voiceRows).run();
+
+    const sourceSamples = db
+      .select()
+      .from(samples)
+      .where(eq(samples.kit_name, sourceKitName))
+      .all();
+    for (const sample of sourceSamples) {
+      db.insert(samples).values(cloneForDest(sample)).run();
+    }
+  });
+}
+
+/**
  * Delete a kit and all its child records (samples, voices) atomically
  */
 export function deleteKit(dbDir: string, kitName: string): DbResult<void> {

--- a/electron/main/db/romperDbCoreORM.ts
+++ b/electron/main/db/romperDbCoreORM.ts
@@ -6,6 +6,7 @@ export {
   addKit,
   addSample,
   buildDeleteConditions,
+  copyKit,
   deleteKit,
   deleteSamples,
   deleteSamplesWithoutReindexing,

--- a/electron/main/services/__tests__/kitService.integration.test.ts
+++ b/electron/main/services/__tests__/kitService.integration.test.ts
@@ -13,6 +13,10 @@ import {
   createRomperDbFile,
   getKit,
   getKitSamples,
+  updateVoiceAlias,
+  updateVoiceSampleMode,
+  updateVoiceStereoMode,
+  updateVoiceVolume,
 } from "../../db/romperDbCoreORM.js";
 import { KitService } from "../kitService.js";
 import { ScanService } from "../scanService.js";
@@ -247,6 +251,93 @@ describe("KitService Integration Tests", () => {
       const destSamplesResult = getKitSamples(TEST_DB_PATH, "D2");
       expect(destSamplesResult.success).toBe(true);
       expect(destSamplesResult.data).toHaveLength(0);
+    });
+
+    it("preserves bpm, trigger conditions, voice settings, and sample gain on copy", () => {
+      const sourceKitRecord: NewKit = {
+        alias: "Full Kit",
+        bank_letter: "E",
+        bpm: 140,
+        editable: false,
+        locked: true,
+        modified_since_sync: true,
+        name: "E1",
+        step_pattern: [
+          [1, 0, 1, 0],
+          [0, 1, 0, 1],
+        ],
+        trigger_conditions: [["1:2", null, "3:4", null]],
+      };
+      expect(addKit(TEST_DB_PATH, sourceKitRecord).success).toBe(true);
+
+      // Customize every voice-level setting on the source
+      expect(updateVoiceAlias(TEST_DB_PATH, "E1", 1, "Kicks").success).toBe(
+        true,
+      );
+      expect(updateVoiceVolume(TEST_DB_PATH, "E1", 2, 55).success).toBe(true);
+      expect(
+        updateVoiceSampleMode(TEST_DB_PATH, "E1", 3, "random").success,
+      ).toBe(true);
+      expect(updateVoiceStereoMode(TEST_DB_PATH, "E1", 4, true).success).toBe(
+        true,
+      );
+
+      // Sample with non-default gain and full WAV metadata
+      const sample: NewSample = {
+        filename: "kick.wav",
+        gain_db: -6,
+        is_stereo: false,
+        kit_name: "E1",
+        slot_number: 0,
+        source_path: "/test/path/kick.wav",
+        voice_number: 1,
+        wav_bit_depth: 24,
+        wav_bitrate: 16,
+        wav_channels: 1,
+        wav_sample_rate: 48000,
+      };
+      expect(addSample(TEST_DB_PATH, sample).success).toBe(true);
+
+      const copyResult = kitService.copyKit(mockInMemorySettings, "E1", "F2");
+      expect(copyResult.success).toBe(true);
+
+      const destKit = getKit(TEST_DB_PATH, "F2");
+      expect(destKit.success).toBe(true);
+      expect(destKit.data?.bpm).toBe(140);
+      expect(destKit.data?.trigger_conditions).toEqual([
+        ["1:2", null, "3:4", null],
+      ]);
+      expect(destKit.data?.step_pattern).toEqual([
+        [1, 0, 1, 0],
+        [0, 1, 0, 1],
+      ]);
+      // Lifecycle flags reset for the duplicate
+      expect(destKit.data?.editable).toBe(true);
+      expect(destKit.data?.locked).toBe(false);
+      expect(destKit.data?.modified_since_sync).toBe(false);
+      expect(destKit.data?.is_favorite).toBe(false);
+
+      const destVoices = destKit.data?.voices ?? [];
+      expect(destVoices).toHaveLength(4);
+      expect(destVoices.find((v) => v.voice_number === 1)?.voice_alias).toBe(
+        "Kicks",
+      );
+      expect(destVoices.find((v) => v.voice_number === 2)?.voice_volume).toBe(
+        55,
+      );
+      expect(destVoices.find((v) => v.voice_number === 3)?.sample_mode).toBe(
+        "random",
+      );
+      expect(destVoices.find((v) => v.voice_number === 4)?.stereo_mode).toBe(
+        true,
+      );
+
+      const destSamples = getKitSamples(TEST_DB_PATH, "F2");
+      expect(destSamples.success).toBe(true);
+      const destSample = destSamples.data?.[0];
+      expect(destSample?.gain_db).toBe(-6);
+      expect(destSample?.wav_bit_depth).toBe(24);
+      expect(destSample?.wav_channels).toBe(1);
     });
 
     it("REGRESSION TEST: demonstrates rescanKit incompatibility with reference-only duplication", async () => {

--- a/electron/main/services/__tests__/kitService.test.ts
+++ b/electron/main/services/__tests__/kitService.test.ts
@@ -9,30 +9,27 @@ vi.mock("node:path", () => ({
 // Mock database operations
 vi.mock("../../db/romperDbCoreORM.js", () => ({
   addKit: vi.fn(),
-  addSample: vi.fn(),
+  copyKit: vi.fn(),
   deleteKit: vi.fn(),
   getKit: vi.fn(),
   getKitDeleteSummary: vi.fn(),
-  getKitSamples: vi.fn(),
 }));
 
 import {
   addKit,
-  addSample,
+  copyKit,
   deleteKit,
   getKit,
   getKitDeleteSummary,
-  getKitSamples,
 } from "../../db/romperDbCoreORM.js";
 import { KitService } from "../kitService.js";
 
 const mockPath = vi.mocked(path);
 const mockAddKit = vi.mocked(addKit);
-const mockAddSample = vi.mocked(addSample);
+const mockCopyKit = vi.mocked(copyKit);
 const mockDeleteKit = vi.mocked(deleteKit);
 const mockGetKit = vi.mocked(getKit);
 const mockGetKitDeleteSummary = vi.mocked(getKitDeleteSummary);
-const mockGetKitSamples = vi.mocked(getKitSamples);
 
 describe("KitService", () => {
   let kitService: KitService;
@@ -46,9 +43,8 @@ describe("KitService", () => {
 
     mockPath.join.mockImplementation((...args) => args.join("/"));
     mockAddKit.mockReturnValue({ success: true });
-    mockAddSample.mockReturnValue({ data: { sampleId: 1 }, success: true });
+    mockCopyKit.mockReturnValue({ success: true });
     mockGetKit.mockReturnValue({ success: false }); // Kit doesn't exist by default
-    mockGetKitSamples.mockReturnValue({ data: [], success: true }); // No samples by default
   });
 
   describe("createKit", () => {
@@ -129,216 +125,29 @@ describe("KitService", () => {
   });
 
   describe("copyKit", () => {
-    const sourceKitData = {
-      alias: "Original Kit",
-      bank_letter: "A",
-      editable: false,
-      locked: true,
-      modified_since_sync: true,
-      name: "A1",
-      step_pattern: "1010101010101010",
-    };
-
-    beforeEach(() => {
-      mockGetKit.mockImplementation((dbPath: string, kitName: string) => {
-        if (kitName === "A1") {
-          return { data: sourceKitData, success: true };
-        }
-        return { success: false }; // Destination doesn't exist
-      });
-    });
-
-    it("successfully copies an existing kit", () => {
+    it("delegates to the atomic db copy operation", () => {
       const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
 
       expect(result.success).toBe(true);
-      expect(mockGetKit).toHaveBeenCalledWith("/test/path/.romperdb", "A1"); // Check source exists
-      expect(mockGetKit).toHaveBeenCalledWith("/test/path/.romperdb", "B2"); // Check dest doesn't exist
-      expect(mockAddKit).toHaveBeenCalledWith(
-        "/test/path/.romperdb",
-        expect.objectContaining({
-          alias: "Original Kit", // Copy source kit's alias
-          bank_letter: "B",
-          editable: true, // Always editable for copied kits
-          locked: false, // Always unlocked for copied kits
-          modified_since_sync: false, // Reset for new kit
-          name: "B2",
-          step_pattern: "1010101010101010", // Copied from source
-        }),
-      );
-    });
-
-    it("successfully copies samples from source to destination kit", () => {
-      const mockSamples = [
-        {
-          filename: "kick.wav",
-          id: 1,
-          is_stereo: false,
-          kit_name: "A1",
-          slot_number: 0,
-          source_path: "/path/to/kick.wav",
-          voice_number: 1,
-          wav_bitrate: 16,
-          wav_sample_rate: 44100,
-        },
-        {
-          filename: "snare.wav",
-          id: 2,
-          is_stereo: true,
-          kit_name: "A1",
-          slot_number: 1,
-          source_path: "/path/to/snare.wav",
-          voice_number: 1,
-          wav_bitrate: 16,
-          wav_sample_rate: 44100,
-        },
-      ];
-
-      mockGetKitSamples.mockReturnValue({
-        data: mockSamples,
-        success: true,
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(true);
-      expect(mockGetKitSamples).toHaveBeenCalledWith(
+      expect(mockCopyKit).toHaveBeenCalledWith(
         "/test/path/.romperdb",
         "A1",
+        "B2",
       );
-      expect(mockAddSample).toHaveBeenCalledTimes(2);
-
-      // Check first sample
-      expect(mockAddSample).toHaveBeenNthCalledWith(1, "/test/path/.romperdb", {
-        filename: "kick.wav",
-        is_stereo: false,
-        kit_name: "B2", // Changed to destination kit
-        slot_number: 0,
-        source_path: "/path/to/kick.wav",
-        voice_number: 1,
-        wav_bitrate: 16,
-        wav_sample_rate: 44100,
-      });
-
-      // Check second sample
-      expect(mockAddSample).toHaveBeenNthCalledWith(2, "/test/path/.romperdb", {
-        filename: "snare.wav",
-        is_stereo: true,
-        kit_name: "B2", // Changed to destination kit
-        slot_number: 1,
-        source_path: "/path/to/snare.wav",
-        voice_number: 1,
-        wav_bitrate: 16,
-        wav_sample_rate: 44100,
-      });
-    });
-
-    it("handles empty source kit (no samples to copy)", () => {
-      mockGetKitSamples.mockReturnValue({
-        data: [],
-        success: true,
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(true);
-      expect(mockGetKitSamples).toHaveBeenCalledWith(
-        "/test/path/.romperdb",
-        "A1",
-      );
-      expect(mockAddSample).not.toHaveBeenCalled();
-    });
-
-    it("handles sample copy failure", () => {
-      const mockSamples = [
-        {
-          filename: "kick.wav",
-          id: 1,
-          is_stereo: false,
-          kit_name: "A1",
-          slot_number: 0,
-          source_path: "/path/to/kick.wav",
-          voice_number: 1,
-          wav_bitrate: 16,
-          wav_sample_rate: 44100,
-        },
-      ];
-
-      mockGetKitSamples.mockReturnValue({
-        data: mockSamples,
-        success: true,
-      });
-
-      mockAddSample.mockReturnValue({
-        error: "Sample insertion failed",
-        success: false,
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe(
-        "Failed to copy sample: Sample insertion failed",
-      );
-    });
-
-    it("handles failure to fetch source kit samples", () => {
-      mockGetKitSamples.mockReturnValue({
-        error: "Database connection failed",
-        success: false,
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe(
-        "Failed to fetch samples for source kit: Database connection failed",
-      );
-      expect(mockAddSample).not.toHaveBeenCalled();
     });
 
     it("rejects invalid source kit slot", () => {
       expect(() => {
         kitService.copyKit(mockInMemorySettings, "invalid", "B2");
       }).toThrow("Invalid kit slot. Use format A0-Z99.");
-      expect(mockAddKit).not.toHaveBeenCalled();
+      expect(mockCopyKit).not.toHaveBeenCalled();
     });
 
     it("rejects invalid destination kit slot", () => {
       expect(() => {
         kitService.copyKit(mockInMemorySettings, "A1", "invalid");
       }).toThrow("Invalid kit slot. Use format A0-Z99.");
-      expect(mockAddKit).not.toHaveBeenCalled();
-    });
-
-    it("rejects if source kit does not exist", () => {
-      mockGetKit.mockImplementation(() => {
-        return { success: false }; // Source doesn't exist
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Source kit does not exist.");
-      expect(mockAddKit).not.toHaveBeenCalled();
-    });
-
-    it("rejects if destination kit already exists", () => {
-      mockGetKit.mockImplementation((dbPath: string, kitName: string) => {
-        if (kitName === "A1") {
-          return { data: sourceKitData, success: true };
-        }
-        if (kitName === "B2") {
-          return { data: { name: "B2" }, success: true }; // Destination exists
-        }
-        return { success: false };
-      });
-
-      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Destination kit already exists.");
-      expect(mockAddKit).not.toHaveBeenCalled();
+      expect(mockCopyKit).not.toHaveBeenCalled();
     });
 
     it("returns error when no local store path configured", () => {
@@ -346,20 +155,31 @@ describe("KitService", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("No local store path configured");
+      expect(mockCopyKit).not.toHaveBeenCalled();
     });
 
-    it("handles database errors gracefully", () => {
-      mockAddKit.mockReturnValue({
-        error: "Database connection failed",
+    it("passes through missing-source errors from the db layer", () => {
+      mockCopyKit.mockReturnValue({
+        error: "Source kit does not exist.",
         success: false,
       });
 
       const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe(
-        "Failed to duplicate kit: Database connection failed",
-      );
+      expect(result.error).toBe("Source kit does not exist.");
+    });
+
+    it("passes through existing-destination errors from the db layer", () => {
+      mockCopyKit.mockReturnValue({
+        error: "Destination kit already exists.",
+        success: false,
+      });
+
+      const result = kitService.copyKit(mockInMemorySettings, "A1", "B2");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Destination kit already exists.");
     });
   });
 

--- a/electron/main/services/kitService.ts
+++ b/electron/main/services/kitService.ts
@@ -1,4 +1,4 @@
-import type { DbResult, NewKit, NewSample } from "@romper/shared/db/schema.js";
+import type { DbResult, NewKit } from "@romper/shared/db/schema.js";
 
 import * as path from "node:path";
 
@@ -6,11 +6,10 @@ import type { InMemorySettings } from "../types/settings.js";
 
 import {
   addKit,
-  addSample,
+  copyKit as copyKitDb,
   deleteKit as deleteKitDb,
   getKit,
   getKitDeleteSummary as getKitDeleteSummaryDb,
-  getKitSamples,
 } from "../db/romperDbCoreORM.js";
 
 /**
@@ -37,70 +36,10 @@ export class KitService {
 
     const dbPath = this.getDbPath(localStorePath);
 
-    // Check if source kit exists in database
-    const sourceKitData = getKit(dbPath, sourceKit);
-    if (!sourceKitData.success || !sourceKitData.data) {
-      return { error: "Source kit does not exist.", success: false };
-    }
-
-    // Check if destination kit already exists in database
-    const existingDestKit = getKit(dbPath, destKit);
-    if (existingDestKit.success && existingDestKit.data) {
-      return { error: "Destination kit already exists.", success: false };
-    }
-
-    // Copy kit metadata in database only (no folder copying)
-    const destKitRecord: NewKit = {
-      alias: sourceKitData.data.alias, // Copy source kit's alias
-      bank_letter: destKit.charAt(0), // Extract bank letter from kit name
-      editable: true, // Duplicated kits are editable by default
-      locked: false,
-      modified_since_sync: false,
-      name: destKit,
-      step_pattern: sourceKitData.data.step_pattern,
-    };
-
-    const result = addKit(dbPath, destKitRecord);
-    if (!result.success) {
-      return {
-        error: `Failed to duplicate kit: ${result.error}`,
-        success: false,
-      };
-    }
-
-    // Copy all sample references from source kit to destination kit
-    const sourceSamples = getKitSamples(dbPath, sourceKit);
-    if (!sourceSamples.success) {
-      return {
-        error: `Failed to fetch samples for source kit: ${sourceSamples.error ?? "Unknown error"}`,
-        success: false,
-      };
-    }
-    if (sourceSamples.data) {
-      for (const sample of sourceSamples.data) {
-        // Create new sample record for destination kit, preserving all original properties
-        const newSample: NewSample = {
-          filename: sample.filename,
-          is_stereo: sample.is_stereo,
-          kit_name: destKit, // Change kit_name to destination
-          slot_number: sample.slot_number,
-          source_path: sample.source_path,
-          voice_number: sample.voice_number,
-          wav_bitrate: sample.wav_bitrate,
-          wav_sample_rate: sample.wav_sample_rate,
-        };
-
-        const sampleResult = addSample(dbPath, newSample);
-        if (!sampleResult.success) {
-          return {
-            error: `Failed to copy sample: ${sampleResult.error}`,
-            success: false,
-          };
-        }
-      }
-    }
-
-    return { success: true };
+    // The db layer copies kit, voices, and samples atomically with all
+    // user-editable fields preserved (bpm, trigger conditions, voice
+    // settings, sample gain and WAV metadata).
+    return copyKitDb(dbPath, sourceKit, destKit);
   }
 
   /**


### PR DESCRIPTION
First item from the audit Phase-3 backlog: kit duplication silently lost user data.

## The bug

`KitService.copyKit` rebuilt the destination kit from a hand-picked subset of fields, so every duplicate dropped:

- **kit**: `bpm` (reset to 120), `trigger_conditions` (lost entirely)
- **samples**: `gain_db` (user gain trims reset to 0), `wav_bit_depth`, `wav_channels`
- **voices**: not copied at all — aliases, volumes, sample modes, and stereo modes all silently reset to defaults

It was also non-atomic: kit insert followed by per-sample inserts, so a mid-copy failure left a partial kit in the database (`deleteKit` was already transactional; copy was not).

## The fix

`copyKit` moves to the db-operations layer (`kitCrudOperations.ts`) inside `withDbTransaction`. It clones the kit row, voice rows, and sample rows **wholesale** — ids stripped, `kit_name` retargeted — so future schema columns are copied automatically instead of needing to be remembered. Only the lifecycle flags are reset (editable on; locked/favorite/modified_since_sync off). Existence checks happen in-transaction (race-free), and the renderer-facing error strings ("Source kit does not exist." / "Destination kit already exists.") are unchanged.

The service keeps slot/path validation and delegates.

## Tests

- Unit tests rewritten to cover the delegation seam (validation short-circuits, arg passing, error passthrough)
- New integration test against a real database asserts `bpm`, `trigger_conditions`, `step_pattern`, all four voice settings, `gain_db`, and full WAV metadata survive a copy, and that lifecycle flags reset

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_