### PR TITLE
release: bump version to 1.3.0-rc.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.3.0-rc.2",
+      "version": "1.3.0-rc.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.3.0-rc.2",
+  "version": "1.3.0-rc.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/peteb4ker/romper.git"


### PR DESCRIPTION
Bumps to **1.3.0-rc.3** to re-cut the release candidate off current `main`.

## Why a fresh RC

`v1.3.0-rc.2` published successfully, but `main` has since gained CI/coverage hardening (no functional app changes):
- `test(kit-editor)`: cover `useKitEditorKeyboardNav` (#317)
- `test(coverage)`: exclude `tests/**` from instrumentation (#318) — CodeCov now **90.07%**, above target

Reusing the published `rc.2` tag is what the release skill warns against, so this cuts **rc.3**.

## After merge

Tag `v1.3.0-rc.3` on the new main HEAD → fires the release workflow (Sonar gate → 3-platform signed builds → prerelease publish). Hyphen tag ⇒ GitHub marks it **Pre-release**; **Latest** stays at `v1.2.0`.