### PR TITLE
perf(db): apply WAL, busy_timeout, and immediate transactions per connection

### DIFF
--- a/electron/main/db/utils/__tests__/dbUtilities.integration.test.ts
+++ b/electron/main/db/utils/__tests__/dbUtilities.integration.test.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -172,6 +173,24 @@ describe("Database Utilities Integration Tests", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
+    });
+
+    it("applies the per-connection pragmas (WAL + busy_timeout)", () => {
+      const result = withDb(TEST_DB_DIR, (db) => {
+        // drizzle exposes the underlying better-sqlite3 session; query the
+        // pragmas through raw SQL on the same connection
+        const journalMode = db.get<{ journal_mode: string }>(
+          sql`PRAGMA journal_mode`,
+        );
+        const busyTimeout = db.get<{ timeout: number }>(
+          sql`PRAGMA busy_timeout`,
+        );
+        return { busyTimeout, journalMode };
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.journalMode?.journal_mode).toBe("wal");
+      expect(result.data?.busyTimeout?.timeout).toBe(5000);
     });
   });
 

--- a/electron/main/db/utils/dbMigrations.ts
+++ b/electron/main/db/utils/dbMigrations.ts
@@ -75,6 +75,9 @@ export function ensureDatabaseMigrations(dbDir: string): DbResult<boolean> {
 
   try {
     const sqlite = new BetterSqlite3(dbPath);
+    // Wait for concurrent connections instead of failing with SQLITE_BUSY
+    // (openDatabase lives in dbUtilities, which imports this module)
+    sqlite.pragma("busy_timeout = 5000");
     const db = drizzle(sqlite, { schema });
 
     checkMigrationState(sqlite);

--- a/electron/main/db/utils/dbUtilities.ts
+++ b/electron/main/db/utils/dbUtilities.ts
@@ -38,7 +38,7 @@ export function createRomperDbFile(dbDir: string): {
   const dbPath = path.join(dbDir, DB_FILENAME);
   try {
     fs.mkdirSync(dbDir, { recursive: true });
-    const sqlite = new BetterSqlite3(dbPath);
+    const sqlite = openDatabase(dbPath);
     const db = drizzle(sqlite, { schema });
     const migrationsPath = getMigrationsPath();
     if (migrationsPath) {
@@ -78,13 +78,47 @@ export function createRomperDbFile(dbDir: string): {
 }
 
 /**
+ * Open a SQLite connection with the standard per-connection settings.
+ *
+ * Connections are opened fresh for every operation, so pragmas must be
+ * applied on each open:
+ * - busy_timeout: wait for a lock instead of failing immediately with
+ *   SQLITE_BUSY when another connection (sync run, parallel IPC call)
+ *   holds the write lock
+ * - WAL journal mode + synchronous=NORMAL: readers no longer block the
+ *   writer and vice versa; the standard pairing. journal_mode is set
+ *   tolerantly — on filesystems without shared-memory support SQLite
+ *   keeps the previous mode and everything still works.
+ *
+ * foreign_keys stays OFF intentionally: kits.bank_letter references
+ * banks.letter, but kits can be created before a bank scan has populated
+ * the banks table — enforcement would break createKit.
+ */
+export function openDatabase(
+  dbPath: string,
+  options: BetterSqlite3.Options = {},
+): BetterSqlite3.Database {
+  const sqlite = new BetterSqlite3(dbPath, options);
+  sqlite.pragma("busy_timeout = 5000");
+  if (!options.readonly) {
+    try {
+      sqlite.pragma("journal_mode = WAL");
+      sqlite.pragma("synchronous = NORMAL");
+    } catch {
+      // Keep the database usable in its existing journal mode
+    }
+  }
+  return sqlite;
+}
+
+/**
  * Validate that the database schema is correctly set up
  */
 export function validateDatabaseSchema(dbDir: string): DbResult<boolean> {
   const dbPath = path.join(dbDir, DB_FILENAME);
 
   try {
-    const sqlite = new BetterSqlite3(dbPath, { readonly: true });
+    const sqlite = openDatabase(dbPath, { readonly: true });
 
     // Check that all expected tables exist
     const expectedTables = ["banks", "kits", "samples", "voices"];
@@ -134,7 +168,7 @@ export function withDb<T>(
 
   let sqlite: BetterSqlite3.Database | null = null;
   try {
-    sqlite = new BetterSqlite3(dbPath);
+    sqlite = openDatabase(dbPath);
     const db = drizzle(sqlite, { schema });
     const result = fn(db);
     return { data: result, success: true };
@@ -169,11 +203,12 @@ export function withDbTransaction<T>(
 
   let sqlite: BetterSqlite3.Database | null = null;
   try {
-    sqlite = new BetterSqlite3(dbPath);
+    sqlite = openDatabase(dbPath);
     const db = drizzle(sqlite, { schema });
 
-    // Start transaction
-    sqlite.exec("BEGIN TRANSACTION");
+    // IMMEDIATE takes the write lock up front, so a concurrent writer is
+    // rejected at BEGIN (after busy_timeout) instead of mid-transaction
+    sqlite.exec("BEGIN IMMEDIATE TRANSACTION");
 
     try {
       const result = fn(db, sqlite);


### PR DESCRIPTION
Phase-3 backlog: the SQLite connections used stock settings, which is the worst configuration for this app's access pattern (a fresh connection per operation, with a sync worker and IPC calls that can overlap).

## Changes

New `openDatabase()` helper applied at every open site (connections are per-operation, so pragmas must be set on each open):

- **`busy_timeout = 5000`** — concurrent access currently fails *instantly* with `SQLITE_BUSY`; now it waits for the lock. This is the fix for sync-while-browsing races.
- **`journal_mode = WAL` + `synchronous = NORMAL`** — readers stop blocking the writer and vice versa. Set tolerantly: on filesystems without shared-memory support SQLite keeps the prior mode and everything still works. WAL sidecar files are cleaned up on connection close, which happens after every operation.
- **`BEGIN IMMEDIATE`** in `withDbTransaction` — takes the write lock at BEGIN (after the busy wait) instead of mid-transaction, where a busy peer would abort work already done.

**`foreign_keys` deliberately stays off**: `kits.bank_letter` references `banks.letter`, but kits can be created before any bank scan has populated `banks` — enforcement would break `createKit`. Noted in the helper's doc comment.

`dbMigrations.ts` gets an inline `busy_timeout` (it can't import the helper — `dbUtilities` imports from it).

## Tests

New integration test asserts WAL and the 5000ms timeout are live on `withDb` connections. Full suite green via pre-commit gate.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_