### PR TITLE
test(coverage): exclude tests/** so mock files stop dragging CodeCov

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,12 @@ export default defineConfig({
           "**/*.test.*",
           "**/*Mock*.tsx",
           "**/*Mock*.ts",
+          // Test infrastructure (mocks, factories, fixtures, helpers). These
+          // are imported by tests so v8 instruments them, but they are not
+          // production code and were dragging the reported coverage down —
+          // e.g. tests/mocks/electron/electronAPI.ts isn't matched by the
+          // *Mock* patterns above (the word lives in the dir, not the name).
+          "tests/**",
         ],
         include: [
           "app/renderer/**/*.ts",


### PR DESCRIPTION
## Problem

`tests/mocks/electron/electronAPI.ts` and `tests/mocks/electron/electronFileAPI.ts` were being **instrumented and counted by CodeCov**. They're imported by renderer tests, so v8 picks them up — but they're mock-only code with uncovered lines (8/12 and 2/7 respectively → ~9 uncovered lines), dragging the reported project number down.

The existing `**/*Mock*.ts` excludes only match the word **Mock in a filename** — these files are named `electronAPI.ts`/`electronFileAPI.ts` and just live under a `mocks/` directory, so they slipped through.

## Fix

Exclude `tests/**` from coverage instrumentation. The `tests/` tree is entirely test infrastructure (mocks, factories, fixtures, providers, utils, e2e) — never production code. The coverage `include` globs (`app/renderer`, `shared`, `electron`) are unaffected.

## Effect

Locally, removing those files nudges unit coverage up (e.g. Lines 85.32% → 85.40%) by shrinking the denominator of non-production lines.

## Context

CodeCov is **already green** on main (89.96%) after the `useKitEditorKeyboardNav` test (#317) — this PR is the structural cleanup you flagged, giving real headroom above target so a small wobble stops tripping it. Not a release blocker; `v1.3.0-rc.2` already shipped.