### PR TITLE
fix(archive): wait for in-flight writes before settling extraction

### DIFF
--- a/electron/main/__tests__/archiveUtils.test.ts
+++ b/electron/main/__tests__/archiveUtils.test.ts
@@ -123,7 +123,7 @@ describe("extractZipEntries", () => {
       "nested/b.wav": "world",
     });
     const dest = path.join(tmpRoot, "out");
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
 
     await extractZipEntries(zipPath, dest, 2, () => {});
 
@@ -140,7 +140,7 @@ describe("extractZipEntries", () => {
     const big = Buffer.alloc(2048, 0x61); // 2 KiB
     const zipPath = buildZip({ "big.wav": big });
     const dest = path.join(tmpRoot, "out");
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
 
     const limits: ArchiveLimits = {
       ...DEFAULT_ARCHIVE_LIMITS,
@@ -156,7 +156,7 @@ describe("extractZipEntries", () => {
     const big = Buffer.alloc(2048, 0x62);
     const zipPath = buildZip({ "big.wav": big });
     const dest = path.join(tmpRoot, "out");
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
 
     const limits: ArchiveLimits = {
       ...DEFAULT_ARCHIVE_LIMITS,
@@ -175,7 +175,7 @@ describe("extractZipEntries", () => {
       "c.wav": "3",
     });
     const dest = path.join(tmpRoot, "out");
-    fs.mkdirSync(dest);
+    fs.mkdirSync(dest, { recursive: true });
 
     const limits: ArchiveLimits = {
       ...DEFAULT_ARCHIVE_LIMITS,

--- a/electron/main/archiveUtils.ts
+++ b/electron/main/archiveUtils.ts
@@ -86,19 +86,42 @@ export async function extractZipEntries(
   return new Promise((resolve, reject) => {
     let processedCount = 0;
     let settled = false;
+    let streamClosed = false;
+    let failure: Error | null = null;
     const budget: ExtractionBudget = { totalBytes: 0, validEntries: 0 };
+    // In-flight file writes. The extraction promise must not settle until every
+    // write has finished (or been torn down); otherwise a caller that cleans up
+    // the destination directory races still-open write streams, producing
+    // intermittent ENOENT failures under parallel load.
+    const pendingWrites = new Set<Promise<void>>();
+    const openWriteStreams = new Set<fs.WriteStream>();
 
     const stream = fs.createReadStream(zipPath).pipe(unzipper.Parse());
 
-    const fail = (error: unknown) => {
-      if (settled) return;
+    const maybeSettle = () => {
+      if (settled || !streamClosed || pendingWrites.size > 0) return;
       settled = true;
+      if (failure) {
+        reject(failure);
+      } else {
+        resolve();
+      }
+    };
+
+    const fail = (error: unknown) => {
+      if (failure) return;
+      failure = error instanceof Error ? error : new Error(String(error));
       stream.destroy();
-      reject(error instanceof Error ? error : new Error(String(error)));
+      // Tear down any in-flight writes so their streams close promptly and we
+      // don't leave fs operations racing the caller's cleanup.
+      for (const writeStream of openWriteStreams) {
+        writeStream.destroy();
+      }
+      maybeSettle();
     };
 
     stream.on("entry", (entry: UnzipperEntry) => {
-      if (settled) {
+      if (settled || failure) {
         entry.autodrain();
         return;
       }
@@ -133,16 +156,27 @@ export async function extractZipEntries(
       if (entry.type === "Directory") {
         handleDirectoryEntry(entry, destPath);
       } else {
-        handleFileEntry(entry, destPath, limits, budget, fail);
+        const writePromise = handleFileEntry(
+          entry,
+          destPath,
+          limits,
+          budget,
+          fail,
+          () => failure !== null,
+          openWriteStreams,
+        );
+        pendingWrites.add(writePromise);
+        void writePromise.finally(() => {
+          pendingWrites.delete(writePromise);
+          maybeSettle();
+        });
       }
     });
 
     stream.on("error", fail);
     stream.on("close", () => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
+      streamClosed = true;
+      maybeSettle();
     });
   });
 }
@@ -188,6 +222,35 @@ export function isWithinDirectory(destDir: string, entryPath: string): boolean {
   );
 }
 
+// Enforce per-file and cumulative size limits as data flows, failing fast when
+// either bound is crossed.
+function attachSizeGuard(
+  entry: UnzipperEntry,
+  limits: ArchiveLimits,
+  budget: ExtractionBudget,
+  fail: (error: unknown) => void,
+): void {
+  let fileBytes = 0;
+  entry.on("data", (...args: unknown[]) => {
+    const chunk = args[0] as Buffer;
+    fileBytes += chunk.length;
+    budget.totalBytes += chunk.length;
+    if (fileBytes > limits.maxFileBytes) {
+      fail(
+        new Error(
+          `Archive entry exceeds per-file size limit (${limits.maxFileBytes} bytes): ${entry.path}`,
+        ),
+      );
+    } else if (budget.totalBytes > limits.maxTotalBytes) {
+      fail(
+        new Error(
+          `Archive exceeds total uncompressed size limit (${limits.maxTotalBytes} bytes)`,
+        ),
+      );
+    }
+  });
+}
+
 // Helper to track download progress
 function createProgressTracker(
   totalBytes: number,
@@ -219,51 +282,70 @@ function handleDirectoryEntry(entry: UnzipperEntry, destPath: string): void {
 }
 
 // Helper function to handle file extraction, enforcing per-file and cumulative
-// size limits to defend against decompression bombs.
+// size limits to defend against decompression bombs. Returns a promise that
+// resolves once the write has finished (or been torn down/errored), so the
+// caller can wait for every write to complete before settling the extraction.
 function handleFileEntry(
   entry: UnzipperEntry,
   destPath: string,
   limits: ArchiveLimits,
   budget: ExtractionBudget,
   fail: (error: unknown) => void,
-): void {
-  fs.mkdir(path.dirname(destPath), { recursive: true }, (err) => {
-    if (err) {
-      console.warn(
-        "Failed to create parent directory:",
-        path.dirname(destPath),
-        err,
-      );
-      entry.autodrain();
-      return;
-    }
-
-    let fileBytes = 0;
-    entry.on("data", (...args: unknown[]) => {
-      const chunk = args[0] as Buffer;
-      fileBytes += chunk.length;
-      budget.totalBytes += chunk.length;
-      if (fileBytes > limits.maxFileBytes) {
-        fail(
-          new Error(
-            `Archive entry exceeds per-file size limit (${limits.maxFileBytes} bytes): ${entry.path}`,
-          ),
+  isFailed: () => boolean,
+  openWriteStreams: Set<fs.WriteStream>,
+): Promise<void> {
+  return new Promise<void>((resolveWrite) => {
+    fs.mkdir(path.dirname(destPath), { recursive: true }, (err) => {
+      if (err) {
+        console.warn(
+          "Failed to create parent directory:",
+          path.dirname(destPath),
+          err,
         );
-      } else if (budget.totalBytes > limits.maxTotalBytes) {
-        fail(
-          new Error(
-            `Archive exceeds total uncompressed size limit (${limits.maxTotalBytes} bytes)`,
-          ),
-        );
+        entry.autodrain();
+        resolveWrite();
+        return;
       }
-    });
 
-    entry.pipe(fs.createWriteStream(destPath)).on("error", (err: unknown) => {
-      setImmediate(() => {
-        console.warn("Failed to write file:", destPath, err);
-      });
+      // The extraction may have already failed (e.g. a sibling entry tripped a
+      // size or count limit) while this mkdir was in flight. Bail out without
+      // opening a write stream so we don't write into a directory the caller is
+      // about to tear down.
+      if (isFailed()) {
+        entry.autodrain();
+        resolveWrite();
+        return;
+      }
+
+      attachSizeGuard(entry, limits, budget, fail);
+      pipeEntryToFile(entry, destPath, openWriteStreams, resolveWrite);
     });
   });
+}
+
+// Pipe an entry to its destination file, tracking the write stream so the
+// extraction can wait for (and tear down) it. `done` is invoked exactly once
+// when the write is no longer in flight.
+function pipeEntryToFile(
+  entry: UnzipperEntry,
+  destPath: string,
+  openWriteStreams: Set<fs.WriteStream>,
+  done: () => void,
+): void {
+  const writeStream = fs.createWriteStream(destPath);
+  openWriteStreams.add(writeStream);
+  const finishWrite = () => {
+    openWriteStreams.delete(writeStream);
+    done();
+  };
+  // "close" fires after a successful finish and after a destroy(); "error"
+  // covers open/write failures. Either way the write is no longer in flight.
+  writeStream.on("close", finishWrite);
+  writeStream.on("error", (err: unknown) => {
+    warnWriteFailure(destPath, err);
+    finishWrite();
+  });
+  entry.pipe(writeStream);
 }
 
 // Helper to setup file stream handlers
@@ -276,4 +358,12 @@ function setupFileStream(
     fileStream.close(() => resolve());
   });
   fileStream.on("error", reject);
+}
+
+// Defer the warning so it doesn't interleave with the synchronous teardown path
+// (matches the original behaviour of logging write failures out-of-band).
+function warnWriteFailure(destPath: string, err: unknown): void {
+  setImmediate(() => {
+    console.warn("Failed to write file:", destPath, err);
+  });
 }

--- a/electron/main/services/__tests__/archiveService.test.ts
+++ b/electron/main/services/__tests__/archiveService.test.ts
@@ -24,7 +24,15 @@ let lastWriteStream: MockStream | null = null;
 
 vi.mock("node:fs", () => ({
   createReadStream: vi.fn(() => new MockStream()),
-  createWriteStream: vi.fn(() => (lastWriteStream = new MockStream())),
+  createWriteStream: vi.fn(() => {
+    const stream = new MockStream();
+    lastWriteStream = stream;
+    // A real fs.WriteStream emits "close" once writing completes. Extraction
+    // now waits for every write to settle before resolving, so the mock must
+    // model that signal or the handler would hang.
+    setImmediate(() => stream.emit("close"));
+    return stream;
+  }),
   existsSync: vi.fn(() => true),
   mkdir: vi.fn((dir, opts, cb) => cb && cb(null)),
   mkdirSync: vi.fn(),
@@ -252,14 +260,14 @@ describe("download-and-extract-archive handler", () => {
           autodrain: () => {},
           on: () => {},
           path: "foo.wav",
-          pipe: () => {
-            const s = new MockStream();
-            setTimeout(() => s.emit("error", new Error("write fail")), 5);
-            setTimeout(() => s.emit("finish"), 10);
-            return s;
-          },
+          pipe: () => new MockStream(),
           type: "File",
         });
+        // Simulate a failure on the destination write stream (created
+        // synchronously while handling the entry above).
+        if (lastWriteStream) {
+          lastWriteStream.emit("error", new Error("write fail"));
+        }
         // End extraction
         setTimeout(() => stream.emit("close"), 20);
       }, 1);


### PR DESCRIPTION
## Problem

`electron/main/__tests__/archiveUtils.test.ts` failed intermittently (~1-in-3) under full-suite parallelism with errors like:

```
Failed to write file: /var/folders/.../romper-archive-test-XXXX/out/b.wav [ENOENT: no such file or directory, open '.../out/b.wav']
```

It passed 5/5 in isolation but flaked under `npm run test` / the pre-commit suite.

## Root cause

The race was in the **production code** (`extractZipEntries`), not the test's temp-dir setup. Each test already used a unique `mkdtemp` dir, so directory collisions weren't the issue.

`extractZipEntries` resolved/rejected on the zip parser's `"close"` event while the per-file `fs.createWriteStream` writes were still in flight. When an entry tripped a size/count limit (e.g. the entry-count-limit test with `a.wav`, `b.wav`, `c.wav`), the promise settled immediately, the test's `afterEach` ran `fs.rmSync(tmpRoot, { recursive: true })`, and that deleted `out/` out from under a still-opening write to `b.wav` → `ENOENT` on `open`. Under parallel load the window widened.

## Fix

- `handleFileEntry` now returns a promise that resolves on the write stream's `"close"`/`"error"`; `extractZipEntries` tracks all pending writes and only settles once every write has finished or been torn down.
- On failure, open write streams are explicitly `destroy()`-ed so they close promptly instead of racing the caller's cleanup, and late writes are skipped if extraction already failed while their `mkdir` was in flight.
- Refactored into flat helpers (`attachSizeGuard`, `pipeEntryToFile`, `warnWriteFailure`) to stay under SonarJS's nesting limit.
- Updated the `archiveService` test mocks to model real `fs.WriteStream` completion (`"close"`), since they previously assumed fire-and-forget writes, and made the test's `dest` mkdir recursive.

## Verification

- 5 consecutive full unit-suite runs (3438 tests each) with zero failures and no `romper-archive-test` ENOENT messages.
- Full pre-commit gates passed: typecheck, lint, unit + Electron-hosted integration suite (534 tests), and build.

https://claude.ai/code/session_01Q9oShHTfffKzPaFhVBgRfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9oShHTfffKzPaFhVBgRfd)_