### PR TITLE
perf: eliminate per-kit sample fetching at startup (N+1)

### DIFF
--- a/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
+++ b/app/renderer/components/hooks/kit-management/__tests__/useKitDataManager.test.ts
@@ -9,21 +9,6 @@ import { useKitDataManager } from "../useKitDataManager";
 // Using real groupDbSamplesByVoice implementation to handle spaced slots correctly
 
 describe("useKitDataManager", () => {
-  const mockKits: KitWithRelations[] = [
-    {
-      alias: null,
-      bank_letter: "A",
-      editable: false,
-      name: "A0",
-    } as KitWithRelations,
-    {
-      alias: null,
-      bank_letter: "A",
-      editable: false,
-      name: "A1",
-    } as KitWithRelations,
-  ];
-
   const mockSamples = [
     {
       filename: "kick.wav",
@@ -37,6 +22,25 @@ describe("useKitDataManager", () => {
       slot_number: 0,
       voice_number: 2,
     },
+  ];
+
+  // getKits() returns each kit's samples inline — that single call is the
+  // only data source the hook uses at startup (no per-kit fetching).
+  const mockKits: KitWithRelations[] = [
+    {
+      alias: null,
+      bank_letter: "A",
+      editable: false,
+      name: "A0",
+      samples: mockSamples,
+    } as unknown as KitWithRelations,
+    {
+      alias: null,
+      bank_letter: "A",
+      editable: false,
+      name: "A1",
+      samples: mockSamples,
+    } as unknown as KitWithRelations,
   ];
 
   beforeEach(() => {
@@ -113,6 +117,25 @@ describe("useKitDataManager", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(window.electronAPI.getKits).toHaveBeenCalled();
+  });
+
+  it("does not fetch samples kit-by-kit at startup (N+1 regression guard)", async () => {
+    renderHook(() =>
+      useKitDataManager({
+        isInitialized: true,
+        localStorePath: "/test/path",
+        needsLocalStoreSetup: false,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    // Startup samples come from the kits returned by getKits(); the
+    // per-kit IPC call is reserved for single-kit reloads.
+    expect(window.electronAPI.getKits).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.getAllSamplesForKit).not.toHaveBeenCalled();
   });
 
   it("should handle getKits API failure", async () => {

--- a/app/renderer/components/hooks/kit-management/useKitDataManager.ts
+++ b/app/renderer/components/hooks/kit-management/useKitDataManager.ts
@@ -43,6 +43,20 @@ export function useKitDataManager({
     [kit: string]: VoiceSamples;
   }>({});
 
+  // getKits() already returns each kit's samples (batched in the db layer);
+  // group them per voice here instead of re-fetching kit-by-kit over IPC —
+  // the per-kit loop was an N+1 that serialized startup on IPC round trips.
+  const groupLoadedKitSamples = useCallback(
+    (loadedKits: KitWithRelations[]) => {
+      const samples: { [kit: string]: VoiceSamples } = {};
+      for (const kit of loadedKits) {
+        samples[kit.name] = groupDbSamplesByVoice(kit.samples ?? []);
+      }
+      return samples;
+    },
+    [],
+  );
+
   // Helper function to load samples for a single kit
   const loadKitSamples = useCallback(
     async (kit: string): Promise<VoiceSamples> => {
@@ -71,8 +85,8 @@ export function useKitDataManager({
       }
       console.info("[useKitDataManager] Loading kits from", localStorePath);
 
-      // 1. Load kits from database (includes bank relationships)
-      let kitNames: string[] = [];
+      // Load kits from database — the result includes bank relationships
+      // and every kit's samples, so one IPC call covers everything
       let loadedKits: KitWithRelations[] = [];
       try {
         const kitsResult = await globalThis.electronAPI?.getKits?.();
@@ -80,7 +94,6 @@ export function useKitDataManager({
           const kitsWithBanks = kitsResult.data;
           setKits(kitsWithBanks);
           loadedKits = kitsWithBanks;
-          kitNames = kitsWithBanks.map((kit: KitWithRelations) => kit.name);
         } else {
           console.error(
             "Failed to load kits from database:",
@@ -95,20 +108,7 @@ export function useKitDataManager({
         loadedKits = [];
       }
 
-      // 2. Load samples for each kit from database
-      const samples: { [kit: string]: VoiceSamples } = {};
-      if (kitNames.length > 0) {
-        console.debug(
-          `[useKitDataManager] Loading samples for ${kitNames.length} kits...`,
-        );
-        for (const kit of kitNames) {
-          samples[kit] = await loadKitSamples(kit);
-        }
-        console.debug(
-          `[useKitDataManager] Loaded samples for ${kitNames.length} kits`,
-        );
-      }
-      setAllKitSamples(samples);
+      setAllKitSamples(groupLoadedKitSamples(loadedKits));
 
       // If a specific kit should be scrolled to, do it after data loads
       if (scrollToKit) {
@@ -128,7 +128,12 @@ export function useKitDataManager({
         }, 100); // Small delay to ensure DOM is updated
       }
     },
-    [isInitialized, localStorePath, needsLocalStoreSetup, loadKitSamples],
+    [
+      isInitialized,
+      localStorePath,
+      needsLocalStoreSetup,
+      groupLoadedKitSamples,
+    ],
   );
 
   // Function to reload samples for a specific kit
@@ -169,21 +174,7 @@ export function useKitDataManager({
       if (kitsResult?.success && kitsResult.data) {
         const kitsWithBanks = kitsResult.data;
         setKits(kitsWithBanks);
-        const kitNames = kitsWithBanks.map((kit: KitWithRelations) => kit.name);
-
-        const samples: { [kit: string]: VoiceSamples } = {};
-        if (kitNames.length > 0) {
-          console.debug(
-            `[useKitDataManager] Refreshing samples for ${kitNames.length} kits...`,
-          );
-          for (const kit of kitNames) {
-            samples[kit] = await loadKitSamples(kit);
-          }
-          console.debug(
-            `[useKitDataManager] Refreshed samples for ${kitNames.length} kits`,
-          );
-        }
-        setAllKitSamples(samples);
+        setAllKitSamples(groupLoadedKitSamples(kitsWithBanks));
       } else {
         console.error("Failed to load kits from database:", kitsResult?.error);
         setKits([]);
@@ -194,7 +185,7 @@ export function useKitDataManager({
       setKits([]);
       setAllKitSamples({});
     }
-  }, [loadKitSamples]);
+  }, [groupLoadedKitSamples]);
 
   // Get a specific kit by name from the cached data
   const getKitByName = useCallback(

--- a/app/renderer/views/__tests__/KitsView.test.tsx
+++ b/app/renderer/views/__tests__/KitsView.test.tsx
@@ -165,11 +165,45 @@ describe("KitsView", () => {
     }
 
     // Mock electronAPI methods using centralized mocks
+    // getKits() carries each kit's samples inline — the hook no longer
+    // fetches samples kit-by-kit at load time.
+    const defaultSamples = [
+      {
+        filename: "kick.wav",
+        is_stereo: false,
+        slot_number: 100,
+        voice_number: 1,
+      },
+      {
+        filename: "snare.wav",
+        is_stereo: false,
+        slot_number: 100,
+        voice_number: 2,
+      },
+    ];
     vi.mocked(window.electronAPI.getKits).mockResolvedValue({
       data: [
-        { alias: null, bank_letter: "A", editable: false, name: "A0" },
-        { alias: null, bank_letter: "A", editable: false, name: "A1" },
-        { alias: null, bank_letter: "B", editable: false, name: "B0" },
+        {
+          alias: null,
+          bank_letter: "A",
+          editable: false,
+          name: "A0",
+          samples: defaultSamples,
+        },
+        {
+          alias: null,
+          bank_letter: "A",
+          editable: false,
+          name: "A1",
+          samples: defaultSamples,
+        },
+        {
+          alias: null,
+          bank_letter: "B",
+          editable: false,
+          name: "B0",
+          samples: defaultSamples,
+        },
       ],
       success: true,
     });
@@ -400,16 +434,11 @@ describe("KitsView", () => {
 
       await waitFor(() => {
         expect(window.electronAPI.getKits).toHaveBeenCalled();
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalledWith(
-          "A0",
-        );
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalledWith(
-          "A1",
-        );
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalledWith(
-          "B0",
-        );
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
+
+      // Samples arrive inline on getKits(); no per-kit fetching at load
+      expect(window.electronAPI.getAllSamplesForKit).not.toHaveBeenCalled();
     });
 
     it("handles database errors gracefully", async () => {
@@ -429,10 +458,10 @@ describe("KitsView", () => {
       });
     });
 
-    it("handles sample loading errors gracefully", async () => {
-      vi.mocked(window.electronAPI.getAllSamplesForKit).mockResolvedValue({
-        error: "Sample loading failed",
-        success: false,
+    it("handles kits without sample data gracefully", async () => {
+      vi.mocked(window.electronAPI.getKits).mockResolvedValue({
+        data: [{ alias: null, bank_letter: "A", editable: false, name: "A0" }],
+        success: true,
       });
 
       render(
@@ -442,38 +471,47 @@ describe("KitsView", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalled();
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
     });
   });
 
   describe("Sample data processing", () => {
     it("correctly groups samples by voice", async () => {
-      vi.mocked(window.electronAPI.getAllSamplesForKit).mockResolvedValue({
+      vi.mocked(window.electronAPI.getKits).mockResolvedValue({
         data: [
           {
-            filename: "kick.wav",
-            is_stereo: false,
-            slot_number: 100,
-            voice_number: 1,
-          },
-          {
-            filename: "snare.wav",
-            is_stereo: false,
-            slot_number: 100,
-            voice_number: 2,
-          },
-          {
-            filename: "hat.wav",
-            is_stereo: false,
-            slot_number: 200,
-            voice_number: 1,
-          },
-          {
-            filename: "stereo.wav",
-            is_stereo: true,
-            slot_number: 100,
-            voice_number: 3,
+            alias: null,
+            bank_letter: "A",
+            editable: false,
+            name: "A0",
+            samples: [
+              {
+                filename: "kick.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 1,
+              },
+              {
+                filename: "snare.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 2,
+              },
+              {
+                filename: "hat.wav",
+                is_stereo: false,
+                slot_number: 200,
+                voice_number: 1,
+              },
+              {
+                filename: "stereo.wav",
+                is_stereo: true,
+                slot_number: 100,
+                voice_number: 3,
+              },
+            ],
           },
         ],
         success: true,
@@ -486,7 +524,8 @@ describe("KitsView", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalled();
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
 
       // The component should process stereo samples correctly
@@ -753,7 +792,9 @@ describe("KitsView", () => {
       ).toBeInTheDocument();
     });
 
-    it("handles sample loading exceptions", async () => {
+    it("handles single-kit sample reload exceptions", async () => {
+      // The per-kit fetch is only used for single-kit reloads now; a
+      // rejection there must not crash the view
       vi.mocked(window.electronAPI.getAllSamplesForKit).mockRejectedValue(
         new Error("File not found"),
       );
@@ -765,7 +806,7 @@ describe("KitsView", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalled();
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
       });
 
       // Component should still render without crashing
@@ -1019,46 +1060,59 @@ describe("KitsView", () => {
 
   describe("Memoized sample counts", () => {
     it("correctly calculates sample counts for all kits", async () => {
-      // Mock detailed sample data
-      vi.mocked(window.electronAPI.getAllSamplesForKit)
-        .mockResolvedValueOnce({
-          data: [
-            {
-              filename: "kick.wav",
-              is_stereo: false,
-              slot_number: 100,
-              voice_number: 1,
-            },
-            {
-              filename: "snare.wav",
-              is_stereo: false,
-              slot_number: 200,
-              voice_number: 1,
-            },
-            {
-              filename: "hat.wav",
-              is_stereo: false,
-              slot_number: 100,
-              voice_number: 2,
-            },
-          ],
-          success: true,
-        })
-        .mockResolvedValueOnce({
-          data: [
-            {
-              filename: "bass.wav",
-              is_stereo: false,
-              slot_number: 100,
-              voice_number: 1,
-            },
-          ],
-          success: true,
-        })
-        .mockResolvedValueOnce({
-          data: [],
-          success: true,
-        });
+      // Each kit's samples ride along on getKits()
+      vi.mocked(window.electronAPI.getKits).mockResolvedValue({
+        data: [
+          {
+            alias: null,
+            bank_letter: "A",
+            editable: false,
+            name: "A0",
+            samples: [
+              {
+                filename: "kick.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 1,
+              },
+              {
+                filename: "snare.wav",
+                is_stereo: false,
+                slot_number: 200,
+                voice_number: 1,
+              },
+              {
+                filename: "hat.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 2,
+              },
+            ],
+          },
+          {
+            alias: null,
+            bank_letter: "A",
+            editable: false,
+            name: "A1",
+            samples: [
+              {
+                filename: "bass.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 1,
+              },
+            ],
+          },
+          {
+            alias: null,
+            bank_letter: "B",
+            editable: false,
+            name: "B0",
+            samples: [],
+          },
+        ],
+        success: true,
+      });
 
       render(
         <TestSettingsProvider>
@@ -1068,7 +1122,8 @@ describe("KitsView", () => {
 
       // Wait for all data to load
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalledTimes(3);
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
 
       // Component should have processed sample counts
@@ -1078,19 +1133,27 @@ describe("KitsView", () => {
 
   describe("Stereo sample handling", () => {
     it("correctly handles stereo samples spanning two voices", async () => {
-      vi.mocked(window.electronAPI.getAllSamplesForKit).mockResolvedValue({
+      vi.mocked(window.electronAPI.getKits).mockResolvedValue({
         data: [
           {
-            filename: "stereo-kick.wav",
-            is_stereo: true,
-            slot_number: 100,
-            voice_number: 1,
-          },
-          {
-            filename: "mono-snare.wav",
-            is_stereo: false,
-            slot_number: 100,
-            voice_number: 3,
+            alias: null,
+            bank_letter: "A",
+            editable: false,
+            name: "A0",
+            samples: [
+              {
+                filename: "stereo-kick.wav",
+                is_stereo: true,
+                slot_number: 100,
+                voice_number: 1,
+              },
+              {
+                filename: "mono-snare.wav",
+                is_stereo: false,
+                slot_number: 100,
+                voice_number: 3,
+              },
+            ],
           },
         ],
         success: true,
@@ -1103,7 +1166,8 @@ describe("KitsView", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalled();
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
 
       // The stereo sample should appear in both voice 1 and voice 2
@@ -1111,13 +1175,21 @@ describe("KitsView", () => {
     });
 
     it("handles stereo sample at voice 4 boundary", async () => {
-      vi.mocked(window.electronAPI.getAllSamplesForKit).mockResolvedValue({
+      vi.mocked(window.electronAPI.getKits).mockResolvedValue({
         data: [
           {
-            filename: "stereo-at-end.wav",
-            is_stereo: true,
-            slot_number: 100,
-            voice_number: 4,
+            alias: null,
+            bank_letter: "A",
+            editable: false,
+            name: "A0",
+            samples: [
+              {
+                filename: "stereo-at-end.wav",
+                is_stereo: true,
+                slot_number: 100,
+                voice_number: 4,
+              },
+            ],
           },
         ],
         success: true,
@@ -1130,7 +1202,8 @@ describe("KitsView", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.getAllSamplesForKit).toHaveBeenCalled();
+        expect(window.electronAPI.getKits).toHaveBeenCalled();
+        expect(screen.getByText("A0")).toBeInTheDocument();
       });
 
       // Stereo sample at voice 4 should not overflow to voice 5 (doesn't exist)


### PR DESCRIPTION
Phase-3 backlog: startup data loading was an N+1 over IPC.

## The problem

`useKitDataManager.loadKitsData` (and `refreshAllKitsAndSamples`) called `getAllSamplesForKit` once per kit, **serially awaiting each IPC round trip**. With a populated 26-bank local store that's hundreds of sequential renderer→main→SQLite round trips before the kit list renders.

The kicker: `getKits()` has returned every kit's samples all along — the db layer already batches kits, voices, and samples into three queries and attaches them as relations. The renderer received all the sample data in call #1 and then threw it away.

## The fix

The hook now groups the inline `kit.samples` per voice (`groupDbSamplesByVoice`) from the single `getKits()` result. Startup data loading is **one IPC call total**. `getAllSamplesForKit` remains in use only by `reloadCurrentKitSamples`, where refreshing a single kit is the point.

## Tests

- Hook + KitsView mocks updated to carry samples on `getKits` results (matching what the real API returns)
- New regression guard: `getAllSamplesForKit` is never called during initial load
- Full suite green via pre-commit gate

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_