### PR TITLE
fix(sonar): clear 2 critical blockers gating the v1.3.0 release

### DIFF
--- a/app/renderer/components/hooks/kit-management/useKitEditorKeyboardNav.ts
+++ b/app/renderer/components/hooks/kit-management/useKitEditorKeyboardNav.ts
@@ -2,6 +2,15 @@ import type { VoiceSamples } from "@romper/app/renderer/components/kitTypes";
 
 import React from "react";
 
+type SampleNavParams = Pick<
+  UseKitEditorKeyboardNavParams,
+  | "onPlaySample"
+  | "onSampleKeyNav"
+  | "samples"
+  | "selectedSampleIdx"
+  | "selectedVoice"
+>;
+
 interface UseKitEditorKeyboardNavParams {
   isEditable: boolean;
   onInferVoiceNames: () => void;
@@ -39,14 +48,7 @@ export function useKitEditorKeyboardNav({
   React.useEffect(() => {
     function handleGlobalKeyDown(e: KeyboardEvent) {
       // Ignore if a modal, input, textarea, or contenteditable is focused
-      const active = document.activeElement;
-      if (
-        active &&
-        ((active.tagName === "INPUT" &&
-          (active as HTMLInputElement).type !== "checkbox") ||
-          active.tagName === "TEXTAREA" ||
-          (active as HTMLElement).isContentEditable)
-      ) {
+      if (isTypingTarget(document.activeElement)) {
         return;
       }
 
@@ -81,18 +83,13 @@ export function useKitEditorKeyboardNav({
       // Enter key removed to prevent conflicts with kit name editing
       if (!sequencerOpen && [" ", "ArrowDown", "ArrowUp"].includes(e.key)) {
         e.preventDefault();
-        if (e.key === "ArrowDown") {
-          onSampleKeyNav("down");
-        } else if (e.key === "ArrowUp") {
-          onSampleKeyNav("up");
-        } else if (e.key === " ") {
-          // Preview/play selected sample with Space key only
-          const samplesForVoice = samples[selectedVoice] || [];
-          const sample = samplesForVoice[selectedSampleIdx];
-          if (sample) {
-            onPlaySample(selectedVoice, sample);
-          }
-        }
+        handleSampleNavKey(e.key, {
+          onPlaySample,
+          onSampleKeyNav,
+          samples,
+          selectedSampleIdx,
+          selectedVoice,
+        });
       }
     }
     globalThis.addEventListener("keydown", handleGlobalKeyDown);
@@ -111,4 +108,36 @@ export function useKitEditorKeyboardNav({
     onScanKit,
     setSequencerOpen,
   ]);
+}
+
+/** Handle the sample navigation/preview keys (arrows + space). */
+function handleSampleNavKey(key: string, params: SampleNavParams): void {
+  if (key === "ArrowDown") {
+    params.onSampleKeyNav("down");
+    return;
+  }
+  if (key === "ArrowUp") {
+    params.onSampleKeyNav("up");
+    return;
+  }
+  // Preview/play selected sample with Space key only
+  const sample = (params.samples[params.selectedVoice] || [])[
+    params.selectedSampleIdx
+  ];
+  if (sample) {
+    params.onPlaySample(params.selectedVoice, sample);
+  }
+}
+
+/** True when focus is in a text-entry field, where shortcuts must not fire. */
+function isTypingTarget(active: Element | null): boolean {
+  if (!active) {
+    return false;
+  }
+  if (active.tagName === "INPUT") {
+    return (active as HTMLInputElement).type !== "checkbox";
+  }
+  return (
+    active.tagName === "TEXTAREA" || (active as HTMLElement).isContentEditable
+  );
 }

--- a/electron/main/db/operations/kitCrudOperations.ts
+++ b/electron/main/db/operations/kitCrudOperations.ts
@@ -103,8 +103,8 @@ export function copyKit(
     // Strip the autoincrement id and retarget the kit; everything else is
     // copied wholesale so new columns are picked up automatically.
     const cloneForDest = <T extends { id: number }>(row: T) => {
-      const { id, ...rest } = row;
-      void id;
+      const rest: { id?: number } & Omit<T, "id"> = { ...row };
+      delete rest.id;
       return { ...rest, kit_name: destKitName };
     };
 


### PR DESCRIPTION
Unblocks the **v1.3.0** release. The `v1.3.0-rc.2` build failed the SonarCloud release quality gate (auto-filed as #314) on 2 open CRITICAL issues. This clears both.

## Fixes

**S3735** — `electron/main/db/operations/kitCrudOperations.ts`
`copyKit`'s `cloneForDest` used `void id` to discard the autoincrement id after destructuring. Replaced with a typed `delete` — no `void` operator, no unused binding. Verified by the kitCrud integration suite (21 tests, incl. copyKit).

**S3776** — `app/renderer/components/hooks/kit-management/useKitEditorKeyboardNav.ts`
`handleGlobalKeyDown` had cognitive complexity 18 (Sonar limit 15). Extracted two pure helpers — `isTypingTarget` (focus guard) and `handleSampleNavKey` (arrow/space handling) — bringing it to ≤15. Behavior unchanged; verified against `sonarjs/cognitive-complexity` at threshold 15.

## Notes

- The repo's local `sonarjs/cognitive-complexity` threshold is 25, which is why Sonar's server-side 15 caught this but local lint didn't.
- Full pre-commit suite (lint, typecheck, unit + integration) passes.
- Unrelated: spotted a pre-existing flaky temp-dir test (`archiveUtils.test.ts`, intermittent `ENOENT` under parallel load) — flagged separately, not touched here.

Refs #314. Once merged, I'll move the `v1.3.0-rc.2` tag to the new main HEAD to re-trigger the release.