### PR TITLE
perf(kit-grid): virtualize kit grid with react-window VariableSizeList

### DIFF
--- a/app/renderer/components/KitGrid.tsx
+++ b/app/renderer/components/KitGrid.tsx
@@ -3,11 +3,20 @@ import type { KitWithRelations } from "@romper/shared/db/schema";
 import { getNextSlotInBank } from "@romper/shared/kitUtilsShared";
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
+import {
+  ListChildComponentProps,
+  ListOnItemsRenderedProps,
+  VariableSizeList,
+} from "react-window";
+
+import type { KitWithSearchMatch } from "./shared/kitItemUtils";
 
 import AddKitCard from "./AddKitCard";
 import BankHeader from "./BankHeader";
@@ -53,9 +62,40 @@ interface KitGridProps {
 
 // Grid layout constants
 const CARD_WIDTH = 300; // Optimal card width from UX analysis
+const CARD_HEIGHT = 104; // Must match KitGridCard / AddKitCard
 const GAP = 12; // Gap between cards
 const MIN_COLUMNS = 2;
 const MAX_COLUMNS = 6;
+
+// Virtualized row heights
+const KIT_ROW_HEIGHT = CARD_HEIGHT + GAP; // card + bottom gap
+const BANK_HEADER_HEIGHT = 60; // header content + bottom gap
+const BANK_SPACING = 16; // extra top spacing before non-first banks
+const MATCH_LINE_HEIGHT = 20; // per matched-sample line when a card expands
+const OVERSCAN_ROW_COUNT = 2;
+
+// Virtualized row model: each list row is a bank header, a row of up to
+// `columnCount` kit cards (optionally ending with the add-kit card), or a
+// standalone add-kit row when the bank's kit count fills its final row.
+interface AddRow {
+  bank: string;
+  type: "add";
+}
+
+type GridRow = AddRow | HeaderRow | KitsRow;
+
+interface HeaderRow {
+  bank: string;
+  isFirstBank: boolean;
+  type: "header";
+}
+
+interface KitsRow {
+  bank: string;
+  kits: KitWithRelations[];
+  showAddCard: boolean;
+  type: "kits";
+}
 
 // Hook for responsive column calculation
 const useResponsiveColumns = (containerWidth: number) => {
@@ -103,6 +143,198 @@ const useContainerSize = () => {
   return { containerRef, size };
 };
 
+// Props threaded through react-window's itemData to the row renderer
+interface GridRowData {
+  bankNames: Record<string, string>;
+  focusedIdx: null | number;
+  getKitFavoriteState?: (kitName: string) => boolean;
+  gridWidth: number;
+  isCreatingKit?: boolean;
+  kitData?: KitWithRelations[];
+  kitsToDisplay: KitWithRelations[];
+  newlyAnimatedKit?: null | string;
+  onBankNameChange?: (bank: string, newName: string) => void;
+  onCreateKitInBank?: (bankLetter: string) => void;
+  onDelete?: (kit: string) => void;
+  onDeleteKit?: (kitName: string) => Promise<void>;
+  onDuplicate: (kit: string) => void;
+  onDuplicateKit?: (
+    source: string,
+    dest: string,
+  ) => Promise<{ error?: string }>;
+  onFocusKit?: (kit: string) => void;
+  onRequestDeleteSummary?: (
+    kitName: string,
+  ) => Promise<{ locked: boolean; sampleCount: number } | null>;
+  onSelectKit: (kit: string) => void;
+  onToggleFavorite?: (kitName: string) => void;
+  rows: GridRow[];
+  sampleCounts?: Record<string, [number, number, number, number]>;
+  setFocus: (index: number) => void;
+}
+
+// Build the flattened row model from sorted kits
+function buildGridRows(
+  kitsToDisplay: KitWithRelations[],
+  columnCount: number,
+  showAddCards: boolean,
+): { rowIndexByKitIndex: number[]; rows: GridRow[] } {
+  const rows: GridRow[] = [];
+  const rowIndexByKitIndex: number[] = new Array(kitsToDisplay.length);
+  const existingNames = kitsToDisplay.map((k) => k.name);
+
+  let i = 0;
+  let isFirstBank = true;
+  while (i < kitsToDisplay.length) {
+    const bank = kitsToDisplay[i].name[0];
+    const bankStart = i;
+    const bankKits: KitWithRelations[] = [];
+    while (i < kitsToDisplay.length && kitsToDisplay[i].name[0] === bank) {
+      bankKits.push(kitsToDisplay[i]);
+      i++;
+    }
+
+    rows.push({ bank, isFirstBank, type: "header" });
+    isFirstBank = false;
+
+    const bankHasRoom =
+      showAddCards && getNextSlotInBank(bank, existingNames) !== null;
+
+    for (let c = 0; c < bankKits.length; c += columnCount) {
+      const chunk = bankKits.slice(c, c + columnCount);
+      const isLastChunk = c + columnCount >= bankKits.length;
+      const rowIdx = rows.length;
+      for (let j = 0; j < chunk.length; j++) {
+        rowIndexByKitIndex[bankStart + c + j] = rowIdx;
+      }
+      rows.push({
+        bank,
+        kits: chunk,
+        showAddCard: bankHasRoom && isLastChunk && chunk.length < columnCount,
+        type: "kits",
+      });
+    }
+
+    // Add-kit card gets its own row when the bank's final row is full
+    if (bankHasRoom && bankKits.length % columnCount === 0) {
+      rows.push({ bank, type: "add" });
+    }
+  }
+
+  return { rowIndexByKitIndex, rows };
+}
+
+// Extra row height needed when search-matched samples expand a card
+function getRowExpansionExtra(
+  row: KitsRow,
+  kitData: KitWithRelations[] | undefined,
+): number {
+  let maxLines = 0;
+  for (const kit of row.kits) {
+    const kitDataItem = kitData?.find((k) => k.name === kit.name) as
+      | KitWithSearchMatch
+      | undefined;
+    const byVoice = kitDataItem?.searchMatch?.matchedSamplesByVoice;
+    if (!byVoice) continue;
+    for (const matches of Object.values(byVoice)) {
+      maxLines = Math.max(maxLines, matches.length);
+    }
+  }
+  return maxLines * MATCH_LINE_HEIGHT;
+}
+
+const GridRowRenderer: React.FC<ListChildComponentProps<GridRowData>> = ({
+  data,
+  index,
+  style,
+}) => {
+  const row = data.rows[index];
+  if (!row) return null;
+
+  const innerStyle: React.CSSProperties = {
+    margin: "0 auto",
+    width: data.gridWidth,
+  };
+
+  if (row.type === "header") {
+    return (
+      <div style={style}>
+        <div
+          style={{
+            ...innerStyle,
+            paddingTop: row.isFirstBank ? 0 : BANK_SPACING,
+          }}
+        >
+          <BankHeader
+            bank={row.bank}
+            bankName={data.bankNames[row.bank]}
+            onBankNameChange={data.onBankNameChange}
+            variant="grid"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const addKitCard = data.onCreateKitInBank ? (
+    <div style={{ flexShrink: 0, width: CARD_WIDTH }}>
+      <AddKitCard
+        bankLetter={row.bank}
+        isCreating={!!data.isCreatingKit}
+        onClick={data.onCreateKitInBank}
+      />
+    </div>
+  ) : null;
+
+  if (row.type === "add") {
+    return (
+      <div style={style}>
+        <div style={{ ...innerStyle, display: "flex", gap: GAP }}>
+          {addKitCard}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={style}>
+      <div style={{ ...innerStyle, display: "flex", gap: GAP }}>
+        {row.kits.map((kit) => (
+          <div key={kit.name} style={{ flexShrink: 0, width: CARD_WIDTH }}>
+            <KitGridCard
+              focusedIdx={data.focusedIdx}
+              getKitFavoriteState={data.getKitFavoriteState}
+              isNew={kit.name === data.newlyAnimatedKit}
+              kit={kit}
+              kitData={data.kitData}
+              kitsToDisplay={data.kitsToDisplay}
+              onDelete={data.onDelete}
+              onDeleteKit={data.onDeleteKit}
+              onDuplicate={data.onDuplicate}
+              onDuplicateKit={data.onDuplicateKit}
+              onFocusKit={data.onFocusKit}
+              onRequestDeleteSummary={data.onRequestDeleteSummary}
+              onSelectKit={data.onSelectKit}
+              onToggleFavorite={data.onToggleFavorite}
+              sampleCounts={data.sampleCounts}
+              setFocus={data.setFocus}
+            />
+          </div>
+        ))}
+        {row.showAddCard && addKitCard}
+      </div>
+    </div>
+  );
+};
+
+const gridRowKey = (index: number, data: GridRowData): string => {
+  const row = data.rows[index];
+  if (!row) return `row-${index}`;
+  if (row.type === "header") return `header-${row.bank}`;
+  if (row.type === "add") return `add-${row.bank}`;
+  return `kits-${row.kits[0].name}`;
+};
+
 const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
   (
     {
@@ -134,6 +366,7 @@ const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
     const { containerRef, size } = useContainerSize();
     const columnCount = useResponsiveColumns(size.width);
     const rowCount = Math.ceil(kitsToDisplay.length / columnCount);
+    const listRef = useRef<VariableSizeList>(null);
 
     // Navigation logic adapted for grid
     const navFocusedKit = typeof focusedKit === "string" ? focusedKit : null;
@@ -148,6 +381,54 @@ const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
       }
     }, [navFocusedKit, kitsToDisplay, setFocus]);
 
+    // Flatten bank-grouped kits into virtualized rows
+    const showAddCards = !isFiltered && !!onCreateKitInBank;
+    const { rowIndexByKitIndex, rows } = useMemo(
+      () => buildGridRows(kitsToDisplay, columnCount, showAddCards),
+      [kitsToDisplay, columnCount, showAddCards],
+    );
+
+    const getItemSize = useCallback(
+      (index: number) => {
+        const row = rows[index];
+        if (!row) return KIT_ROW_HEIGHT;
+        if (row.type === "header") {
+          return BANK_HEADER_HEIGHT + (row.isFirstBank ? 0 : BANK_SPACING);
+        }
+        if (row.type === "add") return KIT_ROW_HEIGHT;
+        return KIT_ROW_HEIGHT + getRowExpansionExtra(row, kitData);
+      },
+      [rows, kitData],
+    );
+
+    // Row heights depend on the row model and search-match expansion state
+    useEffect(() => {
+      listRef.current?.resetAfterIndex(0);
+    }, [rows, kitData, getItemSize]);
+
+    // Scroll a kit's row into view via the virtualized list. Used by
+    // keyboard navigation and the imperative handle so focus targets are
+    // reachable even when far outside the rendered window.
+    const scrollKitIntoView = useCallback(
+      (idx: number) => {
+        const rowIdx = rowIndexByKitIndex[idx];
+        if (rowIdx === undefined || !listRef.current) return;
+        const row = rows[rowIdx];
+        const prevRow = rows[rowIdx - 1];
+        const isFirstKitInBankRow =
+          row?.type === "kits" &&
+          row.kits[0]?.name === kitsToDisplay[idx]?.name &&
+          prevRow?.type === "header";
+        if (isFirstKitInBankRow) {
+          // Jumping to a bank's first kit: align its header to the top
+          listRef.current.scrollToItem(rowIdx - 1, "start");
+        } else {
+          listRef.current.scrollToItem(rowIdx, "smart");
+        }
+      },
+      [rowIndexByKitIndex, rows, kitsToDisplay],
+    );
+
     // Use keyboard navigation hook
     const { handleKeyDown, scrollAndFocusKitByIndex, scrollToKit } =
       useKitGridKeyboard({
@@ -159,6 +440,7 @@ const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
         onFocusKit,
         onSelectKit,
         rowCount,
+        scrollItemIntoView: scrollKitIntoView,
         setFocus,
       });
 
@@ -171,21 +453,49 @@ const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
       [scrollAndFocusKitByIndex, scrollToKit],
     );
 
-    // Group kits by bank for rendering with headers
-    const kitsByBank = kitsToDisplay.reduce(
-      (acc, kit) => {
-        const bank = kit.name[0];
-        if (!acc[bank]) acc[bank] = [];
-        acc[bank].push(kit);
-        return acc;
+    // Track the visible bank from the virtualized window (replaces the
+    // per-header IntersectionObserver, which only sees mounted headers)
+    const lastVisibleBankRef = useRef<null | string>(null);
+    const handleItemsRendered = useCallback(
+      ({ visibleStartIndex }: ListOnItemsRenderedProps) => {
+        if (!onVisibleBankChange) return;
+        const bank = rows[visibleStartIndex]?.bank;
+        if (bank && bank !== lastVisibleBankRef.current) {
+          lastVisibleBankRef.current = bank;
+          onVisibleBankChange(bank);
+        }
       },
-      {} as Record<string, typeof kitsToDisplay>,
+      [rows, onVisibleBankChange],
     );
+
+    const itemData: GridRowData = {
+      bankNames,
+      focusedIdx,
+      getKitFavoriteState,
+      gridWidth: columnCount * CARD_WIDTH + (columnCount - 1) * GAP,
+      isCreatingKit,
+      kitData,
+      kitsToDisplay,
+      newlyAnimatedKit,
+      onBankNameChange,
+      onCreateKitInBank,
+      onDelete,
+      onDeleteKit,
+      onDuplicate,
+      onDuplicateKit,
+      onFocusKit,
+      onRequestDeleteSummary,
+      onSelectKit,
+      onToggleFavorite,
+      rows,
+      sampleCounts,
+      setFocus,
+    };
 
     return (
       <div
         aria-label="Kit grid"
-        className="h-full w-full bg-surface-1 rounded pt-2 pb-2 pl-2 pr-2 overflow-y-auto"
+        className="h-full w-full bg-surface-1 rounded pt-2 pb-2 pl-2 pr-2 overflow-hidden"
         data-testid="kit-grid"
         onKeyDown={handleKeyDown}
         ref={containerRef}
@@ -193,61 +503,19 @@ const KitGrid = forwardRef<KitGridHandle, KitGridProps>(
         style={{ minHeight: 400 }} // Ensure minimum height
         tabIndex={0}
       >
-        <div
-          className="grid gap-3"
-          style={{
-            gridTemplateColumns: `repeat(${columnCount}, ${CARD_WIDTH}px)`,
-            justifyContent: "center",
-          }}
+        <VariableSizeList
+          height={size.height}
+          itemCount={rows.length}
+          itemData={itemData}
+          itemKey={gridRowKey}
+          itemSize={getItemSize}
+          onItemsRendered={handleItemsRendered}
+          overscanCount={OVERSCAN_ROW_COUNT}
+          ref={listRef}
+          width="100%"
         >
-          {Object.entries(kitsByBank).map(([bank, bankKits]) => {
-            const existingNames = kitsToDisplay.map((k) => k.name);
-            const bankHasRoom = getNextSlotInBank(bank, existingNames) !== null;
-
-            return (
-              <React.Fragment key={bank}>
-                {/* Bank header spans all columns */}
-                <BankHeader
-                  bank={bank}
-                  bankName={bankNames[bank]}
-                  onBankNameChange={onBankNameChange}
-                  onBankVisible={onVisibleBankChange}
-                  variant="grid"
-                />
-                {/* Kit cards for this bank */}
-                {bankKits.map((kit) => (
-                  <KitGridCard
-                    focusedIdx={focusedIdx}
-                    getKitFavoriteState={getKitFavoriteState}
-                    isNew={kit.name === newlyAnimatedKit}
-                    key={kit.name}
-                    kit={kit}
-                    kitData={kitData}
-                    kitsToDisplay={kitsToDisplay}
-                    onDelete={onDelete}
-                    onDeleteKit={onDeleteKit}
-                    onDuplicate={onDuplicate}
-                    onDuplicateKit={onDuplicateKit}
-                    onFocusKit={onFocusKit}
-                    onRequestDeleteSummary={onRequestDeleteSummary}
-                    onSelectKit={onSelectKit}
-                    onToggleFavorite={onToggleFavorite}
-                    sampleCounts={sampleCounts}
-                    setFocus={setFocus}
-                  />
-                ))}
-                {/* Add kit card at end of bank */}
-                {!isFiltered && bankHasRoom && onCreateKitInBank && (
-                  <AddKitCard
-                    bankLetter={bank}
-                    isCreating={!!isCreatingKit}
-                    onClick={onCreateKitInBank}
-                  />
-                )}
-              </React.Fragment>
-            );
-          })}
-        </div>
+          {GridRowRenderer}
+        </VariableSizeList>
       </div>
     );
   },

--- a/app/renderer/components/__tests__/KitGrid.test.tsx
+++ b/app/renderer/components/__tests__/KitGrid.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import React, { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -202,6 +208,62 @@ describe("KitGrid", () => {
       expect(() => {
         ref.current?.scrollToKit("NonExistentKit");
       }).not.toThrow();
+    });
+  });
+
+  describe("virtualization", () => {
+    const makeKit = (name: string) => ({
+      alias: null,
+      artist: null,
+      bank_letter: name[0],
+      editable: false,
+      locked: false,
+      modified_since_sync: false,
+      name,
+      samples: [],
+      step_pattern: null,
+      voices: [],
+    });
+
+    // 20 banks x 25 kits = 500 kits
+    const manyKits = Array.from("ABCDEFGHIJKLMNOPQRST").flatMap((bank) =>
+      Array.from({ length: 25 }, (_, i) => makeKit(`${bank}${i}`)),
+    );
+
+    it("mounts only a bounded number of cards for large kit sets", () => {
+      render(<KitGrid {...baseProps} kits={manyKits} />);
+
+      const mountedCards = screen.getAllByTestId(/^kit-item-/);
+      expect(mountedCards.length).toBeGreaterThan(0);
+      // Only the visible window (plus overscan) should be mounted,
+      // not all 500 kits.
+      expect(mountedCards.length).toBeLessThan(60);
+    });
+
+    it("renders kits at the top of the list in the initial window", () => {
+      render(<KitGrid {...baseProps} kits={manyKits} />);
+
+      expect(screen.getByTestId("kit-item-A0")).toBeInTheDocument();
+      expect(screen.getByTestId("kit-item-A1")).toBeInTheDocument();
+    });
+
+    it("does not mount kits far outside the visible window", () => {
+      render(<KitGrid {...baseProps} kits={manyKits} />);
+
+      expect(screen.queryByTestId("kit-item-T24")).not.toBeInTheDocument();
+    });
+
+    it("scrollToKit scrolls a far-away kit's row into the window", () => {
+      const ref = createRef<KitGridHandle>();
+      render(<KitGrid {...baseProps} kits={manyKits} ref={ref} />);
+
+      expect(screen.queryByTestId("kit-item-T24")).not.toBeInTheDocument();
+
+      act(() => {
+        ref.current?.scrollToKit("T24");
+      });
+
+      expect(screen.getByTestId("kit-item-T24")).toBeInTheDocument();
     });
   });
 

--- a/app/renderer/components/hooks/useKitGridKeyboard.ts
+++ b/app/renderer/components/hooks/useKitGridKeyboard.ts
@@ -12,6 +12,9 @@ interface UseKitGridKeyboardProps {
   onFocusKit?: (kitName: string) => void;
   onSelectKit: (kitName: string) => void;
   rowCount: number;
+  // When provided (virtualized grids), used instead of DOM scrollIntoView
+  // so off-window (unmounted) kits can still be scrolled to.
+  scrollItemIntoView?: (idx: number) => void;
   setFocus: (index: number) => void;
 }
 
@@ -24,6 +27,7 @@ export function useKitGridKeyboard({
   onFocusKit,
   onSelectKit,
   rowCount,
+  scrollItemIntoView,
   setFocus,
 }: UseKitGridKeyboardProps) {
   // Convert flat index to grid coordinates
@@ -49,22 +53,27 @@ export function useKitGridKeyboard({
     (idx: number) => {
       if (idx < 0 || idx >= kitsToDisplay.length) return;
 
-      const kit = kitsToDisplay[idx];
-      const kitElement = containerRef.current?.querySelector(
-        `[data-kit="${kit.name}"]`,
-      );
+      if (scrollItemIntoView) {
+        // Virtualized grid: scroll via the list so unmounted kits work
+        scrollItemIntoView(idx);
+      } else {
+        const kit = kitsToDisplay[idx];
+        const kitElement = containerRef.current?.querySelector(
+          `[data-kit="${kit.name}"]`,
+        );
 
-      if (kitElement && containerRef.current) {
-        kitElement.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
+        if (kitElement && containerRef.current) {
+          kitElement.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          });
+        }
       }
 
       setFocus(idx);
       if (onFocusKit) onFocusKit(kitsToDisplay[idx].name);
     },
-    [kitsToDisplay, setFocus, onFocusKit, containerRef],
+    [kitsToDisplay, setFocus, onFocusKit, containerRef, scrollItemIntoView],
   );
 
   // Helper function to scroll to a kit by name


### PR DESCRIPTION
Last big renderer item from the audit Phase-3 backlog: `KitGrid` mounted every kit card eagerly — thousands of components on a full 26-bank store. `react-window` was already a dependency (used by the now-dead `KitList`), so the grid now renders only the visible window.

## Changes

- **`KitGrid.tsx`**: eager CSS grid → `VariableSizeList`. `buildGridRows()` flattens bank-grouped kits into a row model (bank-header rows, card rows of `columnCount`, `AddKitCard` in the bank's last free column or its own row). Centered fixed-width track preserves the old layout; `role="grid"`/a11y/testids unchanged; all `KitGridCard` props pass through via `itemData`.
- **Imperative handle preserved**: `scrollToKit` / `scrollAndFocusKitByIndex` drive `listRef.scrollToItem` (bank-first kits align the header to top, matching the old bank-jump behavior).
- **Keyboard nav**: `useKitGridKeyboard` accepts an optional `scrollItemIntoView` so arrow keys and A–Z bank jumps reach kits that virtualization has unmounted. Non-virtualized callers unaffected.
- **Visible-bank tracking** moved from per-header IntersectionObserver (unmounted headers can't observe) to the list's `onItemsRendered` — every row carries its bank; `onVisibleBankChange` fires only on change. Prop contract identical; switch point during scroll can differ by up to one row.
- Row heights are fixed estimates (cards 116px, headers 60px + bank spacing, +20px per matched-sample line during search) with `resetAfterIndex` on model changes.

## Tests

- New: with 500 kits across 20 banks, mounted cards stay bounded (<60), far kits aren't mounted, and `scrollToKit` mounts them on demand
- KitGrid 35 + keyboard 12, KitsView + KitBrowser 65 — all passing; full gate green (3458 unit + 534 integration)

## Follow-up noted

`KitList.tsx` is dead production code (only its own test imports it) — removal queued as a separate cleanup.

https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNgF4SMhfpPY8A3WyCXdC)_