### PR TITLE
release: bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romper",
-  "version": "1.3.0-rc.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romper",
-      "version": "1.3.0-rc.3",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Romper Development Team",
   "license": "MIT",
   "private": true,
-  "version": "1.3.0-rc.3",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/peteb4ker/romper.git"


### PR DESCRIPTION
Graduates 1.3.0 from rc.3 to stable.

## What ships in 1.3.0 (since v1.2.0)
- perf: kit grid virtualization (react-window), per-connection SQLite WAL + busy_timeout, elimination of per-kit N+1 sample fetching at startup
- fix: atomic copyKit field copy, archive extraction waits for in-flight writes, release-notes baseline uses previous tag
- chore: dead component removal, coverage re-baseline for Vitest 4, dependency refresh (vite, sharp, postcss, js-yaml, shell-quote, fast-uri, adm-zip, axios, form-data)

## Since rc.3 specifically
- fix(archive): wait for in-flight writes before settling extraction
- 9 dependency bumps (all dev-deps except postcss/axios), each individually CI-green

## After merge
Tag `v1.3.0` at the merge commit and push — the release workflow handles quality gate, cross-platform builds, macOS signing + notarization + stapling, and publishing.